### PR TITLE
Add setting to remove newlines

### DIFF
--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -304,9 +304,13 @@
     ondblclick={(e) => onDoubleTap(e, lines)}
     {contenteditable}
   >
-    {#each lines as line}
-      <p>{line}</p>
-    {/each}
+    {#if $settings.removeNewlines}
+      <p>{lines.join("").replace(/[\n\r\s]/g, '')}</p>
+    {:else}
+      {#each lines as line}
+        <p>{line}</p>
+      {/each}
+    {/if}
   </div>
 {/each}
 

--- a/src/lib/components/Settings/Reader/ReaderToggles.svelte
+++ b/src/lib/components/Settings/Reader/ReaderToggles.svelte
@@ -30,7 +30,8 @@
       key: 'swapWheelBehavior',
       text: 'Swap mouse wheel scroll/zoom',
       value: $settings.swapWheelBehavior
-    }
+    },
+    { key: 'removeNewlines', text: 'Remove newlines', value: $settings.removeNewlines }
   ] as { key: SettingsKey; text: string; value: any; shortcut?: string }[]);
 
   // Mode selection: 'manual' or 'scheduled'

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -92,6 +92,7 @@ export type Settings = {
   invertColorsSchedule: TimeSchedule;
   inactivityTimeoutMinutes: number;
   swapWheelBehavior: boolean;
+  removeNewlines: boolean;
   volumeDefaults: VolumeDefaults;
   ankiConnectSettings: AnkiConnectSettings;
   catalogSettings: CatalogSettings;
@@ -143,6 +144,7 @@ const defaultSettings: Settings = {
   },
   inactivityTimeoutMinutes: 5,
   swapWheelBehavior: false,
+  removeNewlines: false,
   volumeDefaults: {
     singlePageView: 'auto',
     rightToLeft: true,


### PR DESCRIPTION
This removes newlines so tools like Yomitan can capture the whole sentence in the box, rather than only a single line with less context.

One issue: when toggled, it does mess up the text box bounds so the text flows out of the box. A refresh fixes it, but it would be good to recalculate the size though I don't have any Svelte experience so suggestions would be welcome.