### PR TITLE
fix: normalize WebDAV file listing paths

### DIFF
--- a/src/lib/util/sync/providers/webdav/webdav-provider.test.ts
+++ b/src/lib/util/sync/providers/webdav/webdav-provider.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../core/cloud-provider-core-registry', () => ({
+  getCloudProviderCore: vi.fn(() => ({
+    downloadFile: vi.fn(),
+    uploadFile: vi.fn()
+  }))
+}));
+
+vi.mock('../../provider-detection', () => ({
+  setActiveProviderKey: vi.fn(),
+  clearActiveProviderKey: vi.fn()
+}));
+
+describe('WebDAVProvider listing normalization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('normalizes depth-infinity listings into canonical cache paths', async () => {
+    const { WebDAVProvider } = await import('./webdav-provider');
+    const provider = new WebDAVProvider();
+
+    const client = {
+      exists: vi.fn(async () => true),
+      getDirectoryContents: vi.fn(async (_path: string, options?: { deep?: boolean }) => {
+        expect(_path).toBe('/mokuro-reader');
+        expect(options).toEqual({ deep: true });
+
+        return [
+          {
+            type: 'file',
+            filename: 'http://localhost:8080/mokuro-reader/volume-data.json',
+            basename: 'volume-data.json',
+            lastmod: '2026-03-13T00:00:00.000Z',
+            size: 42
+          },
+          {
+            type: 'file',
+            filename: 'http://localhost:8080/mokuro-reader/Series%20Name/Vol%201.cbz',
+            basename: 'Vol 1.cbz',
+            lastmod: '2026-03-13T00:00:01.000Z',
+            size: 128
+          }
+        ];
+      })
+    };
+
+    (provider as any).client = client;
+
+    const files = await provider.listCloudVolumes();
+
+    expect(files).toEqual([
+      {
+        provider: 'webdav',
+        fileId: '/mokuro-reader/volume-data.json',
+        path: 'volume-data.json',
+        modifiedTime: '2026-03-13T00:00:00.000Z',
+        size: 42
+      },
+      {
+        provider: 'webdav',
+        fileId: '/mokuro-reader/Series Name/Vol 1.cbz',
+        path: 'Series Name/Vol 1.cbz',
+        modifiedTime: '2026-03-13T00:00:01.000Z',
+        size: 128
+      }
+    ]);
+  });
+
+  it('normalizes recursive listings into canonical cache paths', async () => {
+    const { WebDAVProvider } = await import('./webdav-provider');
+    const provider = new WebDAVProvider();
+
+    const client = {
+      exists: vi.fn(async () => true),
+      getDirectoryContents: vi.fn(async (path: string) => {
+        if (path === '/mokuro-reader') {
+          return [
+            {
+              type: 'directory',
+              filename: 'http://localhost:8080/mokuro-reader/Series%20Name',
+              basename: 'Series Name',
+              lastmod: '2026-03-13T00:00:00.000Z',
+              size: 0
+            },
+            {
+              type: 'file',
+              filename: 'http://localhost:8080/mokuro-reader/profiles.json',
+              basename: 'profiles.json',
+              lastmod: '2026-03-13T00:00:02.000Z',
+              size: 64
+            }
+          ];
+        }
+
+        if (path === '/mokuro-reader/Series Name') {
+          return [
+            {
+              type: 'file',
+              filename: 'http://localhost:8080/mokuro-reader/Series%20Name/Vol%201.cbz',
+              basename: 'Vol 1.cbz',
+              lastmod: '2026-03-13T00:00:03.000Z',
+              size: 256
+            }
+          ];
+        }
+
+        throw new Error(`Unexpected path: ${path}`);
+      })
+    };
+
+    (provider as any).client = client;
+    (provider as any)._supportsDepthInfinity = false;
+
+    const files = await provider.listCloudVolumes();
+
+    expect(files).toEqual([
+      {
+        provider: 'webdav',
+        fileId: '/mokuro-reader/Series Name/Vol 1.cbz',
+        path: 'Series Name/Vol 1.cbz',
+        modifiedTime: '2026-03-13T00:00:03.000Z',
+        size: 256
+      },
+      {
+        provider: 'webdav',
+        fileId: '/mokuro-reader/profiles.json',
+        path: 'profiles.json',
+        modifiedTime: '2026-03-13T00:00:02.000Z',
+        size: 64
+      }
+    ]);
+  });
+});

--- a/src/lib/util/sync/providers/webdav/webdav-provider.ts
+++ b/src/lib/util/sync/providers/webdav/webdav-provider.ts
@@ -480,6 +480,79 @@ export class WebDAVProvider implements SyncProvider {
     }
   }
 
+  private normalizeListedPath(filename: string): string | null {
+    if (!filename) {
+      return null;
+    }
+
+    let pathname = filename;
+    try {
+      pathname = new URL(filename).pathname;
+    } catch {
+      // Not a full URL - treat as a path-like value.
+    }
+
+    const decodedSegments = pathname
+      .split('/')
+      .filter((segment) => segment.length > 0)
+      .map((segment) => {
+        try {
+          return decodeURIComponent(segment);
+        } catch {
+          return segment;
+        }
+      });
+
+    if (decodedSegments.length === 0) {
+      return MOKURO_FOLDER;
+    }
+
+    const rootSegment = MOKURO_FOLDER.slice(1);
+    const rootIndex = decodedSegments.indexOf(rootSegment);
+    const normalizedSegments =
+      rootIndex >= 0 ? decodedSegments.slice(rootIndex) : [rootSegment, ...decodedSegments];
+
+    return `/${normalizedSegments.join('/')}`;
+  }
+
+  private toRelativeCloudPath(filename: string): string | null {
+    const normalizedPath = this.normalizeListedPath(filename);
+    if (!normalizedPath) {
+      return null;
+    }
+
+    if (normalizedPath === MOKURO_FOLDER) {
+      return '';
+    }
+
+    if (!normalizedPath.startsWith(`${MOKURO_FOLDER}/`)) {
+      return null;
+    }
+
+    return normalizedPath.slice(MOKURO_FOLDER.length + 1);
+  }
+
+  private getTrackedRelativePath(filename: string): string | null {
+    const relativePath = this.toRelativeCloudPath(filename);
+    if (!relativePath) {
+      return null;
+    }
+
+    const lowerName = relativePath.split('/').pop()?.toLowerCase() || '';
+    if (
+      lowerName.endsWith('.cbz') ||
+      lowerName.endsWith('.mokuro') ||
+      lowerName.endsWith('.mokuro.gz') ||
+      lowerName.endsWith('.webp') ||
+      lowerName === 'volume-data.json' ||
+      lowerName === 'profiles.json'
+    ) {
+      return relativePath;
+    }
+
+    return null;
+  }
+
   // GENERIC FILE OPERATIONS
 
   async listCloudVolumes(): Promise<import('../../provider-interface').CloudFileMetadata[]> {
@@ -547,26 +620,20 @@ export class WebDAVProvider implements SyncProvider {
         }>;
 
         for (const item of contents) {
+          const normalizedPath = this.normalizeListedPath(item.filename);
+          if (!normalizedPath) {
+            continue;
+          }
+
           if (item.type === 'directory') {
             // Recurse into subdirectories
-            await processFolder(item.filename);
+            await processFolder(normalizedPath);
           } else {
-            const name = item.basename.toLowerCase();
-            // Include CBZ files, sidecars, and JSON config files
-            if (
-              name.endsWith('.cbz') ||
-              name.endsWith('.mokuro') ||
-              name.endsWith('.mokuro.gz') ||
-              name.endsWith('.webp') ||
-              item.basename === 'volume-data.json' ||
-              item.basename === 'profiles.json'
-            ) {
-              // Build relative path from mokuro folder
-              const relativePath = item.filename.replace(MOKURO_FOLDER + '/', '');
-
+            const relativePath = this.getTrackedRelativePath(item.filename);
+            if (relativePath) {
               allFiles.push({
                 provider: 'webdav',
-                fileId: item.filename, // Full WebDAV path as fileId
+                fileId: `${MOKURO_FOLDER}/${relativePath}`,
                 path: relativePath,
                 modifiedTime: item.lastmod || new Date().toISOString(),
                 size: item.size || 0
@@ -613,22 +680,11 @@ export class WebDAVProvider implements SyncProvider {
 
     for (const item of contents) {
       if (item.type === 'file') {
-        const name = item.basename.toLowerCase();
-        // Include CBZ files, sidecars, and JSON config files
-        if (
-          name.endsWith('.cbz') ||
-          name.endsWith('.mokuro') ||
-          name.endsWith('.mokuro.gz') ||
-          name.endsWith('.webp') ||
-          item.basename === 'volume-data.json' ||
-          item.basename === 'profiles.json'
-        ) {
-          // Build relative path from mokuro folder
-          const relativePath = item.filename.replace(MOKURO_FOLDER + '/', '');
-
+        const relativePath = this.getTrackedRelativePath(item.filename);
+        if (relativePath) {
           allFiles.push({
             provider: 'webdav',
-            fileId: item.filename, // Full WebDAV path as fileId
+            fileId: `${MOKURO_FOLDER}/${relativePath}`,
             path: relativePath,
             modifiedTime: item.lastmod || new Date().toISOString(),
             size: item.size || 0


### PR DESCRIPTION
## Summary
- Add path normalization helpers (`normalizeListedPath`, `toRelativeCloudPath`, `getTrackedRelativePath`) to handle inconsistent WebDAV server responses
- Handles full URLs, URL-encoded paths, and missing root folder prefixes
- Filters tracked file types to only relevant manga and config files
- New test file covering depth-infinity and recursive listing scenarios

## Test plan
- [ ] Run `npm test` to verify WebDAV provider tests pass
- [ ] Test sync with a WebDAV server that returns full URLs in listings
- [ ] Test sync with a WebDAV server that URL-encodes special characters in paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)