### PR TITLE
fix: auto-refresh sync cache on config file miss

### DIFF
--- a/src/lib/util/sync/unified-sync-service.test.ts
+++ b/src/lib/util/sync/unified-sync-service.test.ts
@@ -1,0 +1,184 @@
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CloudFileMetadata, SyncProvider } from './provider-interface';
+
+const getCache = vi.fn();
+const showSnackbar = vi.fn();
+const addProcess = vi.fn();
+const updateProcess = vi.fn();
+const removeProcess = vi.fn();
+const exportLibraries = vi.fn(() => []);
+
+vi.mock('./cache-manager', () => ({
+  cacheManager: {
+    getCache
+  }
+}));
+
+vi.mock('../snackbar', () => ({
+  showSnackbar
+}));
+
+vi.mock('../progress-tracker', () => ({
+  progressTrackerStore: {
+    addProcess,
+    updateProcess,
+    removeProcess
+  }
+}));
+
+vi.mock('$lib/settings', async () => {
+  const { writable } = await vi.importActual<typeof import('svelte/store')>('svelte/store');
+
+  return {
+    volumesWithTrash: writable<Record<string, any>>({}),
+    profiles: writable<Record<string, any>>({}),
+    profilesWithTrash: writable<Record<string, any>>({}),
+    parseVolumesFromJson: (storedData: string) => JSON.parse(storedData),
+    migrateProfiles: (data: Record<string, any>) => data
+  };
+});
+
+vi.mock('$lib/settings/libraries', async () => {
+  const { writable } = await vi.importActual<typeof import('svelte/store')>('svelte/store');
+
+  return {
+    librariesStore: writable([]),
+    importLibraries: vi.fn(),
+    exportLibraries
+  };
+});
+
+function createWebDAVProvider(
+  downloadFile: (file: CloudFileMetadata) => Promise<Blob>
+): SyncProvider {
+  return {
+    type: 'webdav',
+    name: 'WebDAV',
+    supportsWorkerDownload: true,
+    uploadConcurrencyLimit: 8,
+    downloadConcurrencyLimit: 8,
+    isAuthenticated: () => true,
+    getStatus: () => ({
+      isAuthenticated: true,
+      hasStoredCredentials: true,
+      needsAttention: false,
+      statusMessage: 'Connected'
+    }),
+    login: vi.fn(),
+    logout: vi.fn(),
+    listCloudVolumes: vi.fn(async () => []),
+    uploadFile: vi.fn(async () => '/mokuro-reader/volume-data.json'),
+    downloadFile: vi.fn(downloadFile),
+    deleteFile: vi.fn(),
+    renameFile: vi.fn(),
+    renameFolder: vi.fn(),
+    getStorageQuota: vi.fn(async () => ({
+      used: 0,
+      total: null,
+      available: null
+    }))
+  } as unknown as SyncProvider;
+}
+
+function jsonBlob(data: unknown): Blob {
+  return {
+    text: async () => JSON.stringify(data)
+  } as Blob;
+}
+
+describe('UnifiedSyncService cache refresh on sync JSON miss', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const settings = await import('$lib/settings');
+    settings.volumesWithTrash.set({});
+    settings.profilesWithTrash.set({});
+  });
+
+  it('refreshes the cache before reading volume-data.json', async () => {
+    let cachePrimed = false;
+    const volumeMetadata: CloudFileMetadata = {
+      provider: 'webdav',
+      fileId: '/mokuro-reader/volume-data.json',
+      path: 'volume-data.json',
+      modifiedTime: '2026-03-13T00:00:00.000Z',
+      size: 128
+    };
+    const cache = {
+      getAll: vi.fn((path: string) =>
+        cachePrimed && path === 'volume-data.json' ? [volumeMetadata] : []
+      ),
+      get: vi.fn(() => null),
+      fetch: vi.fn(async () => {
+        cachePrimed = true;
+      })
+    };
+    getCache.mockReturnValue(cache);
+
+    const cloudVolumes = {
+      'vol-1': {
+        progress: 12,
+        lastProgressUpdate: '2026-03-13T00:00:00.000Z'
+      }
+    };
+
+    const provider = createWebDAVProvider(async (file) => {
+      expect(file).toEqual(volumeMetadata);
+      return jsonBlob(cloudVolumes);
+    });
+
+    const { unifiedSyncService } = await import('./unified-sync-service');
+    const result = await unifiedSyncService.syncProvider(provider);
+    const settings = await import('$lib/settings');
+
+    expect(result).toEqual({ provider: 'webdav', success: true });
+    expect(cache.fetch).toHaveBeenCalledTimes(1);
+    expect(provider.downloadFile).toHaveBeenCalledTimes(1);
+    expect(provider.uploadFile).not.toHaveBeenCalled();
+    expect(get(settings.volumesWithTrash)).toEqual(cloudVolumes);
+  });
+
+  it('refreshes the cache before reading profiles.json', async () => {
+    let cachePrimed = false;
+    const profilesMetadata: CloudFileMetadata = {
+      provider: 'webdav',
+      fileId: '/mokuro-reader/profiles.json',
+      path: 'profiles.json',
+      modifiedTime: '2026-03-13T00:00:00.000Z',
+      size: 96
+    };
+    const cache = {
+      getAll: vi.fn(() => []),
+      get: vi.fn((path: string) =>
+        cachePrimed && path === 'profiles.json' ? profilesMetadata : null
+      ),
+      fetch: vi.fn(async () => {
+        cachePrimed = true;
+      })
+    };
+    getCache.mockReturnValue(cache);
+
+    const cloudProfiles = {
+      default: {
+        lastUpdated: '2026-03-13T00:00:00.000Z',
+        defaultFullscreen: true
+      }
+    };
+
+    const provider = createWebDAVProvider(async (file) => {
+      expect(file).toEqual(profilesMetadata);
+      return jsonBlob(cloudProfiles);
+    });
+
+    const { unifiedSyncService } = await import('./unified-sync-service');
+    const result = await unifiedSyncService.downloadProfiles(provider);
+    const settings = await import('$lib/settings');
+
+    expect(result).toEqual(cloudProfiles);
+    expect(cache.fetch).toHaveBeenCalledTimes(1);
+    expect(provider.downloadFile).toHaveBeenCalledWith(profilesMetadata);
+    settings.profilesWithTrash.set(result || {});
+    expect(get(settings.profilesWithTrash)).toEqual(cloudProfiles);
+  });
+});

--- a/src/lib/util/sync/unified-sync-service.ts
+++ b/src/lib/util/sync/unified-sync-service.ts
@@ -303,7 +303,15 @@ class UnifiedSyncService {
     reloadCacheOnFileNotFound = true
   ): Promise<any | null> {
     try {
-      const volumeDataFiles = await this.findVolumeDataFiles(provider);
+      let volumeDataFiles = this.findVolumeDataFiles(provider);
+
+      if (volumeDataFiles.length === 0) {
+        const cache = cacheManager.getCache(provider.type);
+        if (cache) {
+          await cache.fetch();
+          volumeDataFiles = this.findVolumeDataFiles(provider);
+        }
+      }
 
       if (volumeDataFiles.length === 0) {
         return null;
@@ -429,7 +437,16 @@ class UnifiedSyncService {
   private async downloadProfilesFile(provider: SyncProvider): Promise<any | null> {
     try {
       console.log('🔎 Finding profiles.json in cache...');
-      const profilesFile = await this.findProfilesFile(provider);
+      let profilesFile = this.findProfilesFile(provider);
+
+      if (!profilesFile) {
+        const cache = cacheManager.getCache(provider.type);
+        if (cache) {
+          await cache.fetch();
+          profilesFile = this.findProfilesFile(provider);
+        }
+      }
+
       console.log('🔎 findProfilesFile result:', profilesFile);
 
       if (!profilesFile) {
@@ -745,7 +762,16 @@ class UnifiedSyncService {
   private async downloadLibrariesFile(provider: SyncProvider): Promise<LibraryConfig[] | null> {
     try {
       console.log('🔎 Finding libraries.json in cache...');
-      const librariesFile = this.findLibrariesFile(provider);
+      let librariesFile = this.findLibrariesFile(provider);
+
+      if (!librariesFile) {
+        const cache = cacheManager.getCache(provider.type);
+        if (cache) {
+          await cache.fetch();
+          librariesFile = this.findLibrariesFile(provider);
+        }
+      }
+
       console.log('🔎 findLibrariesFile result:', librariesFile);
 
       if (!librariesFile) {


### PR DESCRIPTION
## Summary
- Add automatic cache refresh when `findVolumeDataFiles()`, `findProfilesFile()`, or `findLibrariesFile()` return empty
- On cache miss, fetches fresh file listing from the provider and retries the lookup
- Fixes sync silently skipping config files when cache is stale or empty
- New test file verifying the refresh-and-retry behavior

## Test plan
- [ ] Run `npm test` to verify unified sync service tests pass
- [ ] Test sync with a fresh/empty cache — config files should be found after auto-refresh
- [ ] Test sync with populated cache — no unnecessary extra fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)