### PR TITLE
WebDAV download retry with resume and compact cloud series

### DIFF
--- a/src/lib/components/CatalogItem.svelte
+++ b/src/lib/components/CatalogItem.svelte
@@ -78,13 +78,16 @@
     }
 
     // Cloud path: use enriched placeholders, capped to prevent cache thrashing
+    if (useCompactForCloud) {
+      return enrichedPlaceholders.slice(0, 1);
+    }
     const limit = stackCount === 0 ? MAX_CLOUD_STACK : Math.min(stackCount, MAX_CLOUD_STACK);
     return enrichedPlaceholders.slice(0, limit);
   });
 
   // Key for CompositeCanvas - forces fresh component on settings change
   let compositeKey = $derived(
-    `${$catalogSettings?.stackCount ?? 3}-${$catalogSettings?.horizontalStep ?? 11}-${$catalogSettings?.verticalStep ?? 5}`
+    `${$catalogSettings?.stackCount ?? 3}-${$catalogSettings?.horizontalStep ?? 11}-${$catalogSettings?.verticalStep ?? 5}-${($catalogSettings?.compactCloudSeries ?? false) ? 'compact' : 'full'}`
   );
 
   // Check if this series is downloading or queued

--- a/src/lib/workers/unified-file-worker.ts
+++ b/src/lib/workers/unified-file-worker.ts
@@ -271,48 +271,178 @@ async function downloadFromWebDAV(
     headers.Authorization = 'Basic ' + btoa(`${username}:${password}`);
   }
 
-  const response = await fetch(fullUrl, { headers });
-
-  if (!response.ok) {
-    throw new Error(`WebDAV download failed: ${response.status} ${response.statusText}`);
-  }
-
-  const contentLength = parseInt(response.headers.get('Content-Length') || '0', 10);
-  const reader = response.body?.getReader();
-
-  if (!reader) {
-    throw new Error('Response body is not readable');
-  }
+  const MAX_ERROR_RETRIES = 5;
+  const MAX_PARTIAL_RESUME_RETRIES = 8;
+  const BASE_RETRY_DELAY_MS = 400;
+  const MAX_RETRY_DELAY_MS = 5000;
+  const PROGRESS_THROTTLE_MS = 67; // ~15 updates per second
 
   const chunks: Uint8Array[] = [];
   let receivedLength = 0;
-
-  // Throttle progress updates to ~15/second (matches XHR behavior)
+  let expectedTotal = 0;
   let lastProgressUpdate = 0;
-  const PROGRESS_THROTTLE_MS = 67; // ~15 updates per second
+  let lastError: Error | null = null;
+  let errorRetries = 0;
+  let partialResumeRetries = 0;
+  let lastRetryResetOffset = 0;
+
+  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  const isRetryableStatus = (status: number) => status === 408 || status === 429 || status >= 500;
+  const isRetryableError = (error: unknown) => {
+    const message = error instanceof Error ? error.message.toLowerCase() : '';
+    return (
+      message.includes('network') ||
+      message.includes('timeout') ||
+      message.includes('failed to fetch') ||
+      message.includes('fetch')
+    );
+  };
+
+  const parseContentRangeTotal = (value: string | null): number => {
+    if (!value) return 0;
+    const match = value.match(/\/(\d+)$/);
+    return match ? parseInt(match[1], 10) : 0;
+  };
+
+  const getRetryResetThreshold = (): number => {
+    // Reset retry budgets after meaningful forward progress:
+    // max(1MB, 5% of expected size when known)
+    if (expectedTotal > 0) {
+      return Math.max(1024 * 1024, Math.floor(expectedTotal * 0.05));
+    }
+    return 1024 * 1024;
+  };
+
+  // Best-effort size probe: helps detect truncation even when GET is chunked
+  // without Content-Length. If HEAD fails/is unsupported, we'll continue without it.
+  try {
+    const headResponse = await fetch(fullUrl, { method: 'HEAD', headers });
+    if (headResponse.ok) {
+      const headSize = parseInt(headResponse.headers.get('Content-Length') || '0', 10);
+      if (headSize > 0) {
+        expectedTotal = headSize;
+      }
+    }
+  } catch {
+    // ignore
+  }
 
   while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
+    const requestHeaders: Record<string, string> = { ...headers };
+    if (receivedLength > 0) {
+      requestHeaders.Range = `bytes=${receivedLength}-`;
+    }
 
-    chunks.push(value);
-    receivedLength += value.length;
+    try {
+      const response = await fetch(fullUrl, { headers: requestHeaders });
 
-    // Only send progress update if enough time has passed
-    const now = Date.now();
-    if (now - lastProgressUpdate >= PROGRESS_THROTTLE_MS) {
-      onProgress(receivedLength, contentLength || receivedLength);
-      lastProgressUpdate = now;
+      if (!response.ok) {
+        // 416 can happen when range start == size (already complete)
+        if (response.status === 416 && expectedTotal > 0 && receivedLength >= expectedTotal) {
+          break;
+        }
+
+        const error = new Error(`WebDAV download failed: ${response.status} ${response.statusText}`);
+        lastError = error;
+        if (isRetryableStatus(response.status) && errorRetries < MAX_ERROR_RETRIES) {
+          errorRetries += 1;
+          const jitter = Math.floor(Math.random() * 150);
+          const delay = Math.min(
+            MAX_RETRY_DELAY_MS,
+            BASE_RETRY_DELAY_MS * 2 ** (errorRetries - 1) + jitter
+          );
+          await sleep(delay);
+          continue;
+        }
+        throw error;
+      }
+
+      // If server ignores Range on resumed attempts, restart in-worker from scratch.
+      if (receivedLength > 0 && response.status === 200) {
+        chunks.length = 0;
+        receivedLength = 0;
+      }
+
+      const contentLength = parseInt(response.headers.get('Content-Length') || '0', 10);
+      const contentRangeTotal = parseContentRangeTotal(response.headers.get('Content-Range'));
+      if (contentRangeTotal > 0) {
+        expectedTotal = contentRangeTotal;
+      } else if (contentLength > 0) {
+        expectedTotal = receivedLength + contentLength;
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error('Response body is not readable');
+      }
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+
+        chunks.push(value);
+        receivedLength += value.length;
+
+        // Connection is making forward progress; clear retry pressure periodically.
+        if (receivedLength - lastRetryResetOffset >= getRetryResetThreshold()) {
+          errorRetries = 0;
+          partialResumeRetries = 0;
+          lastRetryResetOffset = receivedLength;
+        }
+
+        const now = Date.now();
+        if (now - lastProgressUpdate >= PROGRESS_THROTTLE_MS) {
+          onProgress(receivedLength, expectedTotal || receivedLength);
+          lastProgressUpdate = now;
+        }
+      }
+
+      // If stream ended early, retry with Range from current offset.
+      if (expectedTotal > 0 && receivedLength < expectedTotal) {
+        if (partialResumeRetries >= MAX_PARTIAL_RESUME_RETRIES) {
+          throw new Error('WebDAV download incomplete after partial-resume retries');
+        }
+        partialResumeRetries += 1;
+        const jitter = Math.floor(Math.random() * 150);
+        const delay = Math.min(
+          MAX_RETRY_DELAY_MS,
+          BASE_RETRY_DELAY_MS * 2 ** (partialResumeRetries - 1) + jitter
+        );
+        await sleep(delay);
+        continue;
+      }
+
+      break;
+    } catch (error) {
+      const wrapped =
+        error instanceof Error ? error : new Error('Unknown error during WebDAV download');
+      lastError = wrapped;
+
+      if (isRetryableError(wrapped) && errorRetries < MAX_ERROR_RETRIES) {
+        errorRetries += 1;
+        const jitter = Math.floor(Math.random() * 150);
+        const delay = Math.min(
+          MAX_RETRY_DELAY_MS,
+          BASE_RETRY_DELAY_MS * 2 ** (errorRetries - 1) + jitter
+        );
+        await sleep(delay);
+        continue;
+      }
+
+      throw wrapped;
     }
   }
 
-  // Always send final progress update at 100%
-  onProgress(receivedLength, contentLength || receivedLength);
+  if (expectedTotal > 0 && receivedLength < expectedTotal) {
+    throw lastError || new Error('WebDAV download incomplete after retries');
+  }
 
-  // Use Blob to combine chunks - avoids allocating a second copy of the entire file
+  onProgress(receivedLength, expectedTotal || receivedLength);
+
   const blob = new Blob(chunks as BlobPart[]);
   const buffer = await blob.arrayBuffer();
-  // Clear chunks array to free memory
   chunks.length = 0;
   return buffer;
 }


### PR DESCRIPTION
## Summary

- **WebDAV download retry with resume** — Downloads now retry up to 5 times with exponential backoff and jitter. Partial downloads resume via HTTP Range headers instead of restarting from scratch.
- **Compact cloud series toggle** — Cloud-only series in the catalog can show a single thumbnail instead of the full stack, reducing visual clutter and cache pressure.

## Test plan

- [ ] Download a volume from WebDAV and verify it completes successfully
- [ ] Simulate a flaky connection and verify retries with partial resume
- [ ] Toggle compact cloud series setting and verify catalog updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)