### PR TITLE
Add option to always show OCR by default

### DIFF
--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -43,6 +43,8 @@
   $: fontWeight = $settings.boldFont ? 'bold' : '400';
   $: display = $settings.displayOCR ? 'block' : 'none';
   $: border = $settings.textBoxBorders ? '1px solid red' : 'none';
+  $: alwaysShowOCRClass = $settings.alwaysShowOCR ? 'always-show-ocr' : '';
+  $: isControlPressed = false;
   $: contenteditable = $settings.textEditable;
 
   $: triggerMethod = $settings.ankiConnectSettings.triggerMethod || 'both';
@@ -74,11 +76,14 @@
       onUpdateCard(lines);
     }
   }
+
+  window.addEventListener('keydown', (e) => isControlPressed = e.ctrlKey);
+  window.addEventListener('keyup', (e) => isControlPressed = e.ctrlKey);
 </script>
 
 {#each textBoxes as { fontSize, height, left, lines, top, width, writingMode }, index (`textBox-${index}`)}
   <div
-    class="textBox"
+    class="textBox {isControlPressed ? '' : alwaysShowOCRClass}"
     style:width
     style:height
     style:left
@@ -128,8 +133,16 @@
     z-index: 11;
   }
 
-  .textBox:focus p,
-  .textBox:hover p {
-    display: table;
+  .textBox:not(.always-show):focus p,
+  .textBox:not(.always-show):hover p {
+      display: table;
+  }
+
+  .textBox.always-show-ocr {
+      background: rgb(255, 255, 255);
+  }
+
+  .textBox.always-show-ocr p {
+      display: table;
   }
 </style>

--- a/src/lib/components/Settings/Reader/ReaderToggles.svelte
+++ b/src/lib/components/Settings/Reader/ReaderToggles.svelte
@@ -7,6 +7,7 @@
     { key: 'textEditable', text: 'Editable text', value: $settings.textEditable },
     { key: 'textBoxBorders', text: 'Text box borders', value: $settings.textBoxBorders },
     { key: 'displayOCR', text: 'OCR enabled', value: $settings.displayOCR },
+    { key: 'alwaysShowOCR', text: 'Show OCR by default', value: $settings.alwaysShowOCR },
     { key: 'boldFont', text: 'Bold font', value: $settings.boldFont },
     { key: 'pageNum', text: 'Show page number', value: $settings.pageNum },
     { key: 'charCount', text: 'Show character count', value: $settings.charCount },

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -45,6 +45,7 @@ export type Settings = {
   textEditable: boolean;
   textBoxBorders: boolean;
   displayOCR: boolean;
+  alwaysShowOCR: boolean;
   boldFont: boolean;
   pageNum: boolean;
   charCount: boolean;
@@ -71,6 +72,7 @@ export type VolumeDefaultsKey = keyof VolumeDefaults;
 const defaultSettings: Settings = {
   defaultFullscreen: false,
   displayOCR: true,
+  alwaysShowOCR: false,
   textEditable: false,
   textBoxBorders: false,
   boldFont: false,


### PR DESCRIPTION
I often have trouble reading extremely blurry text of most of manga - its already hard for a beginner to recognise words and kanji, but the blur makes it near impossible, so I added option to display OCR by default.