### PR TITLE
Add light mode

### DIFF
--- a/src/lib/components/CatalogListItem.svelte
+++ b/src/lib/components/CatalogListItem.svelte
@@ -12,7 +12,7 @@
     <ListgroupItem>
       <a href={id} class="h-full w-full">
         <div class="flex justify-between items-center">
-          <p class="font-semibold text-white">{manga.mokuroData.title}</p>
+          <p class="font-semibold text-black dark:text-white">{manga.mokuroData.title}</p>
           <img
             src={URL.createObjectURL(Object.values(manga.files)[0])}
             alt="img"

--- a/src/lib/components/Settings/AppearanceSettings.svelte
+++ b/src/lib/components/Settings/AppearanceSettings.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { settings, updateSetting } from '$lib/settings';
+  import { AccordionItem, Toggle } from 'flowbite-svelte';
+  let darkMode = $settings.darkMode;
+</script>
+
+<AccordionItem>
+  <span slot="header">Appearance</span>
+  <div class="flex flex-col gap-5">
+    <div>
+      <Toggle bind:checked={darkMode} on:change={() => {
+        updateSetting('darkMode', darkMode)
+      }}>Dark Mode</Toggle>
+    </div>
+  </div>
+</AccordionItem>
+
+

--- a/src/lib/components/Settings/Settings.svelte
+++ b/src/lib/components/Settings/Settings.svelte
@@ -14,6 +14,7 @@
   import About from './About.svelte';
   import QuickAccess from './QuickAccess.svelte';
   import { beforeNavigate } from '$app/navigation';
+  import AppearanceSettings from './AppearanceSettings.svelte';
 
   let transitionParams = {
     x: 320,
@@ -67,6 +68,7 @@
       <AnkiConnectSettings />
       <CatalogSettings />
       <Stats />
+      <AppearanceSettings />
       <About />
     </Accordion>
     <div class="flex flex-col gap-2">

--- a/src/lib/components/VolumeItem.svelte
+++ b/src/lib/components/VolumeItem.svelte
@@ -54,7 +54,13 @@
         class="flex flex-row gap-5 items-center justify-between w-full"
       >
         <div>
-          <p class="font-semibold" class:text-white={!isComplete}>{volName}</p>
+          <p
+            class="font-semibold"
+            class:text-black={!isComplete}
+            class:dark:text-white={!isComplete}
+          >
+            {volName}
+          </p>
           <p>{progressDisplay}</p>
         </div>
         <div class="flex gap-2">

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -60,6 +60,7 @@ export type Settings = {
   quickActions: boolean;
   fontSize: FontSize;
   zoomDefault: ZoomModes;
+  darkMode: boolean;
   invertColors: boolean;
   volumeDefaults: VolumeDefaults;
   ankiConnectSettings: AnkiConnectSettings;
@@ -88,6 +89,7 @@ const defaultSettings: Settings = {
   quickActions: true,
   fontSize: 'auto',
   zoomDefault: 'zoomFitToScreen',
+  darkMode: true,
   invertColors: false,
   volumeDefaults: {
     singlePageView: false,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,12 +2,29 @@
   import '../app.postcss';
   import { dev } from '$app/environment';
   import { inject } from '@vercel/analytics';
-
+  import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
+  import { settings } from '$lib/settings';
   import NavBar from '$lib/components/NavBar.svelte';
   import Snackbar from '$lib/components/Snackbar.svelte';
   import ConfirmationPopup from '$lib/components/ConfirmationPopup.svelte';
 
   inject({ mode: dev ? 'development' : 'production' });
+
+  // Keep or remove the Tailwind `dark` root class depending on user setting.
+  // Default to dark theme, which existed prior to adding the theme option.
+  onMount(() => {
+    const apply = (darkMode: boolean) => {
+      if (darkMode) document.documentElement.classList.add('dark');
+      else document.documentElement.classList.remove('dark');
+    };
+
+    // Initialize and subscribe to changes
+    apply(get(settings).darkMode ?? true);
+    
+    const unsubscribe = settings.subscribe((s) => apply(s.darkMode ?? true));
+    return unsubscribe;
+  });
 </script>
 
 <div class=" h-full min-h-[100svh] text-white">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -27,7 +27,7 @@
   });
 </script>
 
-<div class=" h-full min-h-[100svh] text-white">
+<div class=" h-full min-h-[100svh] text-black dark:text-white">
   <NavBar />
   <slot />
   <Snackbar />


### PR DESCRIPTION
Adds a light theme, which is suitable for ereaders that have poor contrast, making dark theme hard to see. This is done by leveraging the `dark` class already present throughout the codebase, though the third commit I've added does add it in a few places.

Defaults to dark theme to prevent any changes from current behavior.


https://github.com/user-attachments/assets/a3f826b8-74a2-47d9-934f-77fe31db51b2

PR may be easier to review commit-by-commit.