### PR TITLE
Add PR target guard for external contributions

### DIFF
--- a/.github/workflows/pr-target-guard.yml
+++ b/.github/workflows/pr-target-guard.yml
@@ -1,0 +1,20 @@
+name: PR Target Guard
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  check-target:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork
+    steps:
+      - name: Close and redirect to develop
+        run: |
+          gh pr close ${{ github.event.number }} --repo ${{ github.repository }} --comment "Thanks for helping make this project better!
+
+          We use a \`develop\` branch for external PRs to allow for safer review and integration. Please update your PR to target \`develop\` instead of \`main\`, then reopen it.
+
+          Looking forward to reviewing your changes!"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds workflow that auto-closes fork PRs targeting `main`
- Redirects contributors to use the `develop` branch instead
- Created `develop` branch for external contributions

## Why
Allows external contributors to submit PRs while keeping `main` protected and stable.

🤖 Generated with [Claude Code](https://claude.ai/code)