### PR TITLE
Added option to keep zoom and pan to top right

### DIFF
--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -791,7 +791,7 @@
     const currentMode = $settings.zoomDefault;
     let nextMode: typeof currentMode;
 
-    // Rotate through: fitToScreen -> fitToWidth -> original -> keepZoom -> keepZoomStart -> fitToScreen
+    // Rotate through: fitToScreen -> fitToWidth -> original -> keepZoom -> keepZoomStart -> keepZoomTopCorner -> fitToScreen
     if (currentMode === 'zoomFitToScreen') {
       nextMode = 'zoomFitToWidth';
     } else if (currentMode === 'zoomFitToWidth') {
@@ -800,6 +800,8 @@
       nextMode = 'keepZoom';
     } else if (currentMode === 'keepZoom') {
       nextMode = 'keepZoomStart';
+    } else if (currentMode === 'keepZoomStart') {
+      nextMode = 'keepZoomTopCorner';
     } else {
       nextMode = 'zoomFitToScreen';
     }
@@ -812,7 +814,8 @@
       zoomFitToWidth: 'Fit to Width',
       zoomOriginal: 'Original Size',
       keepZoom: 'Keep Zoom',
-      keepZoomStart: 'Keep Zoom, Pan to Top'
+      keepZoomStart: 'Keep Zoom, Pan to Top Center',
+      keepZoomTopCorner: 'Keep Zoom, Pan to Top Corner'
     };
     showNotification(labels[nextMode], `zoommode-${nextMode}`);
   }

--- a/src/lib/components/Settings/Reader/ReaderSelects.svelte
+++ b/src/lib/components/Settings/Reader/ReaderSelects.svelte
@@ -12,7 +12,8 @@
     { value: 'zoomFitToWidth', name: 'Fit to width' },
     { value: 'zoomOriginal', name: 'Original size' },
     { value: 'keepZoom', name: 'Keep zoom' },
-    { value: 'keepZoomStart', name: 'Keep zoom, pan to top' }
+    { value: 'keepZoomStart', name: 'Keep zoom, pan to top center' },
+    { value: 'keepZoomTopCorner', name: 'Keep zoom, pan to top corner' }
   ];
 
   let pageTransitions = [

--- a/src/lib/panzoom/util.ts
+++ b/src/lib/panzoom/util.ts
@@ -1,7 +1,8 @@
-import { settings } from '$lib/settings';
+import { effectiveVolumeSettings, settings } from '$lib/settings';
 import type { PanZoom } from 'panzoom';
 import panzoom from 'panzoom';
 import { get, writable } from 'svelte/store';
+import { routeParams } from '$lib/util/hash-router';
 
 let pz: PanZoom | undefined;
 let container: HTMLElement | undefined;
@@ -166,6 +167,14 @@ export function keepZoomStart() {
   panAlign('center', 'top');
 }
 
+export function keepZoomTopCorner() {
+  const volumeId = get(routeParams).volume ?? '';
+
+  const isRightToLeft = get(effectiveVolumeSettings)[volumeId]?.rightToLeft ?? false;
+
+  panAlign(isRightToLeft ? 'right' : 'left', 'top');
+}
+
 export function zoomDefault() {
   const zoomDefault = get(settings).zoomDefault;
   switch (zoomDefault) {
@@ -180,6 +189,9 @@ export function zoomDefault() {
       return;
     case 'keepZoomStart':
       keepZoomStart();
+      return;
+    case 'keepZoomTopCorner':
+      keepZoomTopCorner();
       return;
   }
 }

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -24,7 +24,8 @@ export type ZoomModes =
   | 'zoomFitToWidth'
   | 'zoomOriginal'
   | 'keepZoom'
-  | 'keepZoomStart';
+  | 'keepZoomStart'
+  | 'keepZoomTopCorner';
 
 export type PageTransition = 'none' | 'crossfade' | 'vertical' | 'pageTurn' | 'swipe';
 


### PR DESCRIPTION
Default keepZoomStart with top-center focus was useless for right-to-left manga on mobile. Added an option to focus on the top-right when turning pages