### PR TITLE
fix(pwa): add viewport-fit=cover for Android fullscreen

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -6,7 +6,7 @@
     <link rel="manifest" crossorigin="use-credentials" href="manifest.json" />
     <meta
       name="viewport"
-      content="width=device-width, height=device-height,initial-scale=1, minimum-scale=1, user-scalable=no"
+      content="width=device-width, height=device-height,initial-scale=1, minimum-scale=1, user-scalable=no, viewport-fit=cover"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
- Adds `viewport-fit=cover` to the viewport meta tag so page content can extend into Android safe-area / status-bar regions when manifest `display: fullscreen` falls back to `standalone`.
- Speculative fix for #211 — black bar at top of PWA on a specific Android device. Issue could not be reproduced on other devices, so this needs device testing by the reporter to confirm.

## Notes
- If standalone is still being rendered with a real OS status bar (not just safe-area inset), this won't fix it. In that case the next step would be requesting fullscreen via the JS Fullscreen API on user gesture, but that's a larger change and worth holding until we see whether this lands the fix.

## Test plan
- [ ] Reporter tests on the affected Android device in PWA mode (landscape, two-page).
- [ ] Confirm no regressions on desktop / iOS / Android browsers where the issue did not reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)