### PR TITLE
revert: Roll back 1.0.6 release due to mobile touch issues

### DIFF
--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -10,9 +10,7 @@
     toggleFullScreen,
     zoomDefault,
     zoomDefaultWithLayoutWait,
-    zoomFitToScreen,
-    zoomNotification,
-    handleWheel as panzoomHandleWheel
+    zoomFitToScreen
   } from '$lib/panzoom';
   import {
     effectiveVolumeSettings,
@@ -25,7 +23,7 @@
     volumes,
     type VolumeSettings
   } from '$lib/settings';
-  import { clamp, fireExstaticEvent, resetScrollPosition } from '$lib/util';
+  import { clamp, debounce, fireExstaticEvent, resetScrollPosition } from '$lib/util';
   import { Input, Popover, Range, Spinner } from 'flowbite-svelte';
   import MangaPage from './MangaPage.svelte';
   import {
@@ -312,121 +310,43 @@
 
   let startX = 0;
   let startY = 0;
-  let touchStartTime = 0;
-  let isValidSwipeGesture = false; // Only true for clean single-finger gestures
-
-  // For pan-while-pinch: track centroid of two fingers
-  let lastCentroidX = 0;
-  let lastCentroidY = 0;
-  let isMultiTouch = false;
+  let touchStart: Date;
 
   function handleTouchStart(event: TouchEvent) {
-    if (!$settings.mobile) return;
-
-    // Multi-touch: track centroid for pan-while-pinch
-    if (event.touches.length > 1) {
-      isValidSwipeGesture = false;
-      isMultiTouch = true;
-      // Calculate initial centroid
-      const t1 = event.touches[0];
-      const t2 = event.touches[1];
-      lastCentroidX = (t1.clientX + t2.clientX) / 2;
-      lastCentroidY = (t1.clientY + t2.clientY) / 2;
-      return;
-    }
-
-    // Start tracking a potential swipe (single finger, fresh gesture)
-    if (event.touches.length === 1) {
+    if ($settings.mobile) {
       const { clientX, clientY } = event.touches[0];
-      touchStartTime = Date.now();
+      touchStart = new Date();
+
       startX = clientX;
       startY = clientY;
-      isValidSwipeGesture = true;
-      isMultiTouch = false;
     }
   }
-
-  function handleTouchMove(event: TouchEvent) {
-    if (!$settings.mobile) return;
-
-    // Pan-while-pinch: track centroid movement and apply pan
-    if (event.touches.length > 1) {
-      isValidSwipeGesture = false;
-
-      const t1 = event.touches[0];
-      const t2 = event.touches[1];
-      const centroidX = (t1.clientX + t2.clientX) / 2;
-      const centroidY = (t1.clientY + t2.clientY) / 2;
-
-      // If we were already in multi-touch, apply pan based on centroid movement
-      if (isMultiTouch && $panzoomStore) {
-        const dx = centroidX - lastCentroidX;
-        const dy = centroidY - lastCentroidY;
-        if (dx !== 0 || dy !== 0) {
-          $panzoomStore.moveBy(dx, dy, false);
-        }
-      }
-
-      lastCentroidX = centroidX;
-      lastCentroidY = centroidY;
-      isMultiTouch = true;
-    }
-  }
-
-  // Velocity thresholds for swipe sensitivity levels
-  const SWIPE_SENSITIVITY = {
-    low: { minVelocity: 1.6, minDistance: 200 },
-    medium: { minVelocity: 1.0, minDistance: 120 },
-    high: { minVelocity: 0.6, minDistance: 80 }
-  };
 
   function handlePointerUp(event: TouchEvent) {
-    // Early exit if not mobile mode or still touching
-    if (!$settings.mobile || event.touches.length > 0) return;
+    if ($settings.mobile) {
+      debounce(() => {
+        if (event.touches.length === 0) {
+          const { clientX, clientY } = event.changedTouches[0];
 
-    // Only process swipes from valid single-finger gestures
-    if (!isValidSwipeGesture) {
-      return;
-    }
+          const distanceX = clientX - startX;
+          const distanceY = clientY - startY;
 
-    // Reset flag for next gesture
-    isValidSwipeGesture = false;
+          const isSwipe = distanceY < 200 && distanceY > 200 * -1;
 
-    const { clientX, clientY } = event.changedTouches[0];
+          const end = new Date();
+          const touchDuration = end.getTime() - touchStart?.getTime();
 
-    const distanceX = clientX - startX;
-    const distanceY = clientY - startY;
-    const absDistanceX = Math.abs(distanceX);
-    const absDistanceY = Math.abs(distanceY);
+          if (isSwipe && touchDuration < 500) {
+            const swipeThreshold = Math.abs(($settings.swipeThreshold / 100) * window.innerWidth);
 
-    // Calculate elapsed time and velocity
-    const elapsed = Date.now() - touchStartTime;
-    if (elapsed <= 0) return; // Guard against zero/negative time
-
-    const velocity = absDistanceX / elapsed; // pixels per millisecond
-
-    // Get thresholds based on sensitivity setting
-    const sensitivity = $settings.swipeSensitivity || 'medium';
-    const { minVelocity, minDistance } = SWIPE_SENSITIVITY[sensitivity];
-
-    // Max vertical ratio: allow up to 75% vertical movement relative to horizontal
-    // This replaces the fixed 200px check with a ratio that works on any screen
-    const maxVerticalRatio = 0.75;
-
-    // Check swipe conditions:
-    // 1. Must be predominantly horizontal (vertical movement < 75% of horizontal)
-    // 2. Must meet minimum velocity (fast enough to be intentional)
-    // 3. Must travel minimum distance (to distinguish from taps)
-    const isHorizontal = absDistanceX > 0 && absDistanceY / absDistanceX < maxVerticalRatio;
-    const isFastEnough = velocity >= minVelocity;
-    const isFarEnough = absDistanceX >= minDistance;
-
-    if (isHorizontal && isFastEnough && isFarEnough) {
-      if (distanceX > 0) {
-        left(event, true);
-      } else {
-        right(event, true);
-      }
+            if (distanceX > swipeThreshold) {
+              left(event, true);
+            } else if (distanceX < swipeThreshold * -1) {
+              right(event, true);
+            }
+          }
+        }
+      });
     }
   }
 
@@ -443,16 +363,6 @@
     }
   }
 
-  // Wheel handler wrapper that excludes settings drawer and popovers
-  function handleWheelEvent(e: WheelEvent) {
-    const target = e.target as HTMLElement;
-    // Don't capture wheel events from settings drawer or popovers
-    if (target.closest('#settings') || target.closest('[data-popover]')) {
-      return;
-    }
-    panzoomHandleWheel(e);
-  }
-
   onMount(() => {
     // Set the timeout duration from settings
     activityTracker.setTimeoutDuration($settings.inactivityTimeoutMinutes);
@@ -467,27 +377,11 @@
     // Prevent scrollbars from appearing when in reader mode
     document.documentElement.style.overflow = 'hidden';
 
-    // Add wheel listener with capture to intercept ctrl+wheel before browser handles it
-    // passive: false is required to allow preventDefault()
-    window.addEventListener('wheel', handleWheelEvent, { capture: true, passive: false });
-
-    // Add touch listeners with capture phase to track gestures before panzoom handles them
-    // This ensures we can detect swipes even when panzoom is handling pan/zoom
-    window.addEventListener('touchstart', handleTouchStart, { capture: true, passive: true });
-    window.addEventListener('touchmove', handleTouchMove, { capture: true, passive: true });
-    window.addEventListener('touchend', handlePointerUp, { capture: true, passive: true });
-
     return () => {
       // Stop activity tracker when component unmounts
       activityTracker.stop();
       // Restore overflow when leaving reader
       document.documentElement.style.overflow = '';
-      // Remove wheel listener
-      window.removeEventListener('wheel', handleWheelEvent, { capture: true });
-      // Remove touch listeners
-      window.removeEventListener('touchstart', handleTouchStart, { capture: true });
-      window.removeEventListener('touchmove', handleTouchMove, { capture: true });
-      window.removeEventListener('touchend', handlePointerUp, { capture: true });
     };
   });
 
@@ -837,14 +731,6 @@
     }, 2000);
   }
 
-  // Subscribe to zoom notifications from panzoom
-  $effect(() => {
-    const zoom = $zoomNotification;
-    if (zoom) {
-      showNotification(`${zoom.percent}%`, `zoom-${zoom.timestamp}`);
-    }
-  });
-
   function rotatePageMode() {
     if (!volume) return;
 
@@ -905,6 +791,8 @@
     zoomDefaultWithLayoutWait();
   }}
   onkeydown={handleShortcuts}
+  ontouchstart={handleTouchStart}
+  ontouchend={handlePointerUp}
   onscroll={() => {
     // Detect and fix scroll position drift caused by scrolling in overlays
     // (e.g., settings menu) that affects the underlying document

--- a/src/lib/components/Reader/Timer.svelte
+++ b/src/lib/components/Reader/Timer.svelte
@@ -80,17 +80,6 @@
     }
   }
 
-  // Clean up timer when volumeId changes (e.g., navigating to next volume)
-  // This prevents the old interval from continuing to run against the previous volume
-  $effect(() => {
-    // Track volumeId to trigger cleanup when it changes
-    volumeId;
-
-    return () => {
-      stopTimer();
-    };
-  });
-
   onMount(() => {
     // Initialize activity tracker callbacks
     activityTracker.initialize({

--- a/src/lib/components/Settings/Reader/ReaderSettings.svelte
+++ b/src/lib/components/Settings/Reader/ReaderSettings.svelte
@@ -1,20 +1,13 @@
 <script lang="ts">
-  import { AccordionItem, Label, Range, Select } from 'flowbite-svelte';
+  import { AccordionItem, Label, Range } from 'flowbite-svelte';
   import ReaderSelects from './ReaderSelects.svelte';
   import ReaderToggles from './ReaderToggles.svelte';
-  import { settings, updateSetting, type SwipeSensitivity } from '$lib/settings';
+  import { settings, updateSetting } from '$lib/settings';
 
-  let swipeSensitivityValue = $state($settings.swipeSensitivity);
+  let swipeThresholdValue = $state($settings.swipeThreshold);
   let edgeButtonWidthValue = $state($settings.edgeButtonWidth);
-
-  const sensitivityOptions: { value: SwipeSensitivity; name: string }[] = [
-    { value: 'low', name: 'Low - Requires faster swipes' },
-    { value: 'medium', name: 'Medium - Balanced' },
-    { value: 'high', name: 'High - Responds to light swipes' }
-  ];
-
   function onSwipeChange() {
-    updateSetting('swipeSensitivity', swipeSensitivityValue);
+    updateSetting('swipeThreshold', swipeThresholdValue);
   }
 
   function onWidthChange() {
@@ -30,14 +23,15 @@
     <ReaderToggles />
     <div>
       <Label>
-        Swipe sensitivity
+        Swipe threshold
         <span class="ml-2 text-xs text-gray-500 dark:text-gray-400">(Mobile only)</span>
       </Label>
-      <Select
-        items={sensitivityOptions}
-        bind:value={swipeSensitivityValue}
+      <Range
         onchange={onSwipeChange}
+        min={20}
+        max={90}
         disabled={!$settings.mobile}
+        bind:value={swipeThresholdValue}
       />
     </div>
     <div>

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -28,8 +28,6 @@ export type ZoomModes =
 
 export type PageTransition = 'none' | 'crossfade' | 'vertical' | 'pageTurn' | 'swipe';
 
-export type SwipeSensitivity = 'low' | 'medium' | 'high';
-
 export type AnkiConnectSettings = {
   enabled: boolean;
   pictureField: string;
@@ -81,8 +79,7 @@ export type Settings = {
   bounds: boolean;
   mobile: boolean;
   backgroundColor: string;
-  swipeThreshold: number; // Deprecated: kept for migration, use swipeSensitivity
-  swipeSensitivity: SwipeSensitivity;
+  swipeThreshold: number;
   edgeButtonWidth: number;
   showTimer: boolean;
   quickActions: boolean;
@@ -125,8 +122,7 @@ const defaultSettings: Settings = {
   mobile: false,
   bounds: true,
   backgroundColor: '#030712',
-  swipeThreshold: 50, // Deprecated
-  swipeSensitivity: 'medium',
+  swipeThreshold: 50,
   edgeButtonWidth: 40,
   showTimer: false,
   quickActions: true,
@@ -183,7 +179,7 @@ const mobileDefaultSettings: Settings = {
   defaultFullscreen: true,
   edgeButtonWidth: 60,
   showTimer: false,
-  swipeSensitivity: 'medium'
+  swipeThreshold: 50
 };
 
 // Desktop-optimized default settings
@@ -193,7 +189,7 @@ const desktopDefaultSettings: Settings = {
   defaultFullscreen: false,
   edgeButtonWidth: 40,
   showTimer: true,
-  swipeSensitivity: 'medium'
+  swipeThreshold: 50
 };
 
 type Profiles = Record<string, Settings>;

--- a/src/lib/upload/index.ts
+++ b/src/lib/upload/index.ts
@@ -281,14 +281,10 @@ async function processMokuroFile(file: File): Promise<{
   titleUuid: string;
 }> {
   const mokuroData: MokuroData = JSON.parse(await file.text());
-
-  // Use volume title as fallback for empty series title
-  const seriesTitle = mokuroData.title || mokuroData.volume || file.name.replace('.mokuro', '');
-
   return {
     metadata: {
       mokuro_version: mokuroData.version,
-      series_title: seriesTitle,
+      series_title: mokuroData.title,
       series_uuid: mokuroData.title_uuid,
       page_count: mokuroData.pages.length,
       character_count: mokuroData.chars,
@@ -614,19 +610,9 @@ export async function processFiles(
     fileStack.push({ path, file });
   });
 
-  // Sort files: images and zips first, then mokuro files last
-  // This ensures images are stored in pendingImagesByPath before mokuro files try to match them
-  fileStack = fileStack.sort((a, b) => {
-    const aIsMokuro = isMokuro(a.file.name);
-    const bIsMokuro = isMokuro(b.file.name);
-
-    // Mokuro files should come after non-mokuro files
-    if (aIsMokuro && !bIsMokuro) return 1;
-    if (!aIsMokuro && bIsMokuro) return -1;
-
-    // Within each group, sort alphabetically
-    return a.file.name.localeCompare(b.file.name, undefined, { numeric: true });
-  });
+  fileStack = fileStack.sort((a, b) =>
+    a.file.name.localeCompare(b.file.name, undefined, { numeric: true })
+  );
 
   for (const file of fileStack) {
     await processFile(file, volumesByPath, volumesDataByPath, pendingImagesByPath);


### PR DESCRIPTION
## Summary
Reverts the 1.0.6 release merge to restore mobile textbox touch functionality.

## Problem
The 1.0.6 release introduced capture-phase touch event listeners that broke OCR textbox visibility on mobile devices.

## Solution
Rolling back the entire 1.0.6 release to restore working mobile touch behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)