### PR TITLE
fix: disable page swipes when Anki modal is open

### DIFF
--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -31,6 +31,7 @@
   import MangaPage from './MangaPage.svelte';
   import TextBoxContextMenu from './TextBoxContextMenu.svelte';
   import {
+    cropperStore,
     openCreateModal,
     openUpdateModal,
     sendQuickCapture,
@@ -474,6 +475,7 @@
 
   function handleTouchStart(event: TouchEvent) {
     if (!$settings.mobile) return;
+    if ($cropperStore?.open) return;
     if ($settings.continuousScroll) return; // Continuous mode handles its own touch
     if (event.touches.length > 1) return; // Ignore multi-touch starts
 
@@ -494,6 +496,7 @@
   function handlePointerUp(event: TouchEvent) {
     if (!$settings.mobile) return;
     if ($settings.continuousScroll) return; // Continuous mode handles its own touch
+    if ($cropperStore?.open) return; // Don't process swipes when Anki modal is open
 
     // If fingers remain, this was a multi-touch gesture - mark it and wait
     if (event.touches.length !== 0) {


### PR DESCRIPTION
## Summary
- Adds an early return in `handleTouchStart` and `handlePointerUp` that skips swipe processing when the Anki modal (`cropperStore.open`) is active
- Prevents pages from flipping while the user interacts with the crop box or scrolls within the Update/Create Card modal on touchscreens

Closes #189

## Test plan
- [x] Type-check passes
- [x] Mobile: open Update Card modal, drag crop box horizontally — page should not flip
- [x] Mobile: close modal, confirm swipes still flip pages normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)