### PR TITLE
Release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [1.5.0] - 2026-02-28
+
+### Added
+
+- **WebDAV download retry** - Failed downloads now retry automatically with resume support
+- **Easier OCR with mokuro-bunko** - Image-only volumes uploaded to a [mokuro-bunko](https://github.com/Gnathonic/mokuro-bunko) for OCR processing will automatically have their text data added locally on the next refresh.
+- **Catalog drop shadow toggle** - Drop shadows on catalog thumbnails can now be disabled, improving the appearance of spine showcase mode
+- **Delete cloud-only series** - Remove series from cloud storage directly without needing to download them first
+- **Volume keyboard shortcuts** - Hover over a volume on the series page and press E to edit, C to change cover, Delete to remove, or Shift+Delete to delete from cloud
+- **Cover page stitching** - Combine two pages side-by-side when cropping a cover, great for spread artwork split across two pages
+- **Cover picker improvements** - Rotate images, pages in reading order, and custom covers sync to the cloud automatically
+- **Escape closes modals** - Pressing Escape in the volume editor or cover picker closes the modal instead of leaving the series page
+
+### Changed
+
+- **Smarter series grouping** - Local and cloud volumes now always appear together in the catalog even if they were imported separately or have slight differences in naming
+
+### Fixed
+
+- **Dual page cover handling** - Fixed cover page consuming two pages instead of one when dual page mode is set explicitly
+- **AnkiConnect page numbers** - Correct page numbers in templates, including dual-page captures
+- **AnkiConnect tags on mobile** - Fixed tags appearing in update mode on Android when they should be disabled
+- **AnkiConnect card updates** - Updating existing cards now preserves their formatting
+
 ## [1.4.0] - 2026-02-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mokuro-reader",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/anki-connect/index.ts
+++ b/src/lib/anki-connect/index.ts
@@ -15,6 +15,7 @@ import type {
 } from '$lib/settings/settings';
 import { settings, DEFAULT_MODEL_CONFIGS } from '$lib/settings';
 import { showSnackbar } from '$lib/util';
+import { isMobilePlatform } from '$lib/util/platform';
 import { get } from 'svelte/store';
 
 export * from './cropper';
@@ -995,8 +996,8 @@ export async function updateLastCard(
       return;
     }
 
-    // Add tags if provided
-    if (resolvedTags && resolvedTags.length > 0) {
+    // Add tags if provided (AnkiConnect Android doesn't support addTags, so skip on mobile)
+    if (resolvedTags && resolvedTags.length > 0 && !isMobilePlatform()) {
       await ankiConnect('addTags', { notes: [id], tags: resolvedTags }, { silent: true });
     }
 

--- a/src/lib/anki-connect/index.ts
+++ b/src/lib/anki-connect/index.ts
@@ -166,9 +166,9 @@ export function resolveTemplate(
     resolved = resolved.replace(/\{volume\}/g, '');
   }
 
-  // Replace {page_num} with page number (1-indexed for display)
+  // Replace {page_num} with page number (already 1-indexed from callers)
   if (options?.pageNumber !== undefined) {
-    resolved = resolved.replace(/\{page_num\}/g, String(options.pageNumber + 1));
+    resolved = resolved.replace(/\{page_num\}/g, String(options.pageNumber));
   } else {
     resolved = resolved.replace(/\{page_num\}/g, '');
   }

--- a/src/lib/catalog/catalog.ts
+++ b/src/lib/catalog/catalog.ts
@@ -11,19 +11,24 @@ function sortTitles(a: Series, b: Series) {
   return a.title.localeCompare(b.title, undefined, { sensitivity: 'base' });
 }
 
+function normalizeSeriesTitle(title: string): string {
+  return title.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
 export function deriveSeriesFromVolumes(volumeEntries: Array<VolumeMetadata>) {
-  // Group volumes by series_uuid
+  // Group volumes by normalized series title (user-visible identity)
   const titleMap = new Map<string, Series>();
 
   for (const entry of volumeEntries) {
-    let volumes = titleMap.get(entry.series_uuid);
+    const key = normalizeSeriesTitle(entry.series_title);
+    let volumes = titleMap.get(key);
     if (volumes === undefined) {
       volumes = {
         title: entry.series_title,
         series_uuid: entry.series_uuid,
         volumes: []
       };
-      titleMap.set(entry.series_uuid, volumes);
+      titleMap.set(key, volumes);
     }
     volumes.volumes.push(entry);
   }

--- a/src/lib/catalog/placeholders.ts
+++ b/src/lib/catalog/placeholders.ts
@@ -2,6 +2,7 @@ import type { VolumeMetadata } from '$lib/types';
 import type { CloudVolumeWithProvider } from '$lib/util/sync/unified-cloud-manager';
 import { browser } from '$app/environment';
 import { generateDeterministicUUID } from '$lib/util/series-extraction';
+import { enqueueCloudOcrUpgrade } from '$lib/util/libraries/library-ocr-upgrade-queue';
 
 /**
  * Extract series title from description field
@@ -99,26 +100,53 @@ export function generatePlaceholders(
   }
 
   // Create a set of local volume paths for fast lookup
-  const localPaths = new Set(
-    localVolumes.map((vol) => `${vol.series_title}/${vol.volume_title}.cbz`)
-  );
+  const localPaths = new Set(localVolumes.map((vol) => `${vol.series_title}/${vol.volume_title}.cbz`));
+  const localVolumeByPath = new Map<string, VolumeMetadata>();
+  const localImageOnlyByVolumeTitle = new Map<string, VolumeMetadata[]>();
+  for (const vol of localVolumes) {
+    const key = `${vol.series_title}/${vol.volume_title}.cbz`.toLowerCase();
+    if (!vol.isPlaceholder && !localVolumeByPath.has(key)) {
+      localVolumeByPath.set(key, vol);
+    }
+
+    const currentMokuroVersion =
+      typeof vol.mokuro_version === 'string' ? vol.mokuro_version.trim() : '';
+    if (!vol.isPlaceholder && currentMokuroVersion === '') {
+      const titleKey = vol.volume_title.toLowerCase();
+      const existing = localImageOnlyByVolumeTitle.get(titleKey) || [];
+      existing.push(vol);
+      localImageOnlyByVolumeTitle.set(titleKey, existing);
+    }
+  }
 
   // Create a map of series titles to their UUIDs from local volumes
   const seriesTitleToUuid = new Map<string, string>();
   for (const vol of localVolumes) {
-    if (!seriesTitleToUuid.has(vol.series_title)) {
-      seriesTitleToUuid.set(vol.series_title, vol.series_uuid);
+    const lowerTitle = vol.series_title.toLowerCase();
+    if (!seriesTitleToUuid.has(lowerTitle)) {
+      seriesTitleToUuid.set(lowerTitle, vol.series_uuid);
     }
   }
 
   // Flatten Map values into a single array and split out .webp sidecars
   const cloudFiles: CloudVolumeWithProvider[] = [];
   const thumbnailMap = new Map<string, string>(); // basePath -> fileId
+  const mokuroMap = new Map<string, CloudVolumeWithProvider>(); // basePath -> sidecar metadata
   for (const files of cloudFilesMap.values()) {
     for (const file of files) {
-      if (file.path.toLowerCase().endsWith('.webp')) {
+      const lowerPath = file.path.toLowerCase();
+      if (lowerPath.endsWith('.webp')) {
         const basePath = file.path.replace(/\.webp$/i, '');
         thumbnailMap.set(basePath, file.fileId);
+      } else if (lowerPath.endsWith('.mokuro.gz')) {
+        const basePath = file.path.replace(/\.mokuro\.gz$/i, '');
+        // Prefer plain .mokuro over .mokuro.gz when both exist.
+        if (!mokuroMap.has(basePath)) {
+          mokuroMap.set(basePath, file);
+        }
+      } else if (lowerPath.endsWith('.mokuro')) {
+        const basePath = file.path.replace(/\.mokuro$/i, '');
+        mokuroMap.set(basePath, file);
       } else {
         cloudFiles.push(file);
       }
@@ -137,7 +165,8 @@ export function generatePlaceholders(
     // Use existing series UUID if we have local volumes with this series title
     // Otherwise generate a deterministic UUID for a new series
     const seriesUuid =
-      seriesTitleToUuid.get(parsed.seriesTitle) || generateDeterministicUUID(parsed.seriesTitle);
+      seriesTitleToUuid.get(parsed.seriesTitle.toLowerCase()) ||
+      generateDeterministicUUID(parsed.seriesTitle);
 
     const placeholder = createPlaceholder(cloudFile, seriesUuid);
     if (placeholder) {
@@ -147,6 +176,63 @@ export function generatePlaceholders(
         placeholder.cloudThumbnailFileId = thumbnailFileId;
       }
       placeholders.push(placeholder);
+    }
+  }
+
+  console.log(
+    '[Cloud OCR Upgrade] Placeholder matcher scan:',
+    `cbz=${cloudFiles.length}`,
+    `mokuro=${mokuroMap.size}`,
+    `locals=${localPaths.size}`
+  );
+
+  // Auto-upgrade local image-only volumes when matching remote .mokuro sidecar exists.
+  for (const cloudFile of cloudFiles) {
+    const parsed = parseCloudPath(cloudFile.path, cloudFile.description);
+    if (!parsed) continue;
+
+    const cloudPathKey = cloudFile.path.toLowerCase();
+    let localVolume = localVolumeByPath.get(cloudPathKey);
+    if (!localVolume) {
+      // Fallback only when series title also matches; never pair by volume title alone.
+      const candidates = localImageOnlyByVolumeTitle.get(parsed.volumeTitle.toLowerCase()) || [];
+      const seriesMatches = candidates.filter(
+        (candidate) => candidate.series_title.toLowerCase() === parsed.seriesTitle.toLowerCase()
+      );
+      if (seriesMatches.length === 1) {
+        localVolume = seriesMatches[0];
+      } else if (seriesMatches.length > 1 || candidates.length > 0) {
+        console.log(
+          '[Cloud OCR Upgrade] Ambiguous local image-only match; skipping fallback:',
+          parsed.seriesTitle,
+          parsed.volumeTitle,
+          `seriesMatches=${seriesMatches.length}`,
+          `candidates=${candidates.length}`
+        );
+      }
+    }
+
+    if (!localVolume) continue;
+
+    const currentMokuroVersion =
+      typeof localVolume.mokuro_version === 'string' ? localVolume.mokuro_version.trim() : '';
+    if (currentMokuroVersion !== '') continue;
+
+    const basePath = cloudFile.path.replace(/\.cbz$/i, '');
+    const remoteMokuro = mokuroMap.get(basePath);
+    if (remoteMokuro) {
+      console.log(
+        '[Cloud OCR Upgrade] Match found, enqueueing upgrade:',
+        `${localVolume.series_title}/${localVolume.volume_title}`,
+        'using',
+        remoteMokuro.path
+      );
+      enqueueCloudOcrUpgrade(localVolume, remoteMokuro);
+    } else {
+      console.log(
+        '[Cloud OCR Upgrade] Local image-only match has no remote mokuro sidecar:',
+        `${localVolume.series_title}/${localVolume.volume_title}`
+      );
     }
   }
 

--- a/src/lib/components/Catalog.svelte
+++ b/src/lib/components/Catalog.svelte
@@ -317,13 +317,13 @@
       <!-- Local series -->
       <div class="flex flex-col flex-wrap justify-center gap-[3px] sm:flex-row sm:justify-start">
         {#if $miscSettings.galleryLayout === 'grid'}
-          {#each localSeries as { series_uuid, volumes } (series_uuid)}
-            <CatalogItem {series_uuid} {volumes} providerName={providerDisplayName} />
+          {#each localSeries as { title, volumes } (title)}
+            <CatalogItem {volumes} providerName={providerDisplayName} />
           {/each}
         {:else}
           <Listgroup active class="w-full">
-            {#each localSeries as { series_uuid, volumes } (series_uuid)}
-              <CatalogListItem {series_uuid} {volumes} providerName={providerDisplayName} />
+            {#each localSeries as { title, volumes } (title)}
+              <CatalogListItem {volumes} providerName={providerDisplayName} />
             {/each}
           </Listgroup>
         {/if}
@@ -352,13 +352,13 @@
             class="flex flex-col flex-wrap justify-center gap-[3px] sm:flex-row sm:justify-start"
           >
             {#if $miscSettings.galleryLayout === 'grid'}
-              {#each placeholderSeries as { series_uuid, volumes } (series_uuid)}
-                <CatalogItem {series_uuid} {volumes} providerName={providerDisplayName} />
+              {#each placeholderSeries as { title, volumes } (title)}
+                <CatalogItem {volumes} providerName={providerDisplayName} />
               {/each}
             {:else}
               <Listgroup active class="w-full">
-                {#each placeholderSeries as { series_uuid, volumes } (series_uuid)}
-                  <CatalogListItem {series_uuid} {volumes} providerName={providerDisplayName} />
+                {#each placeholderSeries as { title, volumes } (title)}
+                  <CatalogListItem {volumes} providerName={providerDisplayName} />
                 {/each}
               </Listgroup>
             {/if}

--- a/src/lib/components/CatalogItem.svelte
+++ b/src/lib/components/CatalogItem.svelte
@@ -78,13 +78,16 @@
     }
 
     // Cloud path: use enriched placeholders, capped to prevent cache thrashing
+    if (useCompactForCloud) {
+      return enrichedPlaceholders.slice(0, 1);
+    }
     const limit = stackCount === 0 ? MAX_CLOUD_STACK : Math.min(stackCount, MAX_CLOUD_STACK);
     return enrichedPlaceholders.slice(0, limit);
   });
 
   // Key for CompositeCanvas - forces fresh component on settings change
   let compositeKey = $derived(
-    `${$catalogSettings?.stackCount ?? 3}-${$catalogSettings?.horizontalStep ?? 11}-${$catalogSettings?.verticalStep ?? 5}`
+    `${$catalogSettings?.stackCount ?? 3}-${$catalogSettings?.horizontalStep ?? 11}-${$catalogSettings?.verticalStep ?? 5}-${($catalogSettings?.compactCloudSeries ?? false) ? 'compact' : 'full'}`
   );
 
   // Check if this series is downloading or queued

--- a/src/lib/components/CatalogItem.svelte
+++ b/src/lib/components/CatalogItem.svelte
@@ -14,12 +14,11 @@
   const CATALOG_SCROLL_Y_KEY = 'mokuro:catalog:scroll-y';
 
   interface Props {
-    series_uuid: string;
     volumes: VolumeMetadata[]; // Pre-computed by parent - avoids O(N) re-filtering
     providerName?: string; // Shared across all items - avoids repeated lookups
   }
 
-  let { series_uuid, volumes, providerName = 'Cloud' }: Props = $props();
+  let { volumes, providerName = 'Cloud' }: Props = $props();
 
   // Volumes are pre-sorted by catalog store (natural sort)
   let seriesVolumes = $derived(volumes);
@@ -429,9 +428,8 @@
     };
   });
 
-  // Use title for placeholder-only (handles transition when first volume downloads)
-  // Use UUID for local series (handles edge case of same-name series)
-  let navId = $derived(isPlaceholderOnly ? volume?.series_title || '' : series_uuid);
+  // Use series title for navigation so grouping and routing align with user-visible identity.
+  let navId = $derived(volume?.series_title || '');
 
   function persistCatalogScrollPosition() {
     const y =

--- a/src/lib/components/CatalogItem.svelte
+++ b/src/lib/components/CatalogItem.svelte
@@ -84,10 +84,145 @@
     return enrichedPlaceholders.slice(0, limit);
   });
 
+  let showDropShadow = $derived($catalogSettings?.dropShadow ?? true);
+
+  // Per-series horizontal offset adjustment (in-memory only, not persisted)
+  let hOffsetAdjust = $state(0);
+  // Per-volume horizontal offset adjustments (index → pixels)
+  let volumeOffsets = $state<Map<number, number>>(new Map());
+  let isHovered = $state(false);
+  let modifierState = $state<'none' | 'shift' | 'alt-shift'>('none');
+  let hoveredVolumeIndex = $state<number | null>(null);
+  let containerEl = $state<HTMLElement | null>(null);
+  let outerEl = $state<HTMLElement | null>(null);
+
+  const ADJUST_STEP = 0.25; // % per scroll tick for series
+  const VOLUME_ADJUST_STEP = 1; // pixels per scroll tick for individual volume
+
+  // Cumulative offset at index i = sum of volumeOffsets[0..i-1]
+  // Each volume's offset pushes all subsequent volumes
+  function getCumulativeOffset(index: number): number {
+    let total = 0;
+    for (let i = 0; i < index; i++) {
+      total += volumeOffsets.get(i) ?? 0;
+    }
+    return total;
+  }
+
+  // Total cascading offset across all volumes (affects container sizing)
+  // Only offsets 0..N-2 matter; the last volume's offset has no volume after it
+  function getCumulativeOffsetTotal(count: number): number {
+    return getCumulativeOffset(count - 1);
+  }
+
+  function updateModifierState(e: KeyboardEvent | MouseEvent) {
+    if (e.shiftKey && e.altKey) {
+      modifierState = 'alt-shift';
+    } else if (e.shiftKey) {
+      modifierState = 'shift';
+    } else {
+      modifierState = 'none';
+    }
+  }
+
+  function handleKeyChange(e: KeyboardEvent) {
+    if (!isHovered) return;
+    updateModifierState(e);
+  }
+
+  function handleWheel(e: WheelEvent) {
+    if (!isHovered) return;
+    updateModifierState(e);
+
+    if (e.shiftKey && e.altKey && hoveredVolumeIndex !== null) {
+      // Alt+Shift+Scroll: adjust individual volume
+      e.preventDefault();
+      const delta = e.deltaY > 0 ? -VOLUME_ADJUST_STEP : VOLUME_ADJUST_STEP;
+      const current = volumeOffsets.get(hoveredVolumeIndex) ?? 0;
+      const next = new Map(volumeOffsets);
+      next.set(hoveredVolumeIndex, current + delta);
+      volumeOffsets = next;
+    } else if (e.shiftKey && !e.altKey) {
+      // Shift+Scroll: adjust series offset
+      e.preventDefault();
+      const delta = e.deltaY > 0 ? -ADJUST_STEP : ADJUST_STEP;
+      hOffsetAdjust += delta;
+    }
+  }
+
+  function handleContextMenu(e: MouseEvent) {
+    if (e.shiftKey && e.altKey && hoveredVolumeIndex !== null) {
+      // Alt+Shift+RMB: reset individual volume offset
+      e.preventDefault();
+      const next = new Map(volumeOffsets);
+      next.delete(hoveredVolumeIndex);
+      volumeOffsets = next;
+    } else if (e.shiftKey && !e.altKey) {
+      // Shift+RMB: reset series offset
+      e.preventDefault();
+      hOffsetAdjust = 0;
+    }
+  }
+
+  // Determine which volume index the mouse is over based on cascading positions
+  function handleMouseMove(e: MouseEvent) {
+    updateModifierState(e);
+    if (!containerEl || stackedVolumes.length <= 1) {
+      hoveredVolumeIndex = 0;
+      return;
+    }
+
+    const rect = containerEl.getBoundingClientRect();
+    const mouseX = e.clientX - rect.left;
+
+    const sizes = stackedVolumes.length > 0 && hasRenderableThumbnails ? stepSizes : placeholderStepSizes;
+    const count = stackedVolumes.length;
+
+    // Build cascading left positions
+    let cumOffset = 0;
+    const positions: number[] = [];
+    for (let i = 0; i < count; i++) {
+      positions[i] = sizes.leftOffset + i * sizes.horizontal + cumOffset;
+      cumOffset += volumeOffsets.get(i) ?? 0;
+    }
+
+    // Hit test front-to-back (index 0 is front/leftmost, drawn on top)
+    for (let i = 0; i < count; i++) {
+      const left = positions[i];
+      const right = left + BASE_WIDTH;
+      if (mouseX >= left && mouseX <= right) {
+        hoveredVolumeIndex = i;
+        return;
+      }
+    }
+    hoveredVolumeIndex = count - 1;
+  }
+
+  $effect(() => {
+    if (isHovered) {
+      window.addEventListener('keydown', handleKeyChange);
+      window.addEventListener('keyup', handleKeyChange);
+      // Non-passive wheel listener so we can preventDefault on shift+scroll
+      outerEl?.addEventListener('wheel', handleWheel as EventListener, { passive: false });
+      return () => {
+        window.removeEventListener('keydown', handleKeyChange);
+        window.removeEventListener('keyup', handleKeyChange);
+        outerEl?.removeEventListener('wheel', handleWheel as EventListener);
+      };
+    } else {
+      modifierState = 'none';
+    }
+  });
+
   // Key for CompositeCanvas - forces fresh component on settings change
+  let volumeOffsetsKey = $derived([...volumeOffsets.entries()].map(([k, v]) => `${k}:${v}`).join(','));
   let compositeKey = $derived(
-    `${$catalogSettings?.stackCount ?? 3}-${$catalogSettings?.horizontalStep ?? 11}-${$catalogSettings?.verticalStep ?? 5}-${($catalogSettings?.compactCloudSeries ?? false) ? 'compact' : 'full'}`
+    `${$catalogSettings?.stackCount ?? 3}-${$catalogSettings?.horizontalStep ?? 11}-${$catalogSettings?.verticalStep ?? 5}-${($catalogSettings?.compactCloudSeries ?? false) ? 'compact' : 'full'}-${showDropShadow}-${hOffsetAdjust}-${volumeOffsetsKey}`
   );
+
+  // Visual indicator state
+  let showSeriesIndicator = $derived(isHovered && modifierState === 'shift');
+  let showVolumeIndicator = $derived(isHovered && modifierState === 'alt-shift');
 
   // Check if this series is downloading or queued
   let isDownloading = $derived(
@@ -199,7 +334,7 @@
     }
 
     const stackCountSetting = $catalogSettings?.stackCount ?? 3;
-    const hOffsetPercent = ($catalogSettings?.horizontalStep ?? 11) / 100;
+    const hOffsetPercent = (($catalogSettings?.horizontalStep ?? 11) + hOffsetAdjust) / 100;
     // Force vertical offset to 0 when stack count is 0 (all volumes / spine mode)
     const vOffsetPercent =
       stackCountSetting === 0 ? 0 : ($catalogSettings?.verticalStep ?? 5) / 100;
@@ -215,8 +350,11 @@
     const extraWidth = BASE_WIDTH * hOffsetPercent * (effectiveStackCount - 1);
     const extraHeight = BASE_HEIGHT * vOffsetPercent * (effectiveStackCount - 1);
 
-    // Inner container (thumbnail area)
-    const innerWidth = Math.round(baseWidth + extraWidth);
+    // Per-volume offsets cascade: each offset shifts all subsequent volumes
+    const cumulativeOffsetPx = getCumulativeOffsetTotal(effectiveStackCount);
+
+    // Inner container (thumbnail area) — clamp so it never shrinks below one volume
+    const innerWidth = Math.max(BASE_WIDTH, Math.round(baseWidth + extraWidth + cumulativeOffsetPx));
     const innerHeight = Math.round(BASE_HEIGHT + extraHeight);
 
     // Outer container (with padding)
@@ -250,7 +388,7 @@
   // Calculate step sizes and centering/spreading offsets
   let stepSizes = $derived.by(() => {
     const stackCountSetting = $catalogSettings?.stackCount ?? 3;
-    const hOffsetPercent = ($catalogSettings?.horizontalStep ?? 11) / 100;
+    const hOffsetPercent = (($catalogSettings?.horizontalStep ?? 11) + hOffsetAdjust) / 100;
     // Force vertical offset to 0 when stack count is 0 (all volumes / spine mode)
     const vOffsetPercent =
       stackCountSetting === 0 ? 0 : ($catalogSettings?.verticalStep ?? 5) / 100;
@@ -337,7 +475,7 @@
     }
 
     const stackCountSetting = $catalogSettings?.stackCount ?? 3;
-    const hOffsetPercent = ($catalogSettings?.horizontalStep ?? 11) / 100;
+    const hOffsetPercent = (($catalogSettings?.horizontalStep ?? 11) + hOffsetAdjust) / 100;
     const vOffsetPercent =
       stackCountSetting === 0 ? 0 : ($catalogSettings?.verticalStep ?? 5) / 100;
     const centerHorizontal = $catalogSettings?.centerHorizontal ?? true;
@@ -446,11 +584,20 @@
 
 {#if volume}
   <a href="#/series/{encodeURIComponent(navId)}" onclick={handleClick}>
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
+      bind:this={outerEl}
       class:text-green-400={isComplete}
       class:opacity-70={isPlaceholderOnly}
-      class="relative flex flex-col items-center gap-[5px] rounded-lg border-2 border-transparent p-3 text-center transition-colors hover:bg-gray-100 dark:hover:bg-gray-700"
+      class="relative flex flex-col items-center gap-[5px] rounded-lg border-2 p-3 text-center transition-colors hover:bg-gray-100 dark:hover:bg-gray-700"
+      class:border-transparent={!showSeriesIndicator}
+      class:border-blue-400={showSeriesIndicator}
+      class:border-dashed={showSeriesIndicator}
       class:cursor-pointer={isPlaceholderOnly}
+      onmouseenter={() => (isHovered = true)}
+      onmouseleave={() => { isHovered = false; hoveredVolumeIndex = null; }}
+      onmousemove={handleMouseMove}
+      oncontextmenu={handleContextMenu}
     >
       {#if stackedVolumes.length > 0 && hasRenderableThumbnails}
         <!-- CompositeCanvas - unified for BOTH local and cloud thumbnails -->
@@ -459,6 +606,7 @@
           style="width: {containerDimensions.outerWidth}px; height: {containerDimensions.outerHeight}px;"
         >
           <div
+            bind:this={containerEl}
             class="relative overflow-hidden"
             style="width: {containerDimensions.innerWidth}px; height: {containerDimensions.innerHeight}px;"
           >
@@ -469,6 +617,9 @@
                 canvasHeight={containerDimensions.innerHeight}
                 {getCanvasDimensions}
                 {stepSizes}
+                dropShadow={showDropShadow}
+                {volumeOffsets}
+                highlightIndex={showVolumeIndicator ? hoveredVolumeIndex : null}
               />
             {/key}
           </div>
@@ -495,11 +646,14 @@
           >
             {#each Array(placeholderStepSizes.count) as _, i}
               <div
-                class="absolute flex items-center justify-center border border-gray-300 bg-gray-200 dark:border-gray-600 dark:bg-gray-800"
+                class="absolute flex items-center justify-center bg-gray-200 dark:bg-gray-800"
+                class:border={showDropShadow}
+                class:border-gray-300={showDropShadow}
+                class:dark:border-gray-600={showDropShadow}
                 style="width: {BASE_WIDTH}px; height: {BASE_HEIGHT}px; left: {placeholderStepSizes.leftOffset +
-                  i * placeholderStepSizes.horizontal}px; top: {placeholderStepSizes.topOffset +
+                  i * placeholderStepSizes.horizontal + getCumulativeOffset(i)}px; top: {placeholderStepSizes.topOffset +
                   i * placeholderStepSizes.vertical}px; z-index: {placeholderStepSizes.count -
-                  i}; filter: drop-shadow(2px 4px 6px rgba(0, 0, 0, 0.5));"
+                  i};{showDropShadow ? ' filter: drop-shadow(2px 4px 6px rgba(0, 0, 0, 0.5));' : ''}"
               >
                 {#if i === 0}
                   <div class="flex flex-col items-center gap-3">
@@ -528,11 +682,14 @@
           >
             {#each Array(Math.max(stackedVolumes.length, 1)) as _, i}
               <div
-                class="absolute flex items-center justify-center border border-gray-300 bg-gray-200 dark:border-gray-600 dark:bg-gray-800"
+                class="absolute flex items-center justify-center bg-gray-200 dark:bg-gray-800"
+                class:border={showDropShadow}
+                class:border-gray-300={showDropShadow}
+                class:dark:border-gray-600={showDropShadow}
                 style="width: {BASE_WIDTH}px; height: {BASE_HEIGHT}px; left: {stepSizes.leftOffset +
-                  i * stepSizes.horizontal}px; top: {stepSizes.topOffset +
+                  i * stepSizes.horizontal + getCumulativeOffset(i)}px; top: {stepSizes.topOffset +
                   i * stepSizes.vertical}px; z-index: {Math.max(stackedVolumes.length, 1) -
-                  i}; filter: drop-shadow(2px 4px 6px rgba(0, 0, 0, 0.5));"
+                  i};{showDropShadow ? ' filter: drop-shadow(2px 4px 6px rgba(0, 0, 0, 0.5));' : ''}"
               >
                 {#if i === 0}
                   <span class="text-sm text-gray-500 dark:text-gray-400">Generating...</span>

--- a/src/lib/components/CatalogListItem.svelte
+++ b/src/lib/components/CatalogListItem.svelte
@@ -10,12 +10,11 @@
   const CATALOG_SCROLL_Y_KEY = 'mokuro:catalog:scroll-y';
 
   interface Props {
-    series_uuid: string;
     volumes: VolumeMetadata[]; // Pre-computed by parent - avoids O(N) re-filtering
     providerName?: string; // Shared across all items - avoids repeated lookups
   }
 
-  let { series_uuid, volumes, providerName = 'Cloud' }: Props = $props();
+  let { volumes, providerName = 'Cloud' }: Props = $props();
 
   // Volumes are pre-sorted by catalog store (natural sort)
   let sortedVolumes = $derived(volumes);
@@ -82,9 +81,8 @@
     }
   });
 
-  // Use title for placeholder-only (handles transition when first volume downloads)
-  // Use UUID for local series (handles edge case of same-name series)
-  let navId = $derived(isPlaceholderOnly ? volume?.series_title || '' : series_uuid);
+  // Use series title for navigation so grouping and routing align with user-visible identity.
+  let navId = $derived(volume?.series_title || '');
 
   function persistCatalogScrollPosition() {
     const y =

--- a/src/lib/components/PlaceholderThumbnail.svelte
+++ b/src/lib/components/PlaceholderThumbnail.svelte
@@ -15,6 +15,8 @@
     message?: string;
     /** Volume metadata for cloud thumbnail fetching */
     volume?: VolumeMetadata;
+    /** Whether to show drop shadow on stacked items */
+    dropShadow?: boolean;
   }
 
   let {
@@ -22,7 +24,8 @@
     isDownloading = false,
     showDownloadUI = false,
     message,
-    volume
+    volume,
+    dropShadow = true
   }: Props = $props();
 
   // Limit stack to 3 items max
@@ -94,10 +97,13 @@
   >
     {#each Array(stackCount) as _, i}
       <div
-        class="flex items-center justify-center border border-gray-300 bg-gray-200 sm:h-[350px] sm:w-[250px] dark:border-gray-600 dark:bg-gray-800"
+        class="flex items-center justify-center bg-gray-200 sm:h-[350px] sm:w-[250px] dark:bg-gray-800"
+        class:border={dropShadow}
+        class:border-gray-300={dropShadow}
+        class:dark:border-gray-600={dropShadow}
         class:absolute={stackCount > 1}
         style={stackCount > 1
-          ? `left: ${i * stepH}px; top: ${i * stepV}px; z-index: ${stackCount - i}; filter: drop-shadow(2px 4px 6px rgba(0, 0, 0, 0.5));`
+          ? `left: ${i * stepH}px; top: ${i * stepV}px; z-index: ${stackCount - i};${dropShadow ? ' filter: drop-shadow(2px 4px 6px rgba(0, 0, 0, 0.5));' : ''}`
           : ''}
       >
         {#if i === 0}

--- a/src/lib/components/Reader/AnkiFieldModal.svelte
+++ b/src/lib/components/Reader/AnkiFieldModal.svelte
@@ -21,6 +21,7 @@
   import { ChevronRightOutline } from 'flowbite-svelte-icons';
   import { slide } from 'svelte/transition';
   import AnkiTemplateField from '$lib/components/Reader/AnkiTemplateField.svelte';
+  import { isMobilePlatform } from '$lib/util/platform';
   import { onMount, onDestroy } from 'svelte';
   import CropperJS from 'cropperjs';
   import 'cropperjs/dist/cropper.css';
@@ -1008,6 +1009,8 @@
                 configureMode={mode === 'configure'}
                 isModified={isTagsModified()}
                 willUpdate={tagsWillUpdate()}
+                disabled={mode === 'update' && isMobilePlatform()}
+                disabledReason="Not supported by AnkiConnect Android"
                 hint="Spaces separate tags"
                 spaceBeforeInsert={true}
               />

--- a/src/lib/components/Reader/AnkiFieldModal.svelte
+++ b/src/lib/components/Reader/AnkiFieldModal.svelte
@@ -93,7 +93,7 @@
       vars.push({ template: '{volume}', value: metadata.volumeTitle });
     }
     if (store.pageNumber !== undefined) {
-      vars.push({ template: '{page_num}', value: String(store.pageNumber + 1) });
+      vars.push({ template: '{page_num}', value: String(store.pageNumber) });
     }
     if (store.pageFilename) {
       vars.push({ template: '{page_filename}', value: store.pageFilename });

--- a/src/lib/components/Reader/AnkiTemplateField.svelte
+++ b/src/lib/components/Reader/AnkiTemplateField.svelte
@@ -22,6 +22,8 @@
     isModified?: boolean;
     willUpdate?: boolean; // True if this field will change the card (not just {existing})
     configureMode?: boolean;
+    disabled?: boolean; // Disable editing (field is shown but not interactive)
+    disabledReason?: string; // Explanation shown when disabled
     hint?: string; // Helper text shown in expanded view
     spaceBeforeInsert?: boolean; // Add space before inserted templates (for tags)
     onTemplateChange?: (template: string) => void;
@@ -40,6 +42,8 @@
     isModified = false,
     willUpdate = false,
     configureMode = false,
+    disabled = false,
+    disabledReason,
     hint,
     spaceBeforeInsert = false,
     onTemplateChange,
@@ -174,8 +178,9 @@
   <!-- Header - always visible, clickable to expand -->
   <button
     type="button"
-    class="flex w-full items-start gap-2 px-2 py-1.5 text-left hover:bg-gray-50 dark:hover:bg-gray-800"
+    class="flex w-full items-start gap-2 px-2 py-1.5 text-left {disabled ? 'opacity-50' : 'hover:bg-gray-50 dark:hover:bg-gray-800'}"
     onclick={toggleExpand}
+    {disabled}
   >
     <span class="mt-0.5 text-gray-400 transition-transform duration-200" class:rotate-90={expanded}>
       <ChevronRightOutline class="h-3 w-3" />
@@ -185,7 +190,9 @@
     >
     <!-- Preview - truncated to keep rows compact -->
     <span class="flex-1 truncate text-sm text-gray-900 dark:text-white">
-      {#if configureMode}
+      {#if disabled}
+        <span class="text-xs italic text-gray-400 dark:text-gray-500">{disabledReason || 'Disabled'}</span>
+      {:else if configureMode}
         <code class="rounded bg-gray-100 px-1 dark:bg-gray-700">{template || '(not set)'}</code>
       {:else}
         {displayResolvedValue || '(empty)'}

--- a/src/lib/components/Reader/MangaPage.svelte
+++ b/src/lib/components/Reader/MangaPage.svelte
@@ -15,13 +15,15 @@
     src: File;
     cachedUrl?: string | null;
     volumeUuid: string;
+    /** 0-based page index within the volume */
+    pageIndex?: number;
     /** Force text visibility (for placeholder/missing pages) */
     forceVisible?: boolean;
     /** Callback when context menu should be shown */
     onContextMenu?: (data: ContextMenuData) => void;
   }
 
-  let { page, src, cachedUrl, volumeUuid, forceVisible = false, onContextMenu }: Props = $props();
+  let { page, src, cachedUrl, volumeUuid, pageIndex, forceVisible = false, onContextMenu }: Props = $props();
 
   let url = $state('');
 
@@ -60,5 +62,5 @@
   style:background-position="center"
   class="relative"
 >
-  <TextBoxes {page} {src} {volumeUuid} {forceVisible} {onContextMenu} />
+  <TextBoxes {page} {src} {volumeUuid} {pageIndex} {forceVisible} {onContextMenu} />
 </div>

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -1203,6 +1203,7 @@
                   src={imageCache.getFile(index + 1)!}
                   cachedUrl={cachedImageUrl2}
                   volumeUuid={volume.volume_uuid}
+                  pageIndex={index + 1}
                   forceVisible={missingPagePaths.has(pages[index + 1]?.img_path)}
                   onContextMenu={handleTextBoxContextMenu}
                 />
@@ -1212,6 +1213,7 @@
                 src={imageCache.getFile(index)!}
                 cachedUrl={cachedImageUrl1}
                 volumeUuid={volume.volume_uuid}
+                pageIndex={index}
                 forceVisible={missingPagePaths.has(pages[index]?.img_path)}
                 onContextMenu={handleTextBoxContextMenu}
               />

--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -27,13 +27,15 @@
     page: Page;
     src?: File;
     volumeUuid: string;
+    /** 0-based page index within the volume */
+    pageIndex?: number;
     /** Force text visibility (for placeholder/missing pages) */
     forceVisible?: boolean;
     /** Callback when context menu should be shown */
     onContextMenu?: (data: ContextMenuData) => void;
   }
 
-  let { page, src, volumeUuid, forceVisible = false, onContextMenu }: Props = $props();
+  let { page, src, volumeUuid, pageIndex, forceVisible = false, onContextMenu }: Props = $props();
 
   interface TextBoxData {
     left: string;
@@ -337,7 +339,8 @@
     if (!url) return;
 
     // Get current page number for {page} template
-    const pageNumber = $volumes[volumeUuid]?.progress || 1;
+    // Use the explicit pageIndex prop (0-based) when available, otherwise fall back to progress
+    const pageNumber = pageIndex != null ? pageIndex + 1 : ($volumes[volumeUuid]?.progress || 1);
 
     if (cardMode === 'update') {
       // Update mode: fetch previous card values with retry

--- a/src/lib/components/Settings/CatalogSettings.svelte
+++ b/src/lib/components/Settings/CatalogSettings.svelte
@@ -29,6 +29,7 @@
       centerHorizontal: boolean;
       centerVertical: boolean;
       compactCloudSeries: boolean;
+      dropShadow: boolean;
     }
   > = {
     compact: {
@@ -38,7 +39,8 @@
       hideReadVolumes: true,
       centerHorizontal: true,
       centerVertical: true,
-      compactCloudSeries: false
+      compactCloudSeries: false,
+      dropShadow: true
     },
     default: {
       stackCount: 3,
@@ -47,7 +49,8 @@
       hideReadVolumes: true,
       centerHorizontal: true,
       centerVertical: false,
-      compactCloudSeries: false
+      compactCloudSeries: false,
+      dropShadow: true
     },
     spine: {
       stackCount: 0, // 0 = all volumes in series
@@ -56,7 +59,8 @@
       hideReadVolumes: false,
       centerHorizontal: true,
       centerVertical: true,
-      compactCloudSeries: true
+      compactCloudSeries: true,
+      dropShadow: false
     }
   };
 
@@ -71,6 +75,7 @@
       updateCatalogSetting('centerHorizontal', config.centerHorizontal);
       updateCatalogSetting('centerVertical', config.centerVertical);
       updateCatalogSetting('compactCloudSeries', config.compactCloudSeries);
+      updateCatalogSetting('dropShadow', config.dropShadow);
     }
   }
 
@@ -220,6 +225,19 @@
             <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
               Show cloud-only series as single thumbnails
             </p>
+          </div>
+
+          <!-- Drop shadow -->
+          <div class="mt-4">
+            <Toggle
+              checked={$catalogSettings?.dropShadow ?? true}
+              onchange={(e) => {
+                updateCatalogSetting('dropShadow', e.currentTarget.checked);
+                handleSettingChange();
+              }}
+            >
+              Drop shadow
+            </Toggle>
           </div>
         {/if}
       </div>

--- a/src/lib/components/SwUpdateBanner.svelte
+++ b/src/lib/components/SwUpdateBanner.svelte
@@ -30,7 +30,7 @@
         <p class="text-sm font-medium">Update available</p>
         <p class="text-xs opacity-80">
           {#if $latestRelease}
-            v{READER_VERSION} → v{$latestRelease.version}
+            v{$latestRelease.version} ready to install
           {:else}
             A new version is ready to install
           {/if}

--- a/src/lib/components/VolumeEditorCoverPicker.svelte
+++ b/src/lib/components/VolumeEditorCoverPicker.svelte
@@ -154,13 +154,17 @@
       const useTargetAspect = imageAspect >= targetAspect;
 
       cropper = new Cropper(img, {
-        viewMode: 1, // Restrict crop box to image bounds
-        dragMode: 'move',
+        viewMode: 1, // Keep crop box constrained to the actual image
+        dragMode: 'crop',
         autoCropArea: 1, // Start with full coverage
         restore: false,
         guides: true,
         center: true,
         highlight: false,
+        movable: false,
+        zoomable: false,
+        zoomOnWheel: false,
+        zoomOnTouch: false,
         cropBoxMovable: true,
         cropBoxResizable: true,
         toggleDragModeOnDblclick: false,
@@ -243,16 +247,22 @@
     onCancel();
   }
 
-  function handleZoomIn() {
-    cropper?.zoom(0.1);
-  }
-
-  function handleZoomOut() {
-    cropper?.zoom(-0.1);
-  }
-
   function handleReset() {
     cropper?.reset();
+  }
+
+  function handleRotate90() {
+    if (!cropper) return;
+    cropper.rotate(90);
+
+    // Recenter rotated image canvas in the cropper viewport.
+    const container = cropper.getContainerData();
+    const canvas = cropper.getCanvasData();
+    cropper.setCanvasData({
+      ...canvas,
+      left: (container.width - canvas.width) / 2,
+      top: (container.height - canvas.height) / 2
+    });
   }
 
   function getCurrentCropZone() {
@@ -393,10 +403,8 @@
       </div>
 
       <div class="mb-4 flex items-center justify-center gap-2">
-        <Button size="xs" color="light" onclick={handleZoomOut}>−</Button>
-        <span class="text-sm text-gray-600 dark:text-gray-400">Zoom</span>
-        <Button size="xs" color="light" onclick={handleZoomIn}>+</Button>
-        <Button size="xs" color="light" onclick={handleReset} class="ml-4">Reset</Button>
+        <Button size="xs" color="light" onclick={handleReset}>Reset</Button>
+        <Button size="xs" color="light" onclick={handleRotate90}>Rotate 90°</Button>
         {#if lastCropZone}
           <Button size="xs" color="light" onclick={applyLastCropZone}>Copy Last Crop Zone</Button>
         {/if}

--- a/src/lib/components/VolumeEditorCoverPicker.svelte
+++ b/src/lib/components/VolumeEditorCoverPicker.svelte
@@ -55,6 +55,26 @@
   let appendedPageIndex = $state<number | null>(null);
   let appendCandidateIndex = $state<number | null>(null);
 
+  // Capture Escape so it doesn't propagate to the series page's back-navigation handler
+  $effect(() => {
+    if (!open) return;
+
+    function handleKeydown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        e.preventDefault();
+        if (showCropper) {
+          handleCropCancel();
+        } else {
+          handleClose();
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown, true);
+    return () => window.removeEventListener('keydown', handleKeydown, true);
+  });
+
   onMount(async () => {
     await loadPages();
   });

--- a/src/lib/components/VolumeEditorModal.svelte
+++ b/src/lib/components/VolumeEditorModal.svelte
@@ -81,12 +81,19 @@
   // Series options for dropdown
   let seriesOptions = $state<{ uuid: string; title: string }[]>([]);
 
+  let pendingOpenCoverPicker = false;
+
   onMount(() => {
     const unsubscribe = volumeEditorModalStore.subscribe(async (value) => {
       if (value?.open && value.volumeUuid) {
         open = true;
         volumeUuid = value.volumeUuid;
+        pendingOpenCoverPicker = value.openCoverPicker ?? false;
         await loadVolumeData();
+        if (pendingOpenCoverPicker) {
+          pendingOpenCoverPicker = false;
+          openCoverPicker();
+        }
       }
     });
     return unsubscribe;
@@ -130,7 +137,8 @@
 
       // Determine next-volume availability for "Use + Next Volume"
       hasNextSeriesVolume =
-        (await getNextVolumeUuidInSeries(data.metadata.series_uuid, data.metadata.volume_uuid)) !== null;
+        (await getNextVolumeUuidInSeries(data.metadata.series_uuid, data.metadata.volume_uuid)) !==
+        null;
 
       // Regenerate thumbnail URL
       if (thumbnailUrl) {
@@ -408,9 +416,7 @@
               {/if}
             </div>
             <div class="flex gap-1">
-              <Button size="xs" color="light" onclick={openCoverPicker}>
-                Change
-              </Button>
+              <Button size="xs" color="light" onclick={openCoverPicker}>Change</Button>
               <Button size="xs" color="light" onclick={handleResetCover} disabled={saving}>
                 Reset
               </Button>

--- a/src/lib/components/VolumeEditorModal.svelte
+++ b/src/lib/components/VolumeEditorModal.svelte
@@ -83,6 +83,22 @@
 
   let pendingOpenCoverPicker = false;
 
+  // Capture Escape so it doesn't propagate to the series page's back-navigation handler
+  $effect(() => {
+    if (!open) return;
+
+    function handleKeydown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        e.preventDefault();
+        handleClose();
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown, true);
+    return () => window.removeEventListener('keydown', handleKeydown, true);
+  });
+
   onMount(() => {
     const unsubscribe = volumeEditorModalStore.subscribe(async (value) => {
       if (value?.open && value.volumeUuid) {

--- a/src/lib/import/database.ts
+++ b/src/lib/import/database.ts
@@ -75,7 +75,8 @@ export async function saveVolume(volume: ProcessedVolume): Promise<void> {
     thumbnail_width: metadata.thumbnailWidth,
     thumbnail_height: metadata.thumbnailHeight,
     missing_pages: metadata.missingPages,
-    missing_page_paths: metadata.missingPagePaths
+    missing_page_paths: metadata.missingPagePaths,
+    spine_width: metadata.spineWidth
   };
 
   // Write to all 3 tables atomically

--- a/src/lib/import/processing.ts
+++ b/src/lib/import/processing.ts
@@ -42,6 +42,7 @@ export interface ParsedMokuro {
   volumeUuid: string;
   pages: MokuroPage[];
   chars: number;
+  spineWidth?: number;
 }
 
 /**
@@ -177,7 +178,8 @@ export async function parseMokuroFile(file: File): Promise<ParsedMokuro> {
     volume: obj.volume as string,
     volumeUuid: obj.volume_uuid as string,
     pages: obj.pages as MokuroPage[],
-    chars: (obj.chars as number) ?? 0
+    chars: (obj.chars as number) ?? 0,
+    ...(obj.spine_width != null && { spineWidth: obj.spine_width as number })
   };
 }
 
@@ -688,7 +690,8 @@ export async function processVolume(input: DecompressedVolume): Promise<Processe
     missingPages: matchResult.missing.length > 0 ? matchResult.missing.length : undefined,
     missingPagePaths: matchResult.missing.length > 0 ? matchResult.missing : undefined,
     imageOnly: isImageOnly,
-    sourceType
+    sourceType,
+    spineWidth: mokuroData?.spineWidth
   };
 
   return {

--- a/src/lib/import/types.ts
+++ b/src/lib/import/types.ts
@@ -184,6 +184,8 @@ export interface ProcessedMetadata {
   imageOnly?: boolean;
   /** Where this volume came from */
   sourceType?: 'local' | 'cloud';
+  /** Spine width in pixels (from mokuro metadata) */
+  spineWidth?: number;
 }
 
 /**

--- a/src/lib/reader/page-mode-detection.test.ts
+++ b/src/lib/reader/page-mode-detection.test.ts
@@ -157,10 +157,16 @@ describe('shouldShowSinglePage', () => {
       expect(shouldShowSinglePage('single', current, next, undefined)).toBe(true);
     });
 
-    it('should always return false for dual mode', () => {
+    it('should return false for dual mode on normal pages', () => {
       const current = createPage(1000, 1500);
       const next = createPage(1000, 1500);
       expect(shouldShowSinglePage('dual', current, next, undefined)).toBe(false);
+    });
+
+    it('should return true for dual mode on cover page', () => {
+      const current = createPage(1000, 1500);
+      const next = createPage(1000, 1500);
+      expect(shouldShowSinglePage('dual', current, next, undefined, true, true)).toBe(true);
     });
   });
 

--- a/src/lib/reader/page-mode-detection.ts
+++ b/src/lib/reader/page-mode-detection.ts
@@ -51,15 +51,16 @@ export function shouldShowSinglePage(
 ): boolean {
   // Explicit mode overrides
   if (mode === 'single') return true;
+
+  // Cover page is always displayed alone regardless of mode
+  if (isFirstPage && hasCover) {
+    return true;
+  }
+
   if (mode === 'dual') return false;
 
   // Auto mode logic
   if (mode === 'auto') {
-    // Special case: First page with cover should always be single
-    // This ensures covers don't get paired with spreads or other exceptions
-    if (isFirstPage && hasCover) {
-      return true;
-    }
 
     // Portrait orientation → single page
     if (isPortraitOrientation()) {

--- a/src/lib/settings/extraction.ts
+++ b/src/lib/settings/extraction.ts
@@ -16,7 +16,7 @@ const defaultSettings: ExtractionSettings = {
   individualVolumes: true,
   includeSeriesTitle: true,
   includeSidecars: true,
-  embedSidecarsInArchive: true
+  embedSidecarsInArchive: false
 };
 
 const stored = browser ? window.localStorage.getItem('extractionSettings') : undefined;

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -111,6 +111,7 @@ export type CatalogSettings = {
   centerHorizontal: boolean;
   centerVertical: boolean;
   compactCloudSeries: boolean;
+  dropShadow: boolean;
 };
 
 export type Settings = {
@@ -285,7 +286,8 @@ const defaultSettings: Settings = {
     hideReadVolumes: true,
     centerHorizontal: true,
     centerVertical: false,
-    compactCloudSeries: false
+    compactCloudSeries: false,
+    dropShadow: true
   }
 };
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -54,6 +54,9 @@ export interface VolumeMetadata {
   // Library fields (for read-only WebDAV library sources)
   libraryId?: string;
   libraryName?: string;
+
+  // Spine width in pixels (from mokuro metadata, used for catalog stacking)
+  spine_width?: number;
 }
 
 // v3 table: volume_ocr

--- a/src/lib/util/backup-queue.ts
+++ b/src/lib/util/backup-queue.ts
@@ -72,7 +72,7 @@ queueStore.subscribe((queue) => {
 export function queueVolumeForBackup(
   volume: VolumeMetadata,
   providerInstance?: SyncProvider,
-  sidecarOptions: SidecarOptions = { includeSidecars: true, embedSidecarsInArchive: true }
+  sidecarOptions: SidecarOptions = { includeSidecars: true, embedSidecarsInArchive: false }
 ): void {
   // Get default provider if not specified
   const targetProvider = providerInstance || unifiedCloudManager.getDefaultProvider();
@@ -154,7 +154,7 @@ export function queueVolumeForExport(
 export function queueSeriesVolumesForBackup(
   volumes: VolumeMetadata[],
   providerInstance?: SyncProvider,
-  sidecarOptions: SidecarOptions = { includeSidecars: true, embedSidecarsInArchive: true }
+  sidecarOptions: SidecarOptions = { includeSidecars: true, embedSidecarsInArchive: false }
 ): void {
   // Get default provider if not specified
   const targetProvider = providerInstance || unifiedCloudManager.getDefaultProvider();
@@ -358,7 +358,9 @@ async function processBackup(item: BackupQueueItem, processId: string): Promise<
           volumeTitle: item.volumeTitle,
           seriesTitle: item.seriesTitle,
           credentials,
-          embedThumbnailSidecar: item.sidecarOptions.embedSidecarsInArchive
+          embedThumbnailSidecar: item.sidecarOptions.embedSidecarsInArchive,
+          // Cloud uploads store OCR metadata as a separate sidecar file.
+          embedMokuroInArchive: false
         };
       },
       onProgress: (data) => {

--- a/src/lib/util/compress-volume.ts
+++ b/src/lib/util/compress-volume.ts
@@ -12,6 +12,7 @@ export interface MokuroMetadata {
   volume_uuid: string;
   pages: any[];
   chars: number;
+  spine_width?: number;
 }
 
 export interface VolumeSidecarBlobData {
@@ -240,7 +241,8 @@ export async function compressVolumeFromDb(
         volume: volume.volume_title,
         volume_uuid: volume.volume_uuid,
         pages: volumeOcr?.pages || [],
-        chars: volume.character_count
+        chars: volume.character_count,
+        ...(volume.spine_width != null && { spine_width: volume.spine_width })
       };
 
   // Get list of files, excluding placeholders

--- a/src/lib/util/download-queue.ts
+++ b/src/lib/util/download-queue.ts
@@ -381,6 +381,17 @@ async function processVolumeData(
   // This handles missing pages, image-only volumes, placeholder generation, etc.
   const processedVolume = await processVolume(decompressedVolume);
 
+  // Keep cloud placeholder series identity for image-only imports so they stay grouped
+  // with existing volumes before OCR sidecars are applied.
+  const isImageOnly =
+    !processedVolume.metadata.mokuroVersion || processedVolume.metadata.mokuroVersion.trim() === '';
+  if (isImageOnly) {
+    processedVolume.metadata.series = placeholder.series_title;
+    processedVolume.metadata.seriesUuid = placeholder.series_uuid;
+    processedVolume.metadata.volume = placeholder.volume_title;
+    processedVolume.metadata.volumeUuid = placeholder.volume_uuid;
+  }
+
   // Check if volume already exists
   const existingVolume = await db.volumes
     .where('volume_uuid')
@@ -456,6 +467,11 @@ function basename(path: string): string {
   return path.split('/').pop() || path;
 }
 
+function dirname(path: string): string {
+  const idx = path.lastIndexOf('/');
+  return idx >= 0 ? path.slice(0, idx) : '';
+}
+
 function findSidecarFiles(
   placeholder: VolumeMetadata,
   allFiles: import('./sync/provider-interface').CloudFileMetadata[]
@@ -476,11 +492,18 @@ function findSidecarFiles(
 
   // Fallback: robust basename/stem matching to handle encoded paths and naming variance.
   const targetStem = normalizePathKey(placeholder.volume_title);
+  const cloudPath =
+    (placeholder as VolumeMetadata & { cloudPath?: string }).cloudPath ||
+    `${placeholder.series_title}/${placeholder.volume_title}.cbz`;
+  const cloudDir = normalizePathKey(dirname(cloudPath));
   const seriesPrefix = `${normalizePathKey(placeholder.series_title)}/`;
 
   const fallbackMatches = allFiles.filter((file) => {
     const filePathKey = normalizePathKey(file.path);
-    if (!filePathKey.startsWith(seriesPrefix)) return false;
+    // Prefer the original cloud directory when available, then fall back to series title.
+    if (cloudDir && !filePathKey.startsWith(`${cloudDir}/`) && !filePathKey.startsWith(seriesPrefix)) {
+      return false;
+    }
 
     const name = normalizePathKey(basename(file.path));
     return (
@@ -495,29 +518,18 @@ function findSidecarFiles(
       '[Download Queue] Sidecar fallback matches:',
       fallbackMatches.map((file) => file.path)
     );
-  } else {
-    console.log('[Download Queue] No sidecar matches found for:', placeholder.series_title, placeholder.volume_title);
+    return fallbackMatches;
   }
 
-  return fallbackMatches;
+  console.log('[Download Queue] No sidecar matches found for:', placeholder.series_title, placeholder.volume_title);
+  return [];
 }
 
 async function downloadSidecarEntries(placeholder: VolumeMetadata): Promise<DecompressedEntry[]> {
   const provider = unifiedCloudManager.getActiveProvider();
   if (!provider) return [];
 
-  // Use a live provider listing here (not just cache) so we pick up freshly uploaded sidecars
-  // and avoid stale-cache misses for custom thumbnails.
-  let allFiles = unifiedCloudManager.getAllCloudVolumes();
-  try {
-    const liveFiles = await provider.listCloudVolumes();
-    if (liveFiles.length > 0) {
-      allFiles = liveFiles;
-    }
-  } catch (error) {
-    console.warn('Failed live sidecar listing, falling back to cache:', error);
-  }
-
+  const allFiles = unifiedCloudManager.getAllCloudVolumes();
   const selected = findSidecarFiles(placeholder, allFiles);
   if (selected.length > 0) {
     console.log(

--- a/src/lib/util/libraries/index.ts
+++ b/src/lib/util/libraries/index.ts
@@ -24,6 +24,7 @@ export {
 	clearClientCache,
 	clearAllClients,
 	libraryFilesStore,
+	libraryMokuroFilesStore,
 	libraryStatusStore,
 	isAnyLibraryFetching,
 	totalLibraryFileCount,

--- a/src/lib/util/libraries/library-ocr-upgrade-queue.ts
+++ b/src/lib/util/libraries/library-ocr-upgrade-queue.ts
@@ -1,0 +1,277 @@
+import { db } from '$lib/catalog/db';
+import { parseMokuroFile } from '$lib/import/processing';
+import type { VolumeMetadata } from '$lib/types';
+import type { LibraryFileMetadata } from './library-webdav-client';
+import { getLibraryById } from '$lib/settings/libraries';
+import { getLibraryClient } from './library-cache-manager';
+import { unifiedCloudManager, type CloudVolumeWithProvider } from '$lib/util/sync/unified-cloud-manager';
+import type { ProviderType } from '$lib/util/sync/provider-interface';
+
+type LibraryUpgradeTask = {
+  kind: 'library';
+  volumeUuid: string;
+  libraryId: string;
+  sidecar: LibraryFileMetadata;
+};
+
+type CloudUpgradeTask = {
+  kind: 'cloud';
+  volumeUuid: string;
+  provider: ProviderType;
+  sidecar: CloudVolumeWithProvider;
+};
+
+type UpgradeTask = LibraryUpgradeTask | CloudUpgradeTask;
+
+const pendingTaskIds = new Set<string>();
+const queuedTasks: UpgradeTask[] = [];
+let processing = false;
+
+function countCharsInLines(lines: unknown): number {
+  if (!Array.isArray(lines)) return 0;
+  const japaneseRegex =
+    /[○◯々-〇〻ぁ-ゖゝ-ゞァ-ヺー\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}]/u;
+  let total = 0;
+  for (const line of lines) {
+    if (typeof line !== 'string') continue;
+    total += Array.from(line).filter((char) => japaneseRegex.test(char)).length;
+  }
+  return total;
+}
+
+function buildPageCharCounts(pages: unknown[]): { totalChars: number; cumulative: number[] } {
+  let totalChars = 0;
+  const cumulative: number[] = [];
+
+  for (const page of pages) {
+    let pageChars = 0;
+    const blocks = (page as { blocks?: unknown[] })?.blocks;
+    if (Array.isArray(blocks)) {
+      for (const block of blocks) {
+        pageChars += countCharsInLines((block as { lines?: unknown[] })?.lines);
+      }
+    }
+    totalChars += pageChars;
+    cumulative.push(totalChars);
+  }
+
+  return { totalChars, cumulative };
+}
+
+async function decodeMokuroSidecar(sidecarPath: string, blob: Blob): Promise<File | null> {
+  if (sidecarPath.toLowerCase().endsWith('.mokuro')) {
+    console.log('[Library OCR Upgrade] Decoding plain mokuro sidecar:', sidecarPath, blob.size);
+    return new File([blob], sidecarPath.split('/').pop() || sidecarPath, {
+      type: 'application/json'
+    });
+  }
+
+  if (!sidecarPath.toLowerCase().endsWith('.mokuro.gz')) {
+    return null;
+  }
+
+  if (typeof DecompressionStream === 'undefined') {
+    console.warn('[Library OCR Upgrade] DecompressionStream not available for .mokuro.gz');
+    return null;
+  }
+
+  console.log('[Library OCR Upgrade] Decoding gz mokuro sidecar:', sidecarPath, blob.size);
+  const stream = blob.stream().pipeThrough(new DecompressionStream('gzip'));
+  const decompressedBlob = await new Response(stream).blob();
+  const filename = (sidecarPath.split('/').pop() || sidecarPath).replace(/\.gz$/i, '');
+  return new File([decompressedBlob], filename, { type: 'application/json' });
+}
+
+async function applyUpgrade(task: UpgradeTask): Promise<void> {
+  const taskScope = task.kind === 'library' ? `library:${task.libraryId}` : `cloud:${task.provider}`;
+  console.log(
+    '[Library OCR Upgrade] Starting task:',
+    task.volumeUuid,
+    'sidecar=',
+    task.sidecar.path,
+    'scope=',
+    taskScope
+  );
+  let sidecarBlob: Blob;
+  let sidecarPath: string;
+  if (task.kind === 'library') {
+    const library = getLibraryById(task.libraryId);
+    if (!library) {
+      console.warn('[Library OCR Upgrade] Library config not found:', task.libraryId);
+      return;
+    }
+    const client = getLibraryClient(library);
+    sidecarBlob = await client.downloadFile(task.sidecar.fileId);
+    sidecarPath = task.sidecar.path;
+  } else {
+    const activeProvider = unifiedCloudManager.getActiveProvider();
+    if (!activeProvider || activeProvider.type !== task.provider) {
+      console.warn(
+        '[Library OCR Upgrade] Active provider unavailable for cloud sidecar upgrade:',
+        task.provider,
+        'active=',
+        activeProvider?.type
+      );
+      return;
+    }
+    sidecarBlob = await activeProvider.downloadFile(task.sidecar);
+    sidecarPath = task.sidecar.path;
+  }
+
+  console.log('[Library OCR Upgrade] Downloaded sidecar bytes:', sidecarBlob.size, sidecarPath);
+  const mokuroFile = await decodeMokuroSidecar(sidecarPath, sidecarBlob);
+  if (!mokuroFile) {
+    console.warn('[Library OCR Upgrade] Failed to decode sidecar:', sidecarPath);
+    return;
+  }
+
+  const parsed = await parseMokuroFile(mokuroFile);
+  console.log(
+    '[Library OCR Upgrade] Parsed mokuro:',
+    parsed.series,
+    parsed.volume,
+    'pages=',
+    Array.isArray(parsed.pages) ? parsed.pages.length : 0
+  );
+  const existingVolume = await db.volumes.get(task.volumeUuid);
+  const existingMokuroVersion =
+    typeof existingVolume?.mokuro_version === 'string' ? existingVolume.mokuro_version.trim() : '';
+  if (!existingVolume || existingMokuroVersion !== '') {
+    console.log(
+      '[Library OCR Upgrade] Skipping task, volume missing or already OCR:',
+      task.volumeUuid,
+      'existingVersion=',
+      existingMokuroVersion
+    );
+    return;
+  }
+
+  const pages = Array.isArray(parsed.pages) ? parsed.pages : [];
+  const { totalChars, cumulative } = buildPageCharCounts(pages);
+
+  await db.transaction('rw', [db.volumes, db.volume_ocr], async () => {
+    await db.volume_ocr.put({
+      volume_uuid: existingVolume.volume_uuid,
+      pages: pages as any
+    });
+
+    await db.volumes.update(existingVolume.volume_uuid, {
+      mokuro_version: parsed.version || '0.0.0',
+      series_uuid: parsed.seriesUuid || existingVolume.series_uuid,
+      page_count: pages.length,
+      character_count: totalChars,
+      page_char_counts: cumulative
+    });
+  });
+
+  console.log(
+    '[Library OCR Upgrade] Upgraded image-only volume:',
+    existingVolume.series_title,
+    existingVolume.volume_title
+  );
+}
+
+async function processQueue(): Promise<void> {
+  if (processing) return;
+  processing = true;
+  console.log('[Library OCR Upgrade] Processing queue. pending=', queuedTasks.length);
+
+  try {
+    while (queuedTasks.length > 0) {
+      const task = queuedTasks.shift()!;
+      const sidecarId = task.kind === 'library' ? task.sidecar.fileId : task.sidecar.fileId;
+      const taskId = `${task.volumeUuid}:${sidecarId}`;
+      try {
+        await applyUpgrade(task);
+      } catch (error) {
+        console.warn('[Library OCR Upgrade] Failed to auto-upgrade volume:', error);
+      } finally {
+        pendingTaskIds.delete(taskId);
+        console.log('[Library OCR Upgrade] Task complete:', taskId, 'remaining=', queuedTasks.length);
+      }
+    }
+  } finally {
+    processing = false;
+    console.log('[Library OCR Upgrade] Queue idle');
+  }
+}
+
+export function enqueueLibraryOcrUpgrade(volume: VolumeMetadata, sidecar: LibraryFileMetadata): void {
+  if (volume.isPlaceholder) {
+    console.log('[Library OCR Upgrade] Skip enqueue for placeholder volume:', volume.volume_uuid);
+    return;
+  }
+  const currentMokuroVersion =
+    typeof volume.mokuro_version === 'string' ? volume.mokuro_version.trim() : '';
+  if (currentMokuroVersion !== '') {
+    console.log(
+      '[Library OCR Upgrade] Skip enqueue, volume already has OCR:',
+      volume.volume_uuid,
+      currentMokuroVersion
+    );
+    return;
+  }
+
+  const taskId = `${volume.volume_uuid}:${sidecar.fileId}`;
+  if (pendingTaskIds.has(taskId)) {
+    console.log('[Library OCR Upgrade] Skip enqueue duplicate task:', taskId);
+    return;
+  }
+  pendingTaskIds.add(taskId);
+
+  queuedTasks.push({
+    kind: 'library',
+    volumeUuid: volume.volume_uuid,
+    libraryId: sidecar.libraryId,
+    sidecar
+  });
+  console.log(
+    '[Library OCR Upgrade] Enqueued task:',
+    taskId,
+    `${volume.series_title}/${volume.volume_title}`,
+    'queueLength=',
+    queuedTasks.length
+  );
+
+  void processQueue();
+}
+
+export function enqueueCloudOcrUpgrade(volume: VolumeMetadata, sidecar: CloudVolumeWithProvider): void {
+  if (volume.isPlaceholder) {
+    console.log('[Library OCR Upgrade] Skip cloud enqueue for placeholder volume:', volume.volume_uuid);
+    return;
+  }
+  const currentMokuroVersion =
+    typeof volume.mokuro_version === 'string' ? volume.mokuro_version.trim() : '';
+  if (currentMokuroVersion !== '') {
+    console.log(
+      '[Library OCR Upgrade] Skip cloud enqueue, volume already has OCR:',
+      volume.volume_uuid,
+      currentMokuroVersion
+    );
+    return;
+  }
+
+  const taskId = `${volume.volume_uuid}:${sidecar.fileId}`;
+  if (pendingTaskIds.has(taskId)) {
+    console.log('[Library OCR Upgrade] Skip cloud enqueue duplicate task:', taskId);
+    return;
+  }
+  pendingTaskIds.add(taskId);
+
+  queuedTasks.push({
+    kind: 'cloud',
+    volumeUuid: volume.volume_uuid,
+    provider: sidecar.provider,
+    sidecar
+  });
+  console.log(
+    '[Library OCR Upgrade] Enqueued cloud task:',
+    taskId,
+    `${volume.series_title}/${volume.volume_title}`,
+    'queueLength=',
+    queuedTasks.length
+  );
+
+  void processQueue();
+}

--- a/src/lib/util/modals.ts
+++ b/src/lib/util/modals.ts
@@ -197,18 +197,23 @@ export function promptMissingFiles(
 type VolumeEditorModal = {
   open: boolean;
   volumeUuid: string;
+  openCoverPicker?: boolean;
   onSave?: () => void;
   onCancel?: () => void;
 };
 
 export const volumeEditorModalStore = writable<VolumeEditorModal | undefined>(undefined);
 
-export function promptVolumeEditor(volumeUuid: string, onSave?: () => void, onCancel?: () => void) {
+export function promptVolumeEditor(
+  volumeUuid: string,
+  options?: { openCoverPicker?: boolean; onSave?: () => void; onCancel?: () => void }
+) {
   volumeEditorModalStore.set({
     open: true,
     volumeUuid,
-    onSave,
-    onCancel
+    openCoverPicker: options?.openCoverPicker,
+    onSave: options?.onSave,
+    onCancel: options?.onCancel
   });
 }
 

--- a/src/lib/util/sync/core/cloud-provider-core-registry.ts
+++ b/src/lib/util/sync/core/cloud-provider-core-registry.ts
@@ -1,0 +1,14 @@
+import type { CloudCoreProviderType, CloudProviderCore } from './cloud-provider-core-types';
+import { googleDriveCore } from './providers/google-drive-core';
+import { webdavCore } from './providers/webdav-core';
+import { megaCore } from './providers/mega-core';
+
+const coreRegistry: Record<CloudCoreProviderType, CloudProviderCore> = {
+  'google-drive': googleDriveCore,
+  webdav: webdavCore,
+  mega: megaCore
+};
+
+export function getCloudProviderCore(provider: CloudCoreProviderType): CloudProviderCore {
+  return coreRegistry[provider];
+}

--- a/src/lib/util/sync/core/cloud-provider-core-types.ts
+++ b/src/lib/util/sync/core/cloud-provider-core-types.ts
@@ -1,0 +1,43 @@
+import type { ProviderType } from '$lib/util/sync/provider-interface';
+
+export type CloudCoreProviderType = ProviderType;
+
+export type CloudCoreCredentials = Record<string, unknown>;
+
+export interface CloudCoreDownloadArgs {
+  fileId: string;
+  credentials: CloudCoreCredentials;
+  onProgress: (loaded: number, total: number) => void;
+}
+
+export interface CloudCoreUploadArgs {
+  seriesTitle: string;
+  filename: string;
+  blob: Blob;
+  credentials: CloudCoreCredentials;
+  mimeType?: string;
+  existingFileId?: string;
+  onProgress?: (loaded: number, total: number) => void;
+}
+
+export interface CloudProviderCore {
+  downloadFile(args: CloudCoreDownloadArgs): Promise<ArrayBuffer>;
+  uploadFile(args: CloudCoreUploadArgs): Promise<string>;
+}
+
+export function requireCredentialString(
+  credentials: CloudCoreCredentials,
+  key: string,
+  label: string
+): string {
+  const value = credentials[key];
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Missing ${label}`);
+  }
+  return value;
+}
+
+export function optionalCredentialString(credentials: CloudCoreCredentials, key: string): string {
+  const value = credentials[key];
+  return typeof value === 'string' ? value : '';
+}

--- a/src/lib/util/sync/core/providers/google-drive-core.ts
+++ b/src/lib/util/sync/core/providers/google-drive-core.ts
@@ -1,0 +1,127 @@
+import type { CloudProviderCore } from '../cloud-provider-core-types';
+import { requireCredentialString } from '../cloud-provider-core-types';
+
+export const googleDriveCore: CloudProviderCore = {
+  async downloadFile({ fileId, credentials, onProgress }): Promise<ArrayBuffer> {
+    const accessToken = requireCredentialString(
+      credentials,
+      'accessToken',
+      'Google Drive access token'
+    );
+
+    const sizeResponse = await fetch(
+      `https://www.googleapis.com/drive/v3/files/${fileId}?fields=size`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      }
+    );
+
+    if (!sizeResponse.ok) {
+      throw new Error(`Failed to get file size: ${sizeResponse.statusText}`);
+    }
+
+    const sizeData = await sizeResponse.json();
+    const totalSize = parseInt(sizeData.size, 10);
+
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`);
+    xhr.setRequestHeader('Authorization', `Bearer ${accessToken}`);
+    xhr.responseType = 'arraybuffer';
+
+    return await new Promise((resolve, reject) => {
+      xhr.onprogress = (event) => {
+        onProgress(event.loaded, totalSize);
+      };
+
+      xhr.onerror = () => reject(new Error('Network error during download'));
+      xhr.ontimeout = () => reject(new Error('Download timed out'));
+      xhr.onabort = () => reject(new Error('Download aborted'));
+
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve(xhr.response as ArrayBuffer);
+        } else {
+          reject(new Error(`HTTP error ${xhr.status}: ${xhr.statusText}`));
+        }
+      };
+
+      xhr.send();
+    });
+  },
+
+  async uploadFile({
+    filename,
+    blob,
+    credentials,
+    mimeType,
+    existingFileId,
+    onProgress
+  }): Promise<string> {
+    const accessToken = requireCredentialString(
+      credentials,
+      'accessToken',
+      'Google Drive access token'
+    );
+    const seriesFolderId = requireCredentialString(
+      credentials,
+      'seriesFolderId',
+      'Google Drive series folder ID'
+    );
+    const uploadMimeType = mimeType || 'application/octet-stream';
+
+    const metadata = {
+      name: filename,
+      mimeType: uploadMimeType,
+      ...(existingFileId ? {} : { parents: [seriesFolderId] })
+    };
+
+    const uploadBase = existingFileId
+      ? `https://www.googleapis.com/upload/drive/v3/files/${existingFileId}?uploadType=resumable`
+      : 'https://www.googleapis.com/upload/drive/v3/files?uploadType=resumable';
+
+    const initResponse = await fetch(uploadBase, {
+      method: existingFileId ? 'PATCH' : 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(metadata)
+    });
+
+    if (!initResponse.ok) {
+      throw new Error(`Upload init failed: ${initResponse.status} ${initResponse.statusText}`);
+    }
+
+    const uploadUrl = initResponse.headers.get('Location');
+    if (!uploadUrl) {
+      throw new Error('No upload URL returned');
+    }
+
+    return await new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open('PUT', uploadUrl);
+      xhr.setRequestHeader('Content-Type', uploadMimeType);
+
+      xhr.upload.onprogress = (event) => {
+        if (event.lengthComputable && onProgress) {
+          onProgress(event.loaded, event.total);
+        }
+      };
+
+      xhr.onload = async () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          const result = JSON.parse(xhr.responseText);
+          resolve(result.id);
+        } else {
+          reject(new Error(`Upload failed: ${xhr.status} ${xhr.statusText}`));
+        }
+      };
+
+      xhr.onerror = () => reject(new Error('Network error during upload'));
+      xhr.ontimeout = () => reject(new Error('Upload timed out'));
+      xhr.send(blob);
+    });
+  }
+};

--- a/src/lib/util/sync/core/providers/mega-core.ts
+++ b/src/lib/util/sync/core/providers/mega-core.ts
@@ -1,0 +1,176 @@
+import { File as MegaFile, Storage } from 'megajs';
+import type { CloudProviderCore } from '../cloud-provider-core-types';
+import { requireCredentialString } from '../cloud-provider-core-types';
+
+let uploadStoragePromise: Promise<Storage> | null = null;
+let uploadSessionKey: string | null = null;
+
+async function resetUploadStorage(): Promise<void> {
+  const storagePromise = uploadStoragePromise;
+  uploadStoragePromise = null;
+  uploadSessionKey = null;
+  if (!storagePromise) return;
+
+  try {
+    const storage = await storagePromise;
+    await storage.close();
+  } catch (error) {
+    console.warn('Worker: Failed to close MEGA upload storage:', error);
+  }
+}
+
+async function getUploadStorage(email: string, password: string): Promise<Storage> {
+  const sessionKey = `${email}\u0000${password}`;
+
+  if (uploadStoragePromise && uploadSessionKey === sessionKey) {
+    return await uploadStoragePromise;
+  }
+
+  if (uploadStoragePromise && uploadSessionKey !== sessionKey) {
+    await resetUploadStorage();
+  }
+
+  uploadSessionKey = sessionKey;
+  const pendingSession = (async () => {
+    const storage = new Storage({ email, password });
+    await storage.ready;
+    return storage;
+  })();
+  uploadStoragePromise = pendingSession;
+
+  try {
+    return await pendingSession;
+  } catch (error) {
+    if (uploadStoragePromise === pendingSession) {
+      uploadStoragePromise = null;
+      uploadSessionKey = null;
+    }
+    throw error;
+  }
+}
+
+export const megaCore: CloudProviderCore = {
+  async downloadFile({ credentials, onProgress }): Promise<ArrayBuffer> {
+    const shareUrl = requireCredentialString(credentials, 'megaShareUrl', 'MEGA share URL');
+
+    return await new Promise((resolve, reject) => {
+      try {
+        const file = MegaFile.fromURL(shareUrl);
+
+        file.loadAttributes((error) => {
+          if (error) {
+            reject(new Error(`MEGA metadata failed: ${error.message}`));
+            return;
+          }
+
+          const totalSize = file.size || 0;
+          const stream = file.download({});
+          const chunks: Uint8Array[] = [];
+          let loaded = 0;
+
+          stream.on('data', (chunk: Uint8Array) => {
+            chunks.push(chunk);
+            loaded += chunk.length;
+            onProgress(loaded, totalSize);
+          });
+
+          stream.on('end', async () => {
+            const blob = new Blob(chunks as BlobPart[]);
+            const buffer = await blob.arrayBuffer();
+            chunks.length = 0;
+            resolve(buffer);
+          });
+
+          stream.on('error', (streamError: Error) => {
+            reject(new Error(`MEGA download failed: ${streamError.message}`));
+          });
+        });
+      } catch (error) {
+        reject(
+          new Error(
+            `MEGA initialization failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+          )
+        );
+      }
+    });
+  },
+
+  async uploadFile({
+    seriesTitle,
+    filename,
+    blob,
+    credentials,
+    onProgress
+  }): Promise<string> {
+    const email = requireCredentialString(credentials, 'megaEmail', 'MEGA credentials');
+    const password = requireCredentialString(credentials, 'megaPassword', 'MEGA credentials');
+    const storage = await getUploadStorage(email, password);
+
+    try {
+      const CHUNK_SIZE = 1024 * 1024;
+
+      let mokuroFolder = storage.root.children?.find(
+        (child: any) => child.name === 'mokuro-reader' && child.directory
+      );
+
+      if (!mokuroFolder) {
+        mokuroFolder = await storage.root.mkdir('mokuro-reader');
+      }
+
+      let seriesFolder = mokuroFolder.children?.find(
+        (child: any) => child.name === seriesTitle && child.directory
+      );
+
+      if (!seriesFolder) {
+        seriesFolder = await mokuroFolder.mkdir(seriesTitle);
+      }
+
+      const uploadStream: any = seriesFolder.upload({ name: filename, size: blob.size });
+      let uploadedFileId: string | undefined;
+
+      await new Promise<void>((resolve, reject) => {
+        let offset = 0;
+
+        uploadStream.on('progress', (stats: any) => {
+          const uploaded = stats?.bytesUploaded || stats?.loaded || 0;
+          const total = stats?.bytesTotal || stats?.total || blob.size;
+          if (onProgress) {
+            onProgress(uploaded, total);
+          }
+        });
+
+        uploadStream.on('complete', (file: any) => {
+          uploadedFileId = file?.nodeId || file?.id || uploadedFileId;
+          resolve();
+        });
+
+        uploadStream.on('error', (error: unknown) => {
+          reject(error);
+        });
+
+        const writeNextChunk = async () => {
+          if (offset >= blob.size) {
+            uploadStream.end();
+            return;
+          }
+
+          const chunk = blob.slice(offset, Math.min(offset + CHUNK_SIZE, blob.size));
+          const arrayBuffer = await chunk.arrayBuffer();
+          uploadStream.write(new Uint8Array(arrayBuffer));
+          offset += CHUNK_SIZE;
+          setTimeout(() => writeNextChunk(), 0);
+        };
+
+        writeNextChunk();
+      });
+
+      if (!uploadedFileId) {
+        throw new Error('MEGA upload succeeded but did not return file ID');
+      }
+
+      return uploadedFileId;
+    } catch (error: any) {
+      throw new Error(`MEGA upload failed: ${error.message || error}`);
+    }
+  }
+};

--- a/src/lib/util/sync/core/providers/webdav-core.ts
+++ b/src/lib/util/sync/core/providers/webdav-core.ts
@@ -1,0 +1,240 @@
+import { createClient } from 'webdav';
+import {
+  ensureFoldersExist,
+  uploadFileWithClient
+} from '$lib/util/sync/providers/webdav/webdav-upload';
+import type { CloudProviderCore } from '../cloud-provider-core-types';
+import { optionalCredentialString, requireCredentialString } from '../cloud-provider-core-types';
+
+export const webdavCore: CloudProviderCore = {
+  async downloadFile({ fileId, credentials, onProgress }): Promise<ArrayBuffer> {
+    const url = requireCredentialString(credentials, 'webdavUrl', 'WebDAV URL');
+    const username = optionalCredentialString(credentials, 'webdavUsername');
+    const password = optionalCredentialString(credentials, 'webdavPassword');
+
+    const encodedPath = fileId
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/');
+    const baseUrl = url.endsWith('/') ? url.slice(0, -1) : url;
+    const fullUrl = `${baseUrl}${encodedPath}`;
+
+    const headers: Record<string, string> = {};
+    if (username || password) {
+      headers.Authorization = 'Basic ' + btoa(`${username}:${password}`);
+    }
+
+    const MAX_ERROR_RETRIES = 5;
+    const MAX_PARTIAL_RESUME_RETRIES = 8;
+    const BASE_RETRY_DELAY_MS = 400;
+    const MAX_RETRY_DELAY_MS = 5000;
+    const PROGRESS_THROTTLE_MS = 67; // ~15 updates per second
+
+    const chunks: Uint8Array[] = [];
+    let receivedLength = 0;
+    let expectedTotal = 0;
+    let lastProgressUpdate = 0;
+    let lastError: Error | null = null;
+    let errorRetries = 0;
+    let partialResumeRetries = 0;
+    let lastRetryResetOffset = 0;
+
+    const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    const isRetryableStatus = (status: number) => status === 408 || status === 429 || status >= 500;
+    const isRetryableError = (error: unknown) => {
+      const message = error instanceof Error ? error.message.toLowerCase() : '';
+      return (
+        message.includes('network') ||
+        message.includes('timeout') ||
+        message.includes('failed to fetch') ||
+        message.includes('fetch')
+      );
+    };
+
+    const parseContentRangeTotal = (value: string | null): number => {
+      if (!value) return 0;
+      const match = value.match(/\/(\d+)$/);
+      return match ? parseInt(match[1], 10) : 0;
+    };
+
+    const getRetryResetThreshold = (): number => {
+      // Reset retry budgets after meaningful forward progress:
+      // max(1MB, 5% of expected size when known)
+      if (expectedTotal > 0) {
+        return Math.max(1024 * 1024, Math.floor(expectedTotal * 0.05));
+      }
+      return 1024 * 1024;
+    };
+
+    // Best-effort size probe: helps detect truncation even when GET is chunked
+    // without Content-Length. If HEAD fails/is unsupported, we'll continue without it.
+    try {
+      const headResponse = await fetch(fullUrl, { method: 'HEAD', headers });
+      if (headResponse.ok) {
+        const headSize = parseInt(headResponse.headers.get('Content-Length') || '0', 10);
+        if (headSize > 0) {
+          expectedTotal = headSize;
+        }
+      }
+    } catch {
+      // ignore
+    }
+
+    while (true) {
+      const requestHeaders: Record<string, string> = { ...headers };
+      if (receivedLength > 0) {
+        requestHeaders.Range = `bytes=${receivedLength}-`;
+      }
+
+      try {
+        const response = await fetch(fullUrl, { headers: requestHeaders });
+
+        if (!response.ok) {
+          // 416 can happen when range start == size (already complete)
+          if (response.status === 416 && expectedTotal > 0 && receivedLength >= expectedTotal) {
+            break;
+          }
+
+          const error = new Error(
+            `WebDAV download failed: ${response.status} ${response.statusText}`
+          );
+          lastError = error;
+          if (isRetryableStatus(response.status) && errorRetries < MAX_ERROR_RETRIES) {
+            errorRetries += 1;
+            const jitter = Math.floor(Math.random() * 150);
+            const delay = Math.min(
+              MAX_RETRY_DELAY_MS,
+              BASE_RETRY_DELAY_MS * 2 ** (errorRetries - 1) + jitter
+            );
+            await sleep(delay);
+            continue;
+          }
+          throw error;
+        }
+
+        // If server ignores Range on resumed attempts, restart from scratch.
+        if (receivedLength > 0 && response.status === 200) {
+          chunks.length = 0;
+          receivedLength = 0;
+        }
+
+        const contentLength = parseInt(response.headers.get('Content-Length') || '0', 10);
+        const contentRangeTotal = parseContentRangeTotal(response.headers.get('Content-Range'));
+        if (contentRangeTotal > 0) {
+          expectedTotal = contentRangeTotal;
+        } else if (contentLength > 0) {
+          expectedTotal = receivedLength + contentLength;
+        }
+
+        const reader = response.body?.getReader();
+        if (!reader) {
+          throw new Error('Response body is not readable');
+        }
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (!value) continue;
+
+          chunks.push(value);
+          receivedLength += value.length;
+
+          // Connection is making forward progress; clear retry pressure periodically.
+          if (receivedLength - lastRetryResetOffset >= getRetryResetThreshold()) {
+            errorRetries = 0;
+            partialResumeRetries = 0;
+            lastRetryResetOffset = receivedLength;
+          }
+
+          const now = Date.now();
+          if (now - lastProgressUpdate >= PROGRESS_THROTTLE_MS) {
+            onProgress(receivedLength, expectedTotal || receivedLength);
+            lastProgressUpdate = now;
+          }
+        }
+
+        // If stream ended early, retry with Range from current offset.
+        if (expectedTotal > 0 && receivedLength < expectedTotal) {
+          if (partialResumeRetries >= MAX_PARTIAL_RESUME_RETRIES) {
+            throw new Error('WebDAV download incomplete after partial-resume retries');
+          }
+          partialResumeRetries += 1;
+          const jitter = Math.floor(Math.random() * 150);
+          const delay = Math.min(
+            MAX_RETRY_DELAY_MS,
+            BASE_RETRY_DELAY_MS * 2 ** (partialResumeRetries - 1) + jitter
+          );
+          await sleep(delay);
+          continue;
+        }
+
+        break;
+      } catch (error) {
+        const wrapped =
+          error instanceof Error ? error : new Error('Unknown error during WebDAV download');
+        lastError = wrapped;
+
+        if (isRetryableError(wrapped) && errorRetries < MAX_ERROR_RETRIES) {
+          errorRetries += 1;
+          const jitter = Math.floor(Math.random() * 150);
+          const delay = Math.min(
+            MAX_RETRY_DELAY_MS,
+            BASE_RETRY_DELAY_MS * 2 ** (errorRetries - 1) + jitter
+          );
+          await sleep(delay);
+          continue;
+        }
+
+        throw wrapped;
+      }
+    }
+
+    if (expectedTotal > 0 && receivedLength < expectedTotal) {
+      throw lastError || new Error('WebDAV download incomplete after retries');
+    }
+
+    onProgress(receivedLength, expectedTotal || receivedLength);
+
+    const blob = new Blob(chunks as BlobPart[]);
+    const buffer = await blob.arrayBuffer();
+    chunks.length = 0;
+    return buffer;
+  },
+
+  async uploadFile({
+    seriesTitle,
+    filename,
+    blob,
+    credentials,
+    onProgress
+  }): Promise<string> {
+    const serverUrl = requireCredentialString(credentials, 'webdavUrl', 'WebDAV URL');
+    const username = optionalCredentialString(credentials, 'webdavUsername');
+    const password = optionalCredentialString(credentials, 'webdavPassword');
+
+    const clientOptions: { username?: string; password?: string } = {};
+    if (username || password) {
+      clientOptions.username = username;
+      clientOptions.password = password;
+    }
+    const client = createClient(serverUrl, clientOptions);
+
+    const folderPath = seriesTitle ? `mokuro-reader/${seriesTitle}` : 'mokuro-reader';
+    await ensureFoldersExist(client, folderPath);
+
+    const filePath = `/${folderPath}/${filename}`;
+
+    // Delete-before-upload to avoid duplicate renames on servers that don't overwrite on PUT.
+    try {
+      const exists = await client.exists(filePath);
+      if (exists) {
+        await client.deleteFile(filePath);
+      }
+    } catch {
+      // ignore existence/delete checks here; upload attempt will report fatal errors
+    }
+
+    return await uploadFileWithClient(client, filePath, blob, onProgress);
+  }
+};

--- a/src/lib/util/sync/provider-interface.ts
+++ b/src/lib/util/sync/provider-interface.ts
@@ -123,6 +123,8 @@ export interface ProviderCredentials {
   [key: string]: any;
 }
 
+export type UploadPayload = Blob | ArrayBuffer | Uint8Array;
+
 /**
  * Base metadata for a cloud-stored file (CBZ file)
  * This is the common interface - use provider-specific types when possible
@@ -237,9 +239,15 @@ export interface SyncProvider {
    * @param path Target path (e.g., "SeriesTitle/VolumeTitle.cbz")
    * @param blob File data as Blob
    * @param description Optional file description
+   * @param onProgress Optional progress callback (loaded, total)
    * @returns File ID in cloud storage
    */
-  uploadFile(path: string, blob: Blob, description?: string): Promise<string>;
+  uploadFile(
+    path: string,
+    blob: UploadPayload,
+    description?: string,
+    onProgress?: (loaded: number, total: number) => void
+  ): Promise<string>;
 
   /**
    * Download a file from cloud storage

--- a/src/lib/util/volume-sidecars.ts
+++ b/src/lib/util/volume-sidecars.ts
@@ -36,7 +36,9 @@ export async function loadVolumeSidecars(volumeUuid: string): Promise<VolumeSide
   }
 
   let mokuroFile: File | null = null;
-  if (volume.mokuro_version !== '') {
+  const hasMokuroVersion =
+    typeof volume.mokuro_version === 'string' && volume.mokuro_version.trim() !== '';
+  if (hasMokuroVersion) {
     const volumeOcr = await db.volume_ocr.get(volumeUuid);
     if (volumeOcr?.pages) {
       const metadata = buildMokuroMetadata(volume, volumeOcr.pages);

--- a/src/lib/views/SeriesTextView.svelte
+++ b/src/lib/views/SeriesTextView.svelte
@@ -12,10 +12,11 @@
   import { calculateEstimatedTime } from '$lib/util/reading-speed';
 
   let seriesId = $derived($routeParams.manga || '');
+  let normalizedSeriesId = $derived(seriesId.trim().replace(/\s+/g, ' ').toLowerCase());
 
   // Get series volumes from catalog - match by title first (for placeholder URLs), then UUID
   let seriesData = $derived(
-    $catalog?.find((item) => item.title === seriesId) ||
+    $catalog?.find((item) => item.title.trim().replace(/\s+/g, ' ').toLowerCase() === normalizedSeriesId) ||
       $catalog?.find((item) => item.series_uuid === seriesId)
   );
   let volumes = $derived(

--- a/src/lib/workers/cloud-providers/google-drive.ts
+++ b/src/lib/workers/cloud-providers/google-drive.ts
@@ -1,0 +1,3 @@
+import { googleDriveCore } from '$lib/util/sync/core/providers/google-drive-core';
+
+export const googleDriveWorkerProvider = googleDriveCore;

--- a/src/lib/workers/cloud-providers/index.ts
+++ b/src/lib/workers/cloud-providers/index.ts
@@ -1,0 +1,6 @@
+import { getCloudProviderCore } from '$lib/util/sync/core/cloud-provider-core-registry';
+import type { WorkerCloudProviderAdapter, WorkerProviderType } from './types';
+
+export function getWorkerCloudProvider(provider: WorkerProviderType): WorkerCloudProviderAdapter {
+  return getCloudProviderCore(provider);
+}

--- a/src/lib/workers/cloud-providers/mega.ts
+++ b/src/lib/workers/cloud-providers/mega.ts
@@ -1,0 +1,3 @@
+import { megaCore } from '$lib/util/sync/core/providers/mega-core';
+
+export const megaWorkerProvider = megaCore;

--- a/src/lib/workers/cloud-providers/types.ts
+++ b/src/lib/workers/cloud-providers/types.ts
@@ -1,0 +1,7 @@
+export type {
+  CloudCoreProviderType as WorkerProviderType,
+  CloudCoreCredentials as WorkerProviderCredentials,
+  CloudCoreDownloadArgs as WorkerCloudDownloadArgs,
+  CloudCoreUploadArgs as WorkerCloudUploadArgs,
+  CloudProviderCore as WorkerCloudProviderAdapter
+} from '$lib/util/sync/core/cloud-provider-core-types';

--- a/src/lib/workers/cloud-providers/webdav.ts
+++ b/src/lib/workers/cloud-providers/webdav.ts
@@ -1,0 +1,3 @@
+import { webdavCore } from '$lib/util/sync/core/providers/webdav-core';
+
+export const webdavWorkerProvider = webdavCore;

--- a/src/lib/workers/unified-file-worker.ts
+++ b/src/lib/workers/unified-file-worker.ts
@@ -271,48 +271,178 @@ async function downloadFromWebDAV(
     headers.Authorization = 'Basic ' + btoa(`${username}:${password}`);
   }
 
-  const response = await fetch(fullUrl, { headers });
-
-  if (!response.ok) {
-    throw new Error(`WebDAV download failed: ${response.status} ${response.statusText}`);
-  }
-
-  const contentLength = parseInt(response.headers.get('Content-Length') || '0', 10);
-  const reader = response.body?.getReader();
-
-  if (!reader) {
-    throw new Error('Response body is not readable');
-  }
+  const MAX_ERROR_RETRIES = 5;
+  const MAX_PARTIAL_RESUME_RETRIES = 8;
+  const BASE_RETRY_DELAY_MS = 400;
+  const MAX_RETRY_DELAY_MS = 5000;
+  const PROGRESS_THROTTLE_MS = 67; // ~15 updates per second
 
   const chunks: Uint8Array[] = [];
   let receivedLength = 0;
-
-  // Throttle progress updates to ~15/second (matches XHR behavior)
+  let expectedTotal = 0;
   let lastProgressUpdate = 0;
-  const PROGRESS_THROTTLE_MS = 67; // ~15 updates per second
+  let lastError: Error | null = null;
+  let errorRetries = 0;
+  let partialResumeRetries = 0;
+  let lastRetryResetOffset = 0;
+
+  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  const isRetryableStatus = (status: number) => status === 408 || status === 429 || status >= 500;
+  const isRetryableError = (error: unknown) => {
+    const message = error instanceof Error ? error.message.toLowerCase() : '';
+    return (
+      message.includes('network') ||
+      message.includes('timeout') ||
+      message.includes('failed to fetch') ||
+      message.includes('fetch')
+    );
+  };
+
+  const parseContentRangeTotal = (value: string | null): number => {
+    if (!value) return 0;
+    const match = value.match(/\/(\d+)$/);
+    return match ? parseInt(match[1], 10) : 0;
+  };
+
+  const getRetryResetThreshold = (): number => {
+    // Reset retry budgets after meaningful forward progress:
+    // max(1MB, 5% of expected size when known)
+    if (expectedTotal > 0) {
+      return Math.max(1024 * 1024, Math.floor(expectedTotal * 0.05));
+    }
+    return 1024 * 1024;
+  };
+
+  // Best-effort size probe: helps detect truncation even when GET is chunked
+  // without Content-Length. If HEAD fails/is unsupported, we'll continue without it.
+  try {
+    const headResponse = await fetch(fullUrl, { method: 'HEAD', headers });
+    if (headResponse.ok) {
+      const headSize = parseInt(headResponse.headers.get('Content-Length') || '0', 10);
+      if (headSize > 0) {
+        expectedTotal = headSize;
+      }
+    }
+  } catch {
+    // ignore
+  }
 
   while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
+    const requestHeaders: Record<string, string> = { ...headers };
+    if (receivedLength > 0) {
+      requestHeaders.Range = `bytes=${receivedLength}-`;
+    }
 
-    chunks.push(value);
-    receivedLength += value.length;
+    try {
+      const response = await fetch(fullUrl, { headers: requestHeaders });
 
-    // Only send progress update if enough time has passed
-    const now = Date.now();
-    if (now - lastProgressUpdate >= PROGRESS_THROTTLE_MS) {
-      onProgress(receivedLength, contentLength || receivedLength);
-      lastProgressUpdate = now;
+      if (!response.ok) {
+        // 416 can happen when range start == size (already complete)
+        if (response.status === 416 && expectedTotal > 0 && receivedLength >= expectedTotal) {
+          break;
+        }
+
+        const error = new Error(`WebDAV download failed: ${response.status} ${response.statusText}`);
+        lastError = error;
+        if (isRetryableStatus(response.status) && errorRetries < MAX_ERROR_RETRIES) {
+          errorRetries += 1;
+          const jitter = Math.floor(Math.random() * 150);
+          const delay = Math.min(
+            MAX_RETRY_DELAY_MS,
+            BASE_RETRY_DELAY_MS * 2 ** (errorRetries - 1) + jitter
+          );
+          await sleep(delay);
+          continue;
+        }
+        throw error;
+      }
+
+      // If server ignores Range on resumed attempts, restart in-worker from scratch.
+      if (receivedLength > 0 && response.status === 200) {
+        chunks.length = 0;
+        receivedLength = 0;
+      }
+
+      const contentLength = parseInt(response.headers.get('Content-Length') || '0', 10);
+      const contentRangeTotal = parseContentRangeTotal(response.headers.get('Content-Range'));
+      if (contentRangeTotal > 0) {
+        expectedTotal = contentRangeTotal;
+      } else if (contentLength > 0) {
+        expectedTotal = receivedLength + contentLength;
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error('Response body is not readable');
+      }
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+
+        chunks.push(value);
+        receivedLength += value.length;
+
+        // Connection is making forward progress; clear retry pressure periodically.
+        if (receivedLength - lastRetryResetOffset >= getRetryResetThreshold()) {
+          errorRetries = 0;
+          partialResumeRetries = 0;
+          lastRetryResetOffset = receivedLength;
+        }
+
+        const now = Date.now();
+        if (now - lastProgressUpdate >= PROGRESS_THROTTLE_MS) {
+          onProgress(receivedLength, expectedTotal || receivedLength);
+          lastProgressUpdate = now;
+        }
+      }
+
+      // If stream ended early, retry with Range from current offset.
+      if (expectedTotal > 0 && receivedLength < expectedTotal) {
+        if (partialResumeRetries >= MAX_PARTIAL_RESUME_RETRIES) {
+          throw new Error('WebDAV download incomplete after partial-resume retries');
+        }
+        partialResumeRetries += 1;
+        const jitter = Math.floor(Math.random() * 150);
+        const delay = Math.min(
+          MAX_RETRY_DELAY_MS,
+          BASE_RETRY_DELAY_MS * 2 ** (partialResumeRetries - 1) + jitter
+        );
+        await sleep(delay);
+        continue;
+      }
+
+      break;
+    } catch (error) {
+      const wrapped =
+        error instanceof Error ? error : new Error('Unknown error during WebDAV download');
+      lastError = wrapped;
+
+      if (isRetryableError(wrapped) && errorRetries < MAX_ERROR_RETRIES) {
+        errorRetries += 1;
+        const jitter = Math.floor(Math.random() * 150);
+        const delay = Math.min(
+          MAX_RETRY_DELAY_MS,
+          BASE_RETRY_DELAY_MS * 2 ** (errorRetries - 1) + jitter
+        );
+        await sleep(delay);
+        continue;
+      }
+
+      throw wrapped;
     }
   }
 
-  // Always send final progress update at 100%
-  onProgress(receivedLength, contentLength || receivedLength);
+  if (expectedTotal > 0 && receivedLength < expectedTotal) {
+    throw lastError || new Error('WebDAV download incomplete after retries');
+  }
 
-  // Use Blob to combine chunks - avoids allocating a second copy of the entire file
+  onProgress(receivedLength, expectedTotal || receivedLength);
+
   const blob = new Blob(chunks as BlobPart[]);
   const buffer = await blob.arrayBuffer();
-  // Clear chunks array to free memory
   chunks.length = 0;
   return buffer;
 }

--- a/src/lib/workers/unified-file-worker.ts
+++ b/src/lib/workers/unified-file-worker.ts
@@ -131,6 +131,7 @@ interface CompressFromDbMessage {
   credentials?: ProviderCredentials;
   downloadFilename?: string; // For local export
   embedThumbnailSidecar?: boolean;
+  embedMokuroInArchive?: boolean;
 }
 
 type WorkerMessage =
@@ -1376,7 +1377,10 @@ ctx.addEventListener('message', async (event) => {
           };
           ctx.postMessage(progressMessage);
         },
-        { embedThumbnailSidecar: message.embedThumbnailSidecar === true }
+        {
+          embedThumbnailSidecar: message.embedThumbnailSidecar === true,
+          embedMokuroInArchive: message.embedMokuroInArchive !== false
+        }
       );
 
       console.log(`Worker: Compressed ${volumeTitle} (${cbzBlob.size} bytes)`);

--- a/src/lib/workers/unified-file-worker.ts
+++ b/src/lib/workers/unified-file-worker.ts
@@ -9,14 +9,15 @@ import {
   getMimeType,
   BlobReader
 } from '@zip.js/zip.js';
-import { File as MegaFile, Storage } from 'megajs';
 import {
   compressVolume,
   compressVolumeFromDb,
+  generateVolumeSidecarsFromDb,
   type MokuroMetadata
 } from '$lib/util/compress-volume';
-import { uploadToWebDAV } from '$lib/util/sync/providers/webdav/webdav-upload';
 import { matchFileToVolume } from '$lib/import/archive-extraction';
+import { getWorkerCloudProvider } from './cloud-providers';
+import type { WorkerProviderCredentials, WorkerProviderType } from './cloud-providers/types';
 
 // Define the worker context
 const ctx: Worker = self as any;
@@ -34,26 +35,12 @@ interface VolumeMetadata {
   cloudSize?: number;
 }
 
-interface ProviderCredentials {
-  // Google Drive
-  accessToken?: string;
-  seriesFolderId?: string; // Pre-created folder ID (avoids race conditions)
-
-  // WebDAV
-  webdavUrl?: string;
-  webdavUsername?: string;
-  webdavPassword?: string;
-
-  // MEGA
-  megaShareUrl?: string; // For downloads
-  megaEmail?: string; // For uploads
-  megaPassword?: string; // For uploads
-}
+type ProviderCredentials = WorkerProviderCredentials;
 
 // Download messages
 interface DownloadAndDecompressMessage {
   mode: 'download-and-decompress';
-  provider: 'google-drive' | 'webdav' | 'mega';
+  provider: WorkerProviderType;
   fileId: string;
   fileName: string;
   credentials: ProviderCredentials;
@@ -105,7 +92,7 @@ interface DownloadHttpBundleMessage {
 // Upload messages
 interface CompressAndUploadMessage {
   mode: 'compress-and-upload';
-  provider: 'google-drive' | 'webdav' | 'mega';
+  provider: WorkerProviderType;
   volumeTitle: string;
   seriesTitle: string;
   metadata: MokuroMetadata;
@@ -124,7 +111,7 @@ interface CompressAndReturnMessage {
 /** Compress from IndexedDB and optionally upload to cloud provider */
 interface CompressFromDbMessage {
   mode: 'compress-from-db';
-  provider: 'google-drive' | 'webdav' | 'mega' | null; // null = local export (return data)
+  provider: WorkerProviderType | null; // null = local export (return data)
   volumeUuid: string;
   volumeTitle: string;
   seriesTitle: string;
@@ -132,6 +119,7 @@ interface CompressFromDbMessage {
   downloadFilename?: string; // For local export
   embedThumbnailSidecar?: boolean;
   embedMokuroInArchive?: boolean;
+  includeSidecars?: boolean;
 }
 
 type WorkerMessage =
@@ -153,7 +141,7 @@ interface DownloadProgressMessage {
 
 interface UploadProgressMessage {
   type: 'progress';
-  phase: 'compressing' | 'uploading';
+  phase: 'compressing' | 'sidecars' | 'uploading';
   progress: number; // 0-100
 }
 
@@ -175,8 +163,13 @@ interface DownloadCompleteMessage {
 interface UploadCompleteMessage {
   type: 'complete';
   fileId?: string; // For cloud uploads
+  size?: number; // Archive size in bytes (for optimistic cache entry)
   data?: Uint8Array; // For local exports (Transferable Object)
   filename?: string; // For local exports
+  sidecars?: {
+    mokuro?: { filename: string; blob: Blob };
+    thumbnail?: { filename: string; blob: Blob };
+  };
 }
 
 interface ErrorMessage {
@@ -188,321 +181,6 @@ interface ErrorMessage {
 interface DecompressedEntry {
   filename: string;
   data: ArrayBuffer;
-}
-
-// ===========================
-// DOWNLOAD FUNCTIONS
-// ===========================
-
-/**
- * Download from Google Drive using access token
- * Returns ArrayBuffer directly to avoid intermediate Blob creation and disk writes
- */
-async function downloadFromGoogleDrive(
-  fileId: string,
-  accessToken: string,
-  onProgress: (loaded: number, total: number) => void
-): Promise<ArrayBuffer> {
-  // First get the file size
-  const sizeResponse = await fetch(
-    `https://www.googleapis.com/drive/v3/files/${fileId}?fields=size`,
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`
-      }
-    }
-  );
-
-  if (!sizeResponse.ok) {
-    throw new Error(`Failed to get file size: ${sizeResponse.statusText}`);
-  }
-
-  const sizeData = await sizeResponse.json();
-  const totalSize = parseInt(sizeData.size, 10);
-
-  // Now download the file with progress tracking
-  const xhr = new XMLHttpRequest();
-  xhr.open('GET', `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`);
-  xhr.setRequestHeader('Authorization', `Bearer ${accessToken}`);
-  xhr.responseType = 'arraybuffer';
-
-  return new Promise((resolve, reject) => {
-    xhr.onprogress = (event) => {
-      onProgress(event.loaded, totalSize);
-    };
-
-    xhr.onerror = () => reject(new Error('Network error during download'));
-    xhr.ontimeout = () => reject(new Error('Download timed out'));
-    xhr.onabort = () => reject(new Error('Download aborted'));
-
-    xhr.onload = () => {
-      if (xhr.status >= 200 && xhr.status < 300) {
-        resolve(xhr.response as ArrayBuffer);
-      } else {
-        reject(new Error(`HTTP error ${xhr.status}: ${xhr.statusText}`));
-      }
-    };
-
-    xhr.send();
-  });
-}
-
-/**
- * Download from WebDAV server using Basic Auth
- * Returns ArrayBuffer directly to avoid intermediate Blob creation and disk writes
- */
-async function downloadFromWebDAV(
-  fileId: string,
-  url: string,
-  username: string,
-  password: string,
-  onProgress: (loaded: number, total: number) => void
-): Promise<ArrayBuffer> {
-  // Encode each path segment to handle special chars like # → %23
-  // Without this, # is treated as URL fragment and stripped
-  const encodedPath = fileId
-    .split('/')
-    .map((segment) => encodeURIComponent(segment))
-    .join('/');
-  const baseUrl = url.endsWith('/') ? url.slice(0, -1) : url;
-  const fullUrl = `${baseUrl}${encodedPath}`;
-
-  const headers: Record<string, string> = {};
-  if (username || password) {
-    headers.Authorization = 'Basic ' + btoa(`${username}:${password}`);
-  }
-
-  const MAX_ERROR_RETRIES = 5;
-  const MAX_PARTIAL_RESUME_RETRIES = 8;
-  const BASE_RETRY_DELAY_MS = 400;
-  const MAX_RETRY_DELAY_MS = 5000;
-  const PROGRESS_THROTTLE_MS = 67; // ~15 updates per second
-
-  const chunks: Uint8Array[] = [];
-  let receivedLength = 0;
-  let expectedTotal = 0;
-  let lastProgressUpdate = 0;
-  let lastError: Error | null = null;
-  let errorRetries = 0;
-  let partialResumeRetries = 0;
-  let lastRetryResetOffset = 0;
-
-  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-  const isRetryableStatus = (status: number) => status === 408 || status === 429 || status >= 500;
-  const isRetryableError = (error: unknown) => {
-    const message = error instanceof Error ? error.message.toLowerCase() : '';
-    return (
-      message.includes('network') ||
-      message.includes('timeout') ||
-      message.includes('failed to fetch') ||
-      message.includes('fetch')
-    );
-  };
-
-  const parseContentRangeTotal = (value: string | null): number => {
-    if (!value) return 0;
-    const match = value.match(/\/(\d+)$/);
-    return match ? parseInt(match[1], 10) : 0;
-  };
-
-  const getRetryResetThreshold = (): number => {
-    // Reset retry budgets after meaningful forward progress:
-    // max(1MB, 5% of expected size when known)
-    if (expectedTotal > 0) {
-      return Math.max(1024 * 1024, Math.floor(expectedTotal * 0.05));
-    }
-    return 1024 * 1024;
-  };
-
-  // Best-effort size probe: helps detect truncation even when GET is chunked
-  // without Content-Length. If HEAD fails/is unsupported, we'll continue without it.
-  try {
-    const headResponse = await fetch(fullUrl, { method: 'HEAD', headers });
-    if (headResponse.ok) {
-      const headSize = parseInt(headResponse.headers.get('Content-Length') || '0', 10);
-      if (headSize > 0) {
-        expectedTotal = headSize;
-      }
-    }
-  } catch {
-    // ignore
-  }
-
-  while (true) {
-    const requestHeaders: Record<string, string> = { ...headers };
-    if (receivedLength > 0) {
-      requestHeaders.Range = `bytes=${receivedLength}-`;
-    }
-
-    try {
-      const response = await fetch(fullUrl, { headers: requestHeaders });
-
-      if (!response.ok) {
-        // 416 can happen when range start == size (already complete)
-        if (response.status === 416 && expectedTotal > 0 && receivedLength >= expectedTotal) {
-          break;
-        }
-
-        const error = new Error(`WebDAV download failed: ${response.status} ${response.statusText}`);
-        lastError = error;
-        if (isRetryableStatus(response.status) && errorRetries < MAX_ERROR_RETRIES) {
-          errorRetries += 1;
-          const jitter = Math.floor(Math.random() * 150);
-          const delay = Math.min(
-            MAX_RETRY_DELAY_MS,
-            BASE_RETRY_DELAY_MS * 2 ** (errorRetries - 1) + jitter
-          );
-          await sleep(delay);
-          continue;
-        }
-        throw error;
-      }
-
-      // If server ignores Range on resumed attempts, restart in-worker from scratch.
-      if (receivedLength > 0 && response.status === 200) {
-        chunks.length = 0;
-        receivedLength = 0;
-      }
-
-      const contentLength = parseInt(response.headers.get('Content-Length') || '0', 10);
-      const contentRangeTotal = parseContentRangeTotal(response.headers.get('Content-Range'));
-      if (contentRangeTotal > 0) {
-        expectedTotal = contentRangeTotal;
-      } else if (contentLength > 0) {
-        expectedTotal = receivedLength + contentLength;
-      }
-
-      const reader = response.body?.getReader();
-      if (!reader) {
-        throw new Error('Response body is not readable');
-      }
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        if (!value) continue;
-
-        chunks.push(value);
-        receivedLength += value.length;
-
-        // Connection is making forward progress; clear retry pressure periodically.
-        if (receivedLength - lastRetryResetOffset >= getRetryResetThreshold()) {
-          errorRetries = 0;
-          partialResumeRetries = 0;
-          lastRetryResetOffset = receivedLength;
-        }
-
-        const now = Date.now();
-        if (now - lastProgressUpdate >= PROGRESS_THROTTLE_MS) {
-          onProgress(receivedLength, expectedTotal || receivedLength);
-          lastProgressUpdate = now;
-        }
-      }
-
-      // If stream ended early, retry with Range from current offset.
-      if (expectedTotal > 0 && receivedLength < expectedTotal) {
-        if (partialResumeRetries >= MAX_PARTIAL_RESUME_RETRIES) {
-          throw new Error('WebDAV download incomplete after partial-resume retries');
-        }
-        partialResumeRetries += 1;
-        const jitter = Math.floor(Math.random() * 150);
-        const delay = Math.min(
-          MAX_RETRY_DELAY_MS,
-          BASE_RETRY_DELAY_MS * 2 ** (partialResumeRetries - 1) + jitter
-        );
-        await sleep(delay);
-        continue;
-      }
-
-      break;
-    } catch (error) {
-      const wrapped =
-        error instanceof Error ? error : new Error('Unknown error during WebDAV download');
-      lastError = wrapped;
-
-      if (isRetryableError(wrapped) && errorRetries < MAX_ERROR_RETRIES) {
-        errorRetries += 1;
-        const jitter = Math.floor(Math.random() * 150);
-        const delay = Math.min(
-          MAX_RETRY_DELAY_MS,
-          BASE_RETRY_DELAY_MS * 2 ** (errorRetries - 1) + jitter
-        );
-        await sleep(delay);
-        continue;
-      }
-
-      throw wrapped;
-    }
-  }
-
-  if (expectedTotal > 0 && receivedLength < expectedTotal) {
-    throw lastError || new Error('WebDAV download incomplete after retries');
-  }
-
-  onProgress(receivedLength, expectedTotal || receivedLength);
-
-  const blob = new Blob(chunks as BlobPart[]);
-  const buffer = await blob.arrayBuffer();
-  chunks.length = 0;
-  return buffer;
-}
-
-/**
- * Download from MEGA using a share link via the MEGA API
- * The share link includes the decryption key, MEGA API handles download
- * Returns ArrayBuffer directly to avoid intermediate Blob creation and disk writes
- */
-async function downloadFromMega(
-  shareUrl: string,
-  onProgress: (loaded: number, total: number) => void
-): Promise<ArrayBuffer> {
-  return new Promise((resolve, reject) => {
-    try {
-      // Load file from share link using MEGA API
-      const file = MegaFile.fromURL(shareUrl);
-
-      // Load file metadata
-      file.loadAttributes((error) => {
-        if (error) {
-          reject(new Error(`MEGA metadata failed: ${error.message}`));
-          return;
-        }
-
-        const totalSize = file.size || 0;
-
-        // Download file with progress tracking
-        const stream = file.download({});
-        const chunks: Uint8Array[] = [];
-        let loaded = 0;
-
-        stream.on('data', (chunk: Uint8Array) => {
-          chunks.push(chunk);
-          loaded += chunk.length;
-          onProgress(loaded, totalSize);
-        });
-
-        stream.on('end', async () => {
-          // Use Blob to combine chunks - avoids allocating a second copy of the entire file
-          const blob = new Blob(chunks as BlobPart[]);
-          const buffer = await blob.arrayBuffer();
-          // Clear chunks array to free memory before resolving
-          chunks.length = 0;
-          resolve(buffer);
-        });
-
-        stream.on('error', (error: Error) => {
-          reject(new Error(`MEGA download failed: ${error.message}`));
-        });
-      });
-    } catch (error) {
-      reject(
-        new Error(
-          `MEGA initialization failed: ${error instanceof Error ? error.message : 'Unknown error'}`
-        )
-      );
-    }
-  });
 }
 
 /** Filter options for selective extraction */
@@ -576,35 +254,26 @@ function isSystemFile(path: string): boolean {
 function matchesFilter(filename: string, filter?: ExtractFilter): boolean {
   if (!filter) return true;
 
-  // Check extension filter
   if (filter.extensions && filter.extensions.length > 0) {
     const ext = filename.split('.').pop()?.toLowerCase() || '';
     if (filter.extensions.includes(ext)) return true;
   }
 
-  // Check path prefix filter
   if (filter.pathPrefixes && filter.pathPrefixes.length > 0) {
     for (const prefix of filter.pathPrefixes) {
       if (filename.startsWith(prefix + '/') || filename === prefix) return true;
     }
   }
 
-  // If both filters are specified, match either; if only one, that one must match
   if (filter.extensions?.length && filter.pathPrefixes?.length) {
-    return false; // Neither matched
+    return false;
   }
-  if (filter.extensions?.length) return false; // Extension filter didn't match
-  if (filter.pathPrefixes?.length) return false; // Path filter didn't match
+  if (filter.extensions?.length) return false;
+  if (filter.pathPrefixes?.length) return false;
 
-  return true; // No filters = match all
+  return true;
 }
 
-/**
- * Decompress a CBZ file from Blob or ArrayBuffer into entries
- * Uses BlobReader for streaming - handles large files (>2GB) without loading into ArrayBuffer
- * Optional filter allows extracting only specific files (e.g., mokuro files first, then images per volume)
- * If listOnly is true, returns file list without extracting content (for planning extraction)
- */
 // Concurrency limit for parallel extraction - higher = faster but more memory
 const EXTRACT_CONCURRENCY = 16;
 
@@ -614,26 +283,18 @@ async function decompressCbz(
   listOnly?: boolean,
   listAllExtractFiltered?: boolean
 ): Promise<DecompressedEntry[]> {
-  // Convert ArrayBuffer to Blob if needed (for downloaded data)
   const blob = data instanceof Blob ? data : new Blob([data]);
-
-  // Use BlobReader for streaming - doesn't require loading entire file into memory at once
   const zipReader = new ZipReader(new BlobReader(blob));
-
-  // Get all entries from the zip file
   const entries = await zipReader.getEntries();
 
-  // Categorize entries
   const toExtract: { entry: (typeof entries)[0]; filename: string }[] = [];
   const toList: string[] = [];
 
   for (const entry of entries) {
     if (entry.directory) continue;
-    // Skip system files (macOS, Windows, Linux metadata)
     if (isSystemFile(entry.filename)) continue;
 
     const matchesFilterCriteria = matchesFilter(entry.filename, filter);
-
     if (!listAllExtractFiltered && !matchesFilterCriteria) {
       continue;
     }
@@ -651,17 +312,13 @@ async function decompressCbz(
     }
   }
 
-  // Build results
   const decompressedEntries: DecompressedEntry[] = [];
 
-  // Add list-only entries (no extraction needed)
   for (const filename of toList) {
     decompressedEntries.push({ filename, data: new ArrayBuffer(0) });
   }
 
-  // Extract entries in parallel batches
   if (toExtract.length > 0) {
-    // Process in batches for controlled concurrency
     for (let i = 0; i < toExtract.length; i += EXTRACT_CONCURRENCY) {
       const batch = toExtract.slice(i, i + EXTRACT_CONCURRENCY);
 
@@ -745,196 +402,6 @@ async function tryDownloadOptionalUrl(
 }
 
 // ===========================
-// UPLOAD FUNCTIONS
-// ===========================
-
-/**
- * Upload to Google Drive using resumable upload
- * Progress: 0-100% of upload phase
- */
-async function uploadToGoogleDrive(
-  cbzBlob: Blob,
-  filename: string,
-  seriesFolderId: string,
-  accessToken: string,
-  onProgress: (loaded: number, total: number) => void
-): Promise<string> {
-  console.log(`Worker: Uploading ${filename} to Google Drive...`);
-
-  // Use pre-created folder ID (created in backup-queue to avoid race conditions)
-  const metadata = {
-    name: filename,
-    mimeType: 'application/x-cbz',
-    parents: [seriesFolderId]
-  };
-
-  // Step 1: Initiate resumable upload session
-  const initResponse = await fetch(
-    'https://www.googleapis.com/upload/drive/v3/files?uploadType=resumable',
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(metadata)
-    }
-  );
-
-  if (!initResponse.ok) {
-    throw new Error(`Upload init failed: ${initResponse.status} ${initResponse.statusText}`);
-  }
-
-  const uploadUrl = initResponse.headers.get('Location');
-  if (!uploadUrl) {
-    throw new Error('No upload URL returned');
-  }
-
-  // Step 2: Upload the actual file data with progress tracking
-  return new Promise((resolve, reject) => {
-    const xhr = new XMLHttpRequest();
-    xhr.open('PUT', uploadUrl);
-    xhr.setRequestHeader('Content-Type', 'application/x-cbz');
-
-    xhr.upload.onprogress = (event) => {
-      if (event.lengthComputable) {
-        onProgress(event.loaded, event.total);
-      }
-    };
-
-    xhr.onload = async () => {
-      if (xhr.status >= 200 && xhr.status < 300) {
-        const result = JSON.parse(xhr.responseText);
-        console.log(`Worker: Upload complete, file ID: ${result.id}`);
-        resolve(result.id);
-      } else {
-        reject(new Error(`Upload failed: ${xhr.status} ${xhr.statusText}`));
-      }
-    };
-
-    xhr.onerror = () => reject(new Error('Network error during upload'));
-    xhr.ontimeout = () => reject(new Error('Upload timed out'));
-
-    // Send Blob directly - browser streams the data
-    xhr.send(cbzBlob);
-  });
-}
-
-/**
- * Upload to MEGA
- * Progress: 0-100% of upload phase
- */
-async function uploadToMEGA(
-  cbzBlob: Blob,
-  filename: string,
-  seriesTitle: string,
-  email: string,
-  password: string,
-  onProgress: (loaded: number, total: number) => void
-): Promise<string> {
-  console.log(`Worker: Uploading ${filename} to MEGA...`);
-
-  if (!email || !password) {
-    throw new Error('MEGA credentials not provided');
-  }
-
-  // Create MEGA storage instance
-  const storage = new Storage({ email, password });
-
-  // Wait for ready
-  await storage.ready;
-
-  // Ensure folder structure exists
-  let currentFolder = storage.root;
-
-  // Create/find mokuro-reader folder
-  let mokuroFolder = currentFolder.children?.find(
-    (child: any) => child.name === 'mokuro-reader' && child.directory
-  );
-
-  if (!mokuroFolder) {
-    mokuroFolder = await currentFolder.mkdir('mokuro-reader');
-  }
-
-  // Create/find series folder
-  let seriesFolder = mokuroFolder.children?.find(
-    (child: any) => child.name === seriesTitle && child.directory
-  );
-
-  if (!seriesFolder) {
-    seriesFolder = await mokuroFolder.mkdir(seriesTitle);
-  }
-
-  // Upload file to series folder using chunked streaming to avoid OOM
-  console.log(`Worker: Starting MEGA upload for ${filename}, size: ${cbzBlob.size} bytes`);
-
-  try {
-    const CHUNK_SIZE = 1024 * 1024; // 1MB chunks
-
-    // Create upload stream without passing data - we'll write chunks manually
-    const uploadStream = seriesFolder.upload({ name: filename, size: cbzBlob.size });
-
-    // Wait for upload to complete while streaming chunks
-    await new Promise<void>((resolve, reject) => {
-      let offset = 0;
-
-      uploadStream.on('progress', (stats: any) => {
-        // megajs progress: { bytesLoaded, bytesUploaded, bytesTotal }
-        // Use bytesUploaded for actual upload progress to server
-        const uploaded = stats?.bytesUploaded || stats?.loaded || 0;
-        const total = stats?.bytesTotal || stats?.total || cbzBlob.size;
-        onProgress(uploaded, total);
-      });
-
-      uploadStream.on('complete', () => {
-        console.log('Worker: MEGA upload stream completed');
-        resolve();
-      });
-
-      uploadStream.on('error', (err: any) => {
-        console.error('Worker: MEGA upload stream error:', err);
-        reject(err);
-      });
-
-      // Stream chunks to MEGA
-      const writeNextChunk = async () => {
-        if (offset >= cbzBlob.size) {
-          uploadStream.end();
-          return;
-        }
-
-        const chunk = cbzBlob.slice(offset, Math.min(offset + CHUNK_SIZE, cbzBlob.size));
-        const arrayBuffer = await chunk.arrayBuffer();
-        uploadStream.write(new Uint8Array(arrayBuffer));
-        offset += CHUNK_SIZE;
-
-        // Use setTimeout to avoid blocking event loop and allow GC
-        setTimeout(() => writeNextChunk(), 0);
-      };
-
-      writeNextChunk();
-    });
-
-    // After upload completes, find the file in the folder's children
-    // The file should now be in seriesFolder.children
-    const uploadedFile = seriesFolder.children?.find(
-      (child: any) => child.name === filename && !child.directory
-    );
-
-    if (!uploadedFile || !uploadedFile.nodeId) {
-      console.error('Worker: Could not find uploaded file in folder children');
-      throw new Error('MEGA upload succeeded but could not find uploaded file');
-    }
-
-    console.log(`Worker: MEGA upload complete, file ID: ${uploadedFile.nodeId}`);
-    return uploadedFile.nodeId;
-  } catch (error: any) {
-    console.error('Worker: MEGA upload error:', error);
-    throw new Error(`MEGA upload failed: ${error.message || error}`);
-  }
-}
-
-// ===========================
 // MAIN MESSAGE HANDLER
 // ===========================
 
@@ -955,50 +422,11 @@ ctx.addEventListener('message', async (event) => {
       const { provider, fileId, fileName, credentials, metadata } = message;
       console.log(`Worker: Starting download for ${fileName} (${fileId})`);
 
-      let arrayBuffer: ArrayBuffer;
-
-      // Download based on provider - all return ArrayBuffer directly
-      if (provider === 'google-drive') {
-        if (!credentials.accessToken) {
-          throw new Error('Missing access token for Google Drive');
-        }
-        arrayBuffer = await downloadFromGoogleDrive(
-          fileId,
-          credentials.accessToken,
-          (loaded, total) => {
-            const progressMessage: DownloadProgressMessage = {
-              type: 'progress',
-              fileId,
-              loaded,
-              total
-            };
-            ctx.postMessage(progressMessage);
-          }
-        );
-      } else if (provider === 'webdav') {
-        if (!credentials.webdavUrl) {
-          throw new Error('Missing WebDAV URL');
-        }
-        arrayBuffer = await downloadFromWebDAV(
-          fileId,
-          credentials.webdavUrl,
-          credentials.webdavUsername ?? '',
-          credentials.webdavPassword ?? '',
-          (loaded, total) => {
-            const progressMessage: DownloadProgressMessage = {
-              type: 'progress',
-              fileId,
-              loaded,
-              total
-            };
-            ctx.postMessage(progressMessage);
-          }
-        );
-      } else if (provider === 'mega') {
-        if (!credentials.megaShareUrl) {
-          throw new Error('Missing MEGA share URL');
-        }
-        arrayBuffer = await downloadFromMega(credentials.megaShareUrl, (loaded, total) => {
+      const cloudProvider = getWorkerCloudProvider(provider);
+      const arrayBuffer = await cloudProvider.downloadFile({
+        fileId,
+        credentials,
+        onProgress: (loaded, total) => {
           const progressMessage: DownloadProgressMessage = {
             type: 'progress',
             fileId,
@@ -1006,10 +434,8 @@ ctx.addEventListener('message', async (event) => {
             total
           };
           ctx.postMessage(progressMessage);
-        });
-      } else {
-        throw new Error(`Unsupported provider: ${provider}`);
-      }
+        }
+      });
 
       console.log(`Worker: Download complete for ${fileName}`);
 
@@ -1233,72 +659,27 @@ ctx.addEventListener('message', async (event) => {
       console.log(`Worker: Compressed ${volumeTitle} (${cbzBlob.size} bytes)`);
 
       // Phase 2: Upload (0-100%)
-      let fileId: string;
-      const filename = `${volumeTitle}.cbz`;
-
-      if (provider === 'google-drive') {
-        if (!credentials.accessToken || !credentials.seriesFolderId) {
-          throw new Error('Missing Google Drive access token or series folder ID');
-        }
-        fileId = await uploadToGoogleDrive(
-          cbzBlob,
-          filename,
-          credentials.seriesFolderId,
-          credentials.accessToken,
-          (loaded, total) => {
-            const uploadProgress = (loaded / total) * 100; // 0-100% upload
-            const progressMessage: UploadProgressMessage = {
-              type: 'progress',
-              phase: 'uploading',
-              progress: uploadProgress
-            };
-            ctx.postMessage(progressMessage);
-          }
-        );
-      } else if (provider === 'webdav') {
-        if (!credentials.webdavUrl) {
-          throw new Error('Missing WebDAV URL');
-        }
-        fileId = await uploadToWebDAV(
-          credentials.webdavUrl,
-          credentials.webdavUsername ?? '',
-          credentials.webdavPassword ?? '',
-          seriesTitle,
-          filename,
-          cbzBlob,
-          (loaded, total) => {
-            const uploadProgress = (loaded / total) * 100; // 0-100% upload
-            const progressMessage: UploadProgressMessage = {
-              type: 'progress',
-              phase: 'uploading',
-              progress: uploadProgress
-            };
-            ctx.postMessage(progressMessage);
-          }
-        );
-      } else if (provider === 'mega') {
-        if (!credentials.megaEmail || !credentials.megaPassword) {
-          throw new Error('Missing MEGA credentials');
-        }
-        fileId = await uploadToMEGA(
-          cbzBlob,
-          filename,
-          seriesTitle,
-          credentials.megaEmail,
-          credentials.megaPassword,
-          (loaded, total) => {
-            const uploadProgress = (loaded / total) * 100; // 0-100% upload
-            const progressMessage: UploadProgressMessage = {
-              type: 'progress',
-              phase: 'uploading',
-              progress: uploadProgress
-            };
-            ctx.postMessage(progressMessage);
-          }
-        );
-      } else {
-        throw new Error(`Unsupported provider: ${provider}`);
+      if (!credentials) {
+        throw new Error(`Missing ${provider} worker credentials`);
       }
+      const cloudProvider = getWorkerCloudProvider(provider);
+      const filename = `${volumeTitle}.cbz`;
+      const fileId = await cloudProvider.uploadFile({
+        seriesTitle,
+        filename,
+        blob: cbzBlob,
+        credentials,
+        mimeType: 'application/x-cbz',
+        onProgress: (loaded, total) => {
+          const uploadProgress = total > 0 ? (loaded / total) * 100 : 0;
+          const progressMessage: UploadProgressMessage = {
+            type: 'progress',
+            phase: 'uploading',
+            progress: uploadProgress
+          };
+          ctx.postMessage(progressMessage);
+        }
+      });
 
       // Send completion message
       const completeMessage: UploadCompleteMessage = {
@@ -1391,83 +772,102 @@ ctx.addEventListener('message', async (event) => {
         console.log(`Worker: Returning compressed data for download`);
         const cbzArrayBuffer = await cbzBlob.arrayBuffer();
         const cbzData = new Uint8Array(cbzArrayBuffer);
+        let sidecars:
+          | {
+              mokuro?: { filename: string; blob: Blob };
+              thumbnail?: { filename: string; blob: Blob };
+            }
+          | undefined;
+        if (message.includeSidecars === true) {
+          const generated = await generateVolumeSidecarsFromDb(volumeUuid);
+          if (generated.mokuro || generated.thumbnail) {
+            sidecars = {};
+            if (generated.mokuro) {
+              sidecars.mokuro = generated.mokuro;
+            }
+            if (generated.thumbnail) {
+              sidecars.thumbnail = generated.thumbnail;
+            }
+          }
+        }
         const completeMessage: UploadCompleteMessage = {
           type: 'complete',
           data: cbzData,
-          filename: downloadFilename || `${volumeTitle}.cbz`
+          filename: downloadFilename || `${volumeTitle}.cbz`,
+          sidecars
         };
         ctx.postMessage(completeMessage, [cbzData.buffer]);
         console.log(`Worker: Export complete for ${volumeTitle}`);
       } else {
         // Upload to cloud provider
-        let fileId: string;
+        if (!credentials) {
+          throw new Error(`Missing ${provider} worker credentials`);
+        }
+        const cloudProvider = getWorkerCloudProvider(provider);
         const filename = `${volumeTitle}.cbz`;
 
-        if (provider === 'google-drive') {
-          if (!credentials?.accessToken || !credentials?.seriesFolderId) {
-            throw new Error('Missing Google Drive access token or series folder ID');
-          }
-          fileId = await uploadToGoogleDrive(
-            cbzBlob,
-            filename,
-            credentials.seriesFolderId,
-            credentials.accessToken,
-            (loaded, total) => {
-              const progressMessage: UploadProgressMessage = {
-                type: 'progress',
-                phase: 'uploading',
-                progress: (loaded / total) * 100
-              };
-              ctx.postMessage(progressMessage);
-            }
-          );
-        } else if (provider === 'webdav') {
-          // Use shared WebDAV upload utility
-          if (!credentials?.webdavUrl) {
-            throw new Error('Missing WebDAV URL');
-          }
-          fileId = await uploadToWebDAV(
-            credentials.webdavUrl,
-            credentials.webdavUsername ?? '',
-            credentials.webdavPassword ?? '',
+        const uploadSidecar = async (sidecarFilename: string, sidecarBlob: Blob): Promise<void> => {
+          await cloudProvider.uploadFile({
             seriesTitle,
-            filename,
-            cbzBlob,
-            (loaded, total) => {
-              const progressMessage: UploadProgressMessage = {
-                type: 'progress',
-                phase: 'uploading',
-                progress: (loaded / total) * 100
-              };
-              ctx.postMessage(progressMessage);
-            }
-          );
-        } else if (provider === 'mega') {
-          if (!credentials?.megaEmail || !credentials?.megaPassword) {
-            throw new Error('Missing MEGA credentials');
+            filename: sidecarFilename,
+            blob: sidecarBlob,
+            credentials,
+            mimeType: sidecarBlob.type || 'application/octet-stream'
+          });
+        };
+
+        if (message.includeSidecars === true) {
+          const generatedSidecars = await generateVolumeSidecarsFromDb(volumeUuid);
+          const sidecarsToUpload: Array<{ filename: string; blob: Blob }> = [];
+          if (generatedSidecars.mokuro) {
+            sidecarsToUpload.push(generatedSidecars.mokuro);
           }
-          fileId = await uploadToMEGA(
-            cbzBlob,
-            filename,
-            seriesTitle,
-            credentials.megaEmail,
-            credentials.megaPassword,
-            (loaded, total) => {
-              const progressMessage: UploadProgressMessage = {
-                type: 'progress',
-                phase: 'uploading',
-                progress: (loaded / total) * 100
-              };
-              ctx.postMessage(progressMessage);
+          if (generatedSidecars.thumbnail) {
+            sidecarsToUpload.push(generatedSidecars.thumbnail);
+          }
+
+          if (sidecarsToUpload.length > 0) {
+            const sidecarProgressMessage: UploadProgressMessage = {
+              type: 'progress',
+              phase: 'sidecars',
+              progress: 100
+            };
+
+            ctx.postMessage(sidecarProgressMessage);
+            for (const sidecar of sidecarsToUpload) {
+              console.log(`Worker: Uploading sidecar ${sidecar.filename}...`);
+              await uploadSidecar(sidecar.filename, sidecar.blob);
+              ctx.postMessage(sidecarProgressMessage);
             }
-          );
-        } else {
-          throw new Error(`Unsupported provider: ${provider}`);
+          }
         }
+
+        ctx.postMessage({
+          type: 'progress',
+          phase: 'uploading',
+          progress: 0
+        } satisfies UploadProgressMessage);
+
+        const fileId = await cloudProvider.uploadFile({
+          seriesTitle,
+          filename,
+          blob: cbzBlob,
+          credentials,
+          mimeType: 'application/x-cbz',
+          onProgress: (loaded, total) => {
+            const progressMessage: UploadProgressMessage = {
+              type: 'progress',
+              phase: 'uploading',
+              progress: total > 0 ? (loaded / total) * 100 : 0
+            };
+            ctx.postMessage(progressMessage);
+          }
+        });
 
         const completeMessage: UploadCompleteMessage = {
           type: 'complete',
-          fileId
+          fileId,
+          size: cbzBlob.size
         };
         ctx.postMessage(completeMessage);
         console.log(`Worker: Backup complete for ${volumeTitle}`);


### PR DESCRIPTION
## Summary

Release v1.5.0 — see [CHANGELOG.md](CHANGELOG.md) for full details.

### Added
- WebDAV download retry with resume support
- Automatic OCR from mokuro-bunko — image-only volumes get text data on refresh
- Catalog drop shadow toggle for spine showcase mode
- Delete cloud-only series without downloading
- Volume keyboard shortcuts (E, C, Delete, Shift+Delete)
- Cover page stitching for spread artwork
- Cover picker rotation and cloud sync
- Escape closes editor and cover picker modals

### Changed
- Smarter series grouping by title instead of internal ID

### Fixed
- Dual page cover handling
- AnkiConnect page numbers, tags on mobile, and card update formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)