### PR TITLE
ci: add tag trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Release
 on:
   push:
     branches: [main]
+    tags:
+      - 'v*'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
## Summary
- Add `v*` tag push trigger to release workflow
- Allows manual releases via `git tag v1.0.x && git push origin v1.0.x`
- Existing version-change detection on main still works

## Test plan
- [ ] Push a test tag to verify workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)