### PR TITLE
fix(cloud): Add main thread download fallback for mixed content

### DIFF
--- a/src/lib/catalog/thumbnail-cache.ts
+++ b/src/lib/catalog/thumbnail-cache.ts
@@ -15,10 +15,7 @@
  * - Visibility check: skip off-screen items before dispatch
  */
 
-import type {
-  DecodeRequest,
-  DecodeResponse
-} from '$lib/workers/thumbnail-decode-worker';
+import type { DecodeRequest, DecodeResponse } from '$lib/workers/thumbnail-decode-worker';
 
 export interface CacheEntry {
   bitmap: ImageBitmap;

--- a/src/lib/util/sync/folder-deduplicator.ts
+++ b/src/lib/util/sync/folder-deduplicator.ts
@@ -82,7 +82,10 @@ class FolderDeduplicator {
    * @param ops Folder operations for this provider
    * @returns Result with counts of what was merged
    */
-  async deduplicateAll(provider: ProviderType, ops: FolderOperations): Promise<DeduplicationResult> {
+  async deduplicateAll(
+    provider: ProviderType,
+    ops: FolderOperations
+  ): Promise<DeduplicationResult> {
     const result: DeduplicationResult = {
       groupsMerged: 0,
       foldersDeleted: 0,
@@ -112,7 +115,9 @@ class FolderDeduplicator {
         return result;
       }
 
-      console.log(`[Dedup:${provider}] Found ${duplicateGroups.length} duplicate group(s) to merge`);
+      console.log(
+        `[Dedup:${provider}] Found ${duplicateGroups.length} duplicate group(s) to merge`
+      );
 
       // Merge each group
       for (const group of duplicateGroups) {

--- a/src/lib/util/sync/provider-interface.ts
+++ b/src/lib/util/sync/provider-interface.ts
@@ -210,6 +210,17 @@ export interface SyncProvider {
    */
   readonly downloadConcurrencyLimit: number;
 
+  /**
+   * Check if worker downloads are possible in the current context.
+   * This is a dynamic check that considers runtime conditions like mixed content.
+   *
+   * Returns false for mixed content scenarios (HTTPS page + HTTP provider URL),
+   * where blob URL workers cannot make HTTP requests due to browser security.
+   *
+   * If not implemented, falls back to static `supportsWorkerDownload` flag.
+   */
+  canUseWorkerDownload?(): boolean;
+
   /** Check if user is currently authenticated */
   isAuthenticated(): boolean;
 

--- a/src/lib/util/sync/providers/google-drive/drive-files-cache.ts
+++ b/src/lib/util/sync/providers/google-drive/drive-files-cache.ts
@@ -608,10 +608,7 @@ class DriveFilesCacheManager implements CloudCache<DriveFileMetadata> {
    */
   private runDeduplication(): void {
     // Import dynamically to avoid circular dependencies
-    Promise.all([
-      import('../../folder-deduplicator'),
-      import('./google-drive-provider')
-    ])
+    Promise.all([import('../../folder-deduplicator'), import('./google-drive-provider')])
       .then(async ([{ folderDeduplicator }, { googleDriveProvider }]) => {
         if (!googleDriveProvider.isAuthenticated()) {
           return;

--- a/src/lib/util/sync/providers/google-drive/google-drive-provider.ts
+++ b/src/lib/util/sync/providers/google-drive/google-drive-provider.ts
@@ -117,6 +117,14 @@ class GoogleDriveProvider implements SyncProvider {
     };
   }
 
+  /**
+   * Check if worker downloads are possible in the current context.
+   * Google Drive API is always HTTPS, so no mixed content issues.
+   */
+  canUseWorkerDownload(): boolean {
+    return true; // Google Drive API is always HTTPS
+  }
+
   async login(): Promise<void> {
     try {
       if (!browser) {
@@ -704,7 +712,10 @@ class GoogleDriveProvider implements SyncProvider {
     if (folders.length === 0) {
       // No folder exists - create one
       console.log(`📁 Creating folder: ${folderName}`);
-      return await driveApiClient.createFolder(folderName, parentId === 'root' ? undefined : parentId);
+      return await driveApiClient.createFolder(
+        folderName,
+        parentId === 'root' ? undefined : parentId
+      );
     }
 
     // Return first folder found (oldest if multiple - they'll be deduped later)
@@ -714,7 +725,9 @@ class GoogleDriveProvider implements SyncProvider {
         const dateB = new Date(b.createdTime || 0).getTime();
         return dateA - dateB;
       });
-      console.log(`⚠️ Found ${folders.length} folders named '${folderName}', using oldest (dedup will run later)`);
+      console.log(
+        `⚠️ Found ${folders.length} folders named '${folderName}', using oldest (dedup will run later)`
+      );
     }
 
     return folders[0].id;
@@ -814,7 +827,10 @@ class GoogleDriveProvider implements SyncProvider {
       }
 
       // Find or create the folder (dedup handled separately by FolderDeduplicator)
-      const folderId = await this.findOrCreateFolder('root', GOOGLE_DRIVE_CONFIG.FOLDER_NAMES.READER);
+      const folderId = await this.findOrCreateFolder(
+        'root',
+        GOOGLE_DRIVE_CONFIG.FOLDER_NAMES.READER
+      );
 
       // Store in both caches
       this.readerFolderId = folderId;

--- a/src/lib/util/sync/providers/mega/mega-provider.ts
+++ b/src/lib/util/sync/providers/mega/mega-provider.ts
@@ -177,6 +177,14 @@ export class MegaProvider implements SyncProvider {
     };
   }
 
+  /**
+   * Check if worker downloads are possible in the current context.
+   * MEGA API is always HTTPS, so no mixed content issues.
+   */
+  canUseWorkerDownload(): boolean {
+    return true; // MEGA API is always HTTPS
+  }
+
   async login(credentials?: ProviderCredentials): Promise<void> {
     if (!credentials || !credentials.email || !credentials.password) {
       throw new ProviderError('Email and password are required', 'mega', 'INVALID_CREDENTIALS');


### PR DESCRIPTION
## Summary
- Adds dynamic `canUseWorkerDownload()` method to detect mixed content scenarios
- When HTTPS page tries to download from HTTP WebDAV server, downloads on main thread instead of worker
- Worker still handles decompression to keep main thread responsive
- Google Drive and MEGA unaffected (always HTTPS)

## Problem
HTTPS pages with blob URL workers cannot make HTTP requests due to browser mixed content restrictions. The main thread can make these requests (with local network access permission), but workers cannot.

## Solution
- WebDAV provider checks if page is HTTPS and server is HTTP
- If mixed content detected, download queue routes to main thread download + worker decompress path
- Progress tracking: 0-70% download, 70-90% decompress, 90-100% processing

## Test plan
- [ ] Deploy via Vercel preview
- [ ] Serve app over HTTPS
- [ ] Connect to HTTP WebDAV server (e.g., local network NAS)
- [ ] Verify downloads work via main thread path
- [ ] Verify HTTPS WebDAV still uses worker path
- [ ] Verify Google Drive and MEGA still use worker path

🤖 Generated with [Claude Code](https://claude.com/claude-code)