### PR TITLE
fix: v1.0.5.8 - Revert 1.0.6 and apply safe fixes

### DIFF
--- a/.changeset/fix-empty-title-import.md
+++ b/.changeset/fix-empty-title-import.md
@@ -1,0 +1,5 @@
+---
+'mokuro-reader': patch
+---
+
+Fix import failure when mokuro file has empty series name (falls back to volume name)

--- a/.changeset/fix-textbox-interactions.md
+++ b/.changeset/fix-textbox-interactions.md
@@ -1,0 +1,8 @@
+---
+'mokuro-reader': patch
+---
+
+Fix text box interactions in reader:
+
+- Double-clicking text boxes no longer triggers zoom
+- Crop image popup now works on first page load without needing to page first

--- a/.changeset/fix-timer-volume-transition.md
+++ b/.changeset/fix-timer-volume-transition.md
@@ -1,0 +1,5 @@
+---
+'mokuro-reader': patch
+---
+
+Fix timer continuing to run against previous volume when paging into next volume

--- a/.changeset/fix-yomitan-sentence-capture.md
+++ b/.changeset/fix-yomitan-sentence-capture.md
@@ -1,0 +1,5 @@
+---
+'mokuro-reader': patch
+---
+
+Fix Yomitan Anki sentence capture having double linebreaks when copying text from OCR boxes

--- a/.changeset/smooth-wheel-zoom.md
+++ b/.changeset/smooth-wheel-zoom.md
@@ -1,0 +1,5 @@
+---
+'mokuro-reader': patch
+---
+
+Fix wheel zoom normalization across browsers and platforms. Normalizes scroll delta between Chrome and Firefox, adds platform-specific speed adjustment, implements edge-aware zoom to keep corners visible, and captures wheel events at window level to prevent browser zoom when hovering over UI elements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,19 @@
 # Changelog
 
-## 1.0.6.1
-
-### Fixed
-
-- OCR text boxes now show on mobile touch devices (regression from linebreak fix)
-
-## 1.0.6
+## [1.0.5.8] - 2025-12-07
 
 ### Fixed
 
 - Consistent wheel zoom step sizes between Chrome and Firefox with platform-aware speed adjustment
-- Velocity-based swipe detection that works reliably on high-refresh/high-DPI devices
-- Pinch-zoom no longer triggers accidental page turns
-- Pan-while-pinch support (move two fingers together to pan while zooming)
-- Zoom bounds enforcement during pinch gestures
 - Handle mokuro files with empty series name (falls back to volume name)
 - Stop timer when paging into next/previous volume
 - Double-clicking text boxes no longer triggers zoom
 - Crop image popup now works on first page load without needing to page first
-- Window resize and fullscreen now properly reset to fit-to-page mode
 - Copying text from OCR boxes no longer has double linebreaks (fixes Yomitan Anki sentence capture)
 
-### Added
+### Reverted
 
-- New "Swipe sensitivity" setting (Low/Medium/High)
+- Rolled back mobile swipe/pinch-zoom changes from 1.0.6 that broke textbox touch visibility
 
 ## 1.0.5
 
@@ -44,13 +33,6 @@
 
 - Fix cross-site imports via `/upload?manga=X&volume=Y` URLs (regression from hash router migration)
 - Cross-site imports now use global progress tracker instead of dedicated page
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
 
 ## [1.0.3] - 2025-12-03
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mokuro-reader",
-  "version": "1.0.6.1",
+  "version": "1.0.5.8",
   "private": true,
   "scripts": {
     "dev": "vite dev",
@@ -12,9 +12,14 @@
     "format": "prettier --plugin-search-dir . --write .",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
+    "changeset": "changeset",
+    "changeset:version": "changeset version",
+    "changeset:publish": "changeset tag",
     "prepare": "husky"
   },
   "devDependencies": {
+    "@changesets/changelog-github": "^0.5.2",
+    "@changesets/cli": "^2.29.8",
     "@sveltejs/adapter-auto": "^4.0.0",
     "@sveltejs/kit": "^2.5.27",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
@@ -75,6 +80,6 @@
     ]
   },
   "lint-staged": {
-    "*.{js,mjs,cjs,ts,svelte,md,json,css,html}": "prettier --write"
+    "*.{js,ts,svelte,md,json,css,html}": "prettier --write"
   }
 }

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -25,7 +25,7 @@
     volumes,
     type VolumeSettings
   } from '$lib/settings';
-  import { clamp, fireExstaticEvent, resetScrollPosition } from '$lib/util';
+  import { clamp, debounce, fireExstaticEvent, resetScrollPosition } from '$lib/util';
   import { Input, Popover, Range, Spinner } from 'flowbite-svelte';
   import MangaPage from './MangaPage.svelte';
   import {
@@ -312,121 +312,43 @@
 
   let startX = 0;
   let startY = 0;
-  let touchStartTime = 0;
-  let isValidSwipeGesture = false; // Only true for clean single-finger gestures
-
-  // For pan-while-pinch: track centroid of two fingers
-  let lastCentroidX = 0;
-  let lastCentroidY = 0;
-  let isMultiTouch = false;
+  let touchStart: Date;
 
   function handleTouchStart(event: TouchEvent) {
-    if (!$settings.mobile) return;
-
-    // Multi-touch: track centroid for pan-while-pinch
-    if (event.touches.length > 1) {
-      isValidSwipeGesture = false;
-      isMultiTouch = true;
-      // Calculate initial centroid
-      const t1 = event.touches[0];
-      const t2 = event.touches[1];
-      lastCentroidX = (t1.clientX + t2.clientX) / 2;
-      lastCentroidY = (t1.clientY + t2.clientY) / 2;
-      return;
-    }
-
-    // Start tracking a potential swipe (single finger, fresh gesture)
-    if (event.touches.length === 1) {
+    if ($settings.mobile) {
       const { clientX, clientY } = event.touches[0];
-      touchStartTime = Date.now();
+      touchStart = new Date();
+
       startX = clientX;
       startY = clientY;
-      isValidSwipeGesture = true;
-      isMultiTouch = false;
     }
   }
-
-  function handleTouchMove(event: TouchEvent) {
-    if (!$settings.mobile) return;
-
-    // Pan-while-pinch: track centroid movement and apply pan
-    if (event.touches.length > 1) {
-      isValidSwipeGesture = false;
-
-      const t1 = event.touches[0];
-      const t2 = event.touches[1];
-      const centroidX = (t1.clientX + t2.clientX) / 2;
-      const centroidY = (t1.clientY + t2.clientY) / 2;
-
-      // If we were already in multi-touch, apply pan based on centroid movement
-      if (isMultiTouch && $panzoomStore) {
-        const dx = centroidX - lastCentroidX;
-        const dy = centroidY - lastCentroidY;
-        if (dx !== 0 || dy !== 0) {
-          $panzoomStore.moveBy(dx, dy, false);
-        }
-      }
-
-      lastCentroidX = centroidX;
-      lastCentroidY = centroidY;
-      isMultiTouch = true;
-    }
-  }
-
-  // Velocity thresholds for swipe sensitivity levels
-  const SWIPE_SENSITIVITY = {
-    low: { minVelocity: 1.6, minDistance: 200 },
-    medium: { minVelocity: 1.0, minDistance: 120 },
-    high: { minVelocity: 0.6, minDistance: 80 }
-  };
 
   function handlePointerUp(event: TouchEvent) {
-    // Early exit if not mobile mode or still touching
-    if (!$settings.mobile || event.touches.length > 0) return;
+    if ($settings.mobile) {
+      debounce(() => {
+        if (event.touches.length === 0) {
+          const { clientX, clientY } = event.changedTouches[0];
 
-    // Only process swipes from valid single-finger gestures
-    if (!isValidSwipeGesture) {
-      return;
-    }
+          const distanceX = clientX - startX;
+          const distanceY = clientY - startY;
 
-    // Reset flag for next gesture
-    isValidSwipeGesture = false;
+          const isSwipe = distanceY < 200 && distanceY > 200 * -1;
 
-    const { clientX, clientY } = event.changedTouches[0];
+          const end = new Date();
+          const touchDuration = end.getTime() - touchStart?.getTime();
 
-    const distanceX = clientX - startX;
-    const distanceY = clientY - startY;
-    const absDistanceX = Math.abs(distanceX);
-    const absDistanceY = Math.abs(distanceY);
+          if (isSwipe && touchDuration < 500) {
+            const swipeThreshold = Math.abs(($settings.swipeThreshold / 100) * window.innerWidth);
 
-    // Calculate elapsed time and velocity
-    const elapsed = Date.now() - touchStartTime;
-    if (elapsed <= 0) return; // Guard against zero/negative time
-
-    const velocity = absDistanceX / elapsed; // pixels per millisecond
-
-    // Get thresholds based on sensitivity setting
-    const sensitivity = $settings.swipeSensitivity || 'medium';
-    const { minVelocity, minDistance } = SWIPE_SENSITIVITY[sensitivity];
-
-    // Max vertical ratio: allow up to 75% vertical movement relative to horizontal
-    // This replaces the fixed 200px check with a ratio that works on any screen
-    const maxVerticalRatio = 0.75;
-
-    // Check swipe conditions:
-    // 1. Must be predominantly horizontal (vertical movement < 75% of horizontal)
-    // 2. Must meet minimum velocity (fast enough to be intentional)
-    // 3. Must travel minimum distance (to distinguish from taps)
-    const isHorizontal = absDistanceX > 0 && absDistanceY / absDistanceX < maxVerticalRatio;
-    const isFastEnough = velocity >= minVelocity;
-    const isFarEnough = absDistanceX >= minDistance;
-
-    if (isHorizontal && isFastEnough && isFarEnough) {
-      if (distanceX > 0) {
-        left(event, true);
-      } else {
-        right(event, true);
-      }
+            if (distanceX > swipeThreshold) {
+              left(event, true);
+            } else if (distanceX < swipeThreshold * -1) {
+              right(event, true);
+            }
+          }
+        }
+      });
     }
   }
 
@@ -471,12 +393,6 @@
     // passive: false is required to allow preventDefault()
     window.addEventListener('wheel', handleWheelEvent, { capture: true, passive: false });
 
-    // Add touch listeners with capture phase to track gestures before panzoom handles them
-    // This ensures we can detect swipes even when panzoom is handling pan/zoom
-    window.addEventListener('touchstart', handleTouchStart, { capture: true, passive: true });
-    window.addEventListener('touchmove', handleTouchMove, { capture: true, passive: true });
-    window.addEventListener('touchend', handlePointerUp, { capture: true, passive: true });
-
     return () => {
       // Stop activity tracker when component unmounts
       activityTracker.stop();
@@ -484,10 +400,6 @@
       document.documentElement.style.overflow = '';
       // Remove wheel listener
       window.removeEventListener('wheel', handleWheelEvent, { capture: true });
-      // Remove touch listeners
-      window.removeEventListener('touchstart', handleTouchStart, { capture: true });
-      window.removeEventListener('touchmove', handleTouchMove, { capture: true });
-      window.removeEventListener('touchend', handlePointerUp, { capture: true });
     };
   });
 
@@ -905,6 +817,8 @@
     zoomDefaultWithLayoutWait();
   }}
   onkeydown={handleShortcuts}
+  ontouchstart={handleTouchStart}
+  ontouchend={handlePointerUp}
   onscroll={() => {
     // Detect and fix scroll position drift caused by scrolling in overlays
     // (e.g., settings menu) that affects the underlying document

--- a/src/lib/components/Settings/Reader/ReaderSettings.svelte
+++ b/src/lib/components/Settings/Reader/ReaderSettings.svelte
@@ -1,20 +1,13 @@
 <script lang="ts">
-  import { AccordionItem, Label, Range, Select } from 'flowbite-svelte';
+  import { AccordionItem, Label, Range } from 'flowbite-svelte';
   import ReaderSelects from './ReaderSelects.svelte';
   import ReaderToggles from './ReaderToggles.svelte';
-  import { settings, updateSetting, type SwipeSensitivity } from '$lib/settings';
+  import { settings, updateSetting } from '$lib/settings';
 
-  let swipeSensitivityValue = $state($settings.swipeSensitivity);
+  let swipeThresholdValue = $state($settings.swipeThreshold);
   let edgeButtonWidthValue = $state($settings.edgeButtonWidth);
-
-  const sensitivityOptions: { value: SwipeSensitivity; name: string }[] = [
-    { value: 'low', name: 'Low - Requires faster swipes' },
-    { value: 'medium', name: 'Medium - Balanced' },
-    { value: 'high', name: 'High - Responds to light swipes' }
-  ];
-
   function onSwipeChange() {
-    updateSetting('swipeSensitivity', swipeSensitivityValue);
+    updateSetting('swipeThreshold', swipeThresholdValue);
   }
 
   function onWidthChange() {
@@ -30,14 +23,15 @@
     <ReaderToggles />
     <div>
       <Label>
-        Swipe sensitivity
+        Swipe threshold
         <span class="ml-2 text-xs text-gray-500 dark:text-gray-400">(Mobile only)</span>
       </Label>
-      <Select
-        items={sensitivityOptions}
-        bind:value={swipeSensitivityValue}
+      <Range
         onchange={onSwipeChange}
+        min={20}
+        max={90}
         disabled={!$settings.mobile}
+        bind:value={swipeThresholdValue}
       />
     </div>
     <div>

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -28,8 +28,6 @@ export type ZoomModes =
 
 export type PageTransition = 'none' | 'crossfade' | 'vertical' | 'pageTurn' | 'swipe';
 
-export type SwipeSensitivity = 'low' | 'medium' | 'high';
-
 export type AnkiConnectSettings = {
   enabled: boolean;
   pictureField: string;
@@ -81,8 +79,7 @@ export type Settings = {
   bounds: boolean;
   mobile: boolean;
   backgroundColor: string;
-  swipeThreshold: number; // Deprecated: kept for migration, use swipeSensitivity
-  swipeSensitivity: SwipeSensitivity;
+  swipeThreshold: number;
   edgeButtonWidth: number;
   showTimer: boolean;
   quickActions: boolean;
@@ -125,8 +122,7 @@ const defaultSettings: Settings = {
   mobile: false,
   bounds: true,
   backgroundColor: '#030712',
-  swipeThreshold: 50, // Deprecated
-  swipeSensitivity: 'medium',
+  swipeThreshold: 50,
   edgeButtonWidth: 40,
   showTimer: false,
   quickActions: true,
@@ -183,7 +179,7 @@ const mobileDefaultSettings: Settings = {
   defaultFullscreen: true,
   edgeButtonWidth: 60,
   showTimer: false,
-  swipeSensitivity: 'medium'
+  swipeThreshold: 50
 };
 
 // Desktop-optimized default settings
@@ -193,7 +189,7 @@ const desktopDefaultSettings: Settings = {
   defaultFullscreen: false,
   edgeButtonWidth: 40,
   showTimer: true,
-  swipeSensitivity: 'medium'
+  swipeThreshold: 50
 };
 
 type Profiles = Record<string, Settings>;


### PR DESCRIPTION
## Summary

Reverts the problematic 1.0.6 release and cherry-picks only the safe bug fixes that don't break mobile textbox touch visibility.

## Fixed

- Consistent wheel zoom step sizes between Chrome and Firefox with platform-aware speed adjustment
- Handle mokuro files with empty series name (falls back to volume name)
- Stop timer when paging into next/previous volume
- Double-clicking text boxes no longer triggers zoom
- Crop image popup now works on first page load without needing to page first
- Copying text from OCR boxes no longer has double linebreaks (fixes Yomitan Anki sentence capture)

## Reverted

- Rolled back mobile swipe/pinch-zoom changes from 1.0.6 that broke textbox touch visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)