### PR TITLE
Release v1.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.5.8] - 2026-05-16
+
+### Added
+
+- **`{cover}` Anki template variable** - Include the volume cover image in Anki cards alongside `{image}`, targeting a separate field (#205)
+- **Reverse alphabetical volume sort** - Sort volumes Z–A in addition to A–Z
+- **Page index DOM attribute** - The reader exposes `data-page-index` on each page so extensions (e.g. GSM stats) can read the current page without traversing styles (#207)
+
+### Fixed
+
+- **Swipe-to-flip while panning a zoomed page** - A vigorous pan past the edge of a zoomed page could silently flip the page. The swipe now only flips when the relevant edge was already visible at touch start (#186)
+- **WebP thumbnails for archive-extracted pages** - Thumbnails from CBZ/ZIP imports were silently falling back to JPEG because extracted `File` objects had no mime type. Generation is now always WebP regardless of source
+- **MEGA duplicate series/root folders under parallel uploads** - Folder creation is now serialized per path, preventing duplicates when multiple uploads race
+- **MEGA folder deduplication** - The deduplicator now runs for MEGA (previously Drive-only) and loops to convergence so late-pass leftovers no longer remain
+
 ## [1.5.7] - 2026-03-20
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mokuro-reader",
-  "version": "1.5.3",
+  "version": "1.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mokuro-reader",
-      "version": "1.5.3",
+      "version": "1.5.7",
       "dependencies": {
         "@types/gapi": "^0.0.47",
         "@vercel/analytics": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mokuro-reader",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/anki-connect/index.ts
+++ b/src/lib/anki-connect/index.ts
@@ -26,6 +26,7 @@ export const FIELD_TEMPLATES = [
   { template: '{selection}', description: 'Selected/highlighted text' },
   { template: '{sentence}', description: 'Full sentence/textbox content' },
   { template: '{image}', description: 'Screenshot image' },
+  { template: '{cover}', description: 'Volume cover image' },
   { template: '{series}', description: 'Series title' },
   { template: '{volume}', description: 'Volume title' },
   { template: '{page_num}', description: 'Current page number' },
@@ -41,6 +42,7 @@ export const DYNAMIC_TAGS = [
 export type VolumeMetadata = {
   seriesTitle?: string;
   volumeTitle?: string;
+  coverImage?: string; // Base64 data URL of the volume cover/thumbnail
 };
 
 /**
@@ -59,7 +61,11 @@ function sanitizeForFilename(str: string): string {
  * Generates a descriptive image filename from metadata.
  * Format: mokuro_{series}_{volume}_{page}.jpg
  */
-export function generateImageFilename(metadata?: VolumeMetadata, pageFilename?: string): string {
+export function generateImageFilename(
+  metadata?: VolumeMetadata,
+  pageFilename?: string,
+  isCover?: boolean
+): string {
   const parts = ['mokuro'];
 
   if (metadata?.seriesTitle) {
@@ -68,7 +74,9 @@ export function generateImageFilename(metadata?: VolumeMetadata, pageFilename?: 
   if (metadata?.volumeTitle) {
     parts.push(sanitizeForFilename(metadata.volumeTitle));
   }
-  if (pageFilename) {
+  if (isCover) {
+    parts.push('cover');
+  } else if (pageFilename) {
     parts.push(sanitizeForFilename(pageFilename));
   }
 
@@ -132,8 +140,8 @@ export function resolveTemplate(
   sentence?: string,
   options?: ResolveTemplateOptions
 ): string | null {
-  if (!template || template === '{image}') {
-    return null; // {image} is handled specially, not as text
+  if (!template || template === '{image}' || template === '{cover}') {
+    return null; // {image} and {cover} are handled specially as picture parameters, not as text
   }
 
   let resolved = template;
@@ -713,11 +721,15 @@ export async function createCard(
   // Use provided field mappings (from modal) or fall back to saved config
   const fieldMappings = options?.fieldMappings || config.fieldMappings;
 
-  // Find fields that use {image} - these will receive the picture via AnkiConnect's picture parameter
+  // Find fields that use {image} or {cover} - these will receive pictures via AnkiConnect's picture parameter
   const imageFields: string[] = [];
+  const coverFields: string[] = [];
   for (const mapping of fieldMappings) {
     if (mapping.template?.includes('{image}')) {
       imageFields.push(mapping.fieldName);
+    }
+    if (mapping.template?.includes('{cover}')) {
+      coverFields.push(mapping.fieldName);
     }
   }
 
@@ -732,28 +744,39 @@ export async function createCard(
   }
 
   // Build fields object from field mappings
-  // For fields with {image}, we resolve without the image (AnkiConnect will insert it)
+  // For fields with {image}/{cover}, we resolve without them (AnkiConnect will insert the pictures)
   const fields: Record<string, string> = {};
 
   for (const mapping of fieldMappings) {
     if (!mapping.template) continue;
 
-    // Remove {image} from template - AnkiConnect's picture parameter handles image insertion
-    const templateWithoutImage = mapping.template.replace(/\{image\}/g, '');
+    // Remove {image} and {cover} from template - AnkiConnect's picture parameter handles image insertion
+    const templateWithoutImages = mapping.template
+      .replace(/\{image\}/g, '')
+      .replace(/\{cover\}/g, '');
 
-    const resolved = resolveTemplate(templateWithoutImage, metadata || {}, selectedText, sentence, {
-      pageNumber: options?.pageNumber,
-      previousValues: options?.previousValues,
-      fieldName: mapping.fieldName
-    });
+    const resolved = resolveTemplate(
+      templateWithoutImages,
+      metadata || {},
+      selectedText,
+      sentence,
+      {
+        pageNumber: options?.pageNumber,
+        previousValues: options?.previousValues,
+        fieldName: mapping.fieldName
+      }
+    );
     if (resolved) {
       fields[mapping.fieldName] = resolved;
     }
   }
 
   // Ensure we have at least one non-empty field (excluding image-only fields)
-  const nonImageFields = Object.keys(fields).filter((f) => !imageFields.includes(f) || fields[f]);
-  if (nonImageFields.length === 0 && imageFields.length === 0) {
+  const allPictureFields = [...new Set([...imageFields, ...coverFields])];
+  const nonImageFields = Object.keys(fields).filter(
+    (f) => !allPictureFields.includes(f) || fields[f]
+  );
+  if (nonImageFields.length === 0 && allPictureFields.length === 0) {
     showSnackbar('Error: No fields would be populated. Check your field mappings.');
     return;
   }
@@ -767,15 +790,30 @@ export async function createCard(
     }
   };
 
-  // Add picture using AnkiConnect's built-in picture parameter (works on desktop and Android)
+  // Add pictures using AnkiConnect's built-in picture parameter (works on desktop and Android)
+  const pictures: Array<{ filename: string; data: string; fields: string[] }> = [];
+
   if (imageFields.length > 0) {
-    notePayload.picture = [
-      {
-        filename: imageFilename,
-        data: base64Data,
-        fields: imageFields
-      }
-    ];
+    pictures.push({
+      filename: imageFilename,
+      data: base64Data,
+      fields: imageFields
+    });
+  }
+
+  if (coverFields.length > 0 && metadata?.coverImage) {
+    const coverBase64 = metadata.coverImage.split(';base64,')[1];
+    if (coverBase64) {
+      pictures.push({
+        filename: generateImageFilename(metadata, undefined, true),
+        data: coverBase64,
+        fields: coverFields
+      });
+    }
+  }
+
+  if (pictures.length > 0) {
+    notePayload.picture = pictures;
   }
 
   // Only add tags if non-empty
@@ -924,11 +962,15 @@ export async function updateLastCard(
     return;
   }
 
-  // Find fields that use {image} - these will receive the picture via AnkiConnect's picture parameter
+  // Find fields that use {image} or {cover} - these will receive pictures via AnkiConnect's picture parameter
   const imageFields: string[] = [];
+  const coverFields: string[] = [];
   for (const mapping of fieldMappings) {
     if (mapping.template?.includes('{image}')) {
       imageFields.push(mapping.fieldName);
+    }
+    if (mapping.template?.includes('{cover}')) {
+      coverFields.push(mapping.fieldName);
     }
   }
 
@@ -943,18 +985,21 @@ export async function updateLastCard(
   }
 
   // Build fields object from field mappings
-  // For fields with {image}, we resolve without the image (AnkiConnect will insert it)
+  // For fields with {image}/{cover}, we resolve without them (AnkiConnect will insert the pictures)
   const fields: Record<string, any> = {};
+  const allPictureFields = [...new Set([...imageFields, ...coverFields])];
 
   for (const mapping of fieldMappings) {
     if (!mapping.template) continue;
 
-    // Remove {image} from template - AnkiConnect's picture parameter handles image insertion
-    const templateWithoutImage = mapping.template.replace(/\{image\}/g, '');
+    // Remove {image} and {cover} from template - AnkiConnect's picture parameter handles image insertion
+    const templateWithoutImages = mapping.template
+      .replace(/\{image\}/g, '')
+      .replace(/\{cover\}/g, '');
 
     // Resolve text content
     const resolved = resolveTemplate(
-      templateWithoutImage,
+      templateWithoutImages,
       metadata || {},
       options?.selectedText,
       sentence,
@@ -965,9 +1010,9 @@ export async function updateLastCard(
       }
     );
 
-    // For image fields: if template resolves to empty (e.g., just "{image}"),
+    // For picture fields: if template resolves to empty (e.g., just "{image}" or "{cover}"),
     // we must explicitly clear the field first so the new image replaces rather than appends
-    if (imageFields.includes(mapping.fieldName)) {
+    if (allPictureFields.includes(mapping.fieldName)) {
       fields[mapping.fieldName] = resolved || '';
     } else if (resolved) {
       fields[mapping.fieldName] = resolved;
@@ -980,13 +1025,30 @@ export async function updateLastCard(
       fields
     };
 
-    // Add picture using AnkiConnect's built-in picture parameter (works on desktop and Android)
+    // Add pictures using AnkiConnect's built-in picture parameter (works on desktop and Android)
+    const pictures: Array<{ filename: string; data: string; fields: string[] }> = [];
+
     if (imageFields.length > 0) {
-      noteUpdate.picture = {
+      pictures.push({
         filename: imageFilename,
         data: base64Data,
         fields: imageFields
-      };
+      });
+    }
+
+    if (coverFields.length > 0 && metadata?.coverImage) {
+      const coverBase64 = metadata.coverImage.split(';base64,')[1];
+      if (coverBase64) {
+        pictures.push({
+          filename: generateImageFilename(metadata, undefined, true),
+          data: coverBase64,
+          fields: coverFields
+        });
+      }
+    }
+
+    if (pictures.length > 0) {
+      noteUpdate.picture = pictures;
     }
 
     const updateResult = await ankiConnect('updateNoteFields', { note: noteUpdate });

--- a/src/lib/catalog/cloud-thumbnails.ts
+++ b/src/lib/catalog/cloud-thumbnails.ts
@@ -35,11 +35,19 @@ function releaseFetchSlot(): void {
   if (next) next();
 }
 
+function getThumbnailMime(path: string): string {
+  const lower = path.toLowerCase();
+  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
+  return 'image/webp';
+}
+
 async function downloadThumbnailWithTimeout(volume: VolumeMetadata): Promise<Blob> {
+  const thumbnailPath =
+    volume.cloudThumbnailPath ?? `${volume.series_title}/${volume.volume_title}.webp`;
   const downloadPromise = unifiedCloudManager.downloadFile({
     provider: volume.cloudProvider!,
     fileId: volume.cloudThumbnailFileId!,
-    path: `${volume.series_title}/${volume.volume_title}.webp`,
+    path: thumbnailPath,
     modifiedTime: '',
     size: 0
   });
@@ -95,7 +103,11 @@ export async function fetchCloudThumbnail(
     try {
       const blob = await downloadThumbnailWithTimeout(volume);
 
-      const file = new File([blob], `${volume.volume_title}.webp`, { type: 'image/webp' });
+      const thumbnailPath =
+        volume.cloudThumbnailPath ?? `${volume.series_title}/${volume.volume_title}.webp`;
+      const ext = thumbnailPath.split('.').pop()!.toLowerCase();
+      const mime = getThumbnailMime(thumbnailPath);
+      const file = new File([blob], `${volume.volume_title}.${ext}`, { type: mime });
 
       // Measure dimensions using createImageBitmap (most reliable for pixel dimensions)
       const bitmap = await createImageBitmap(file);

--- a/src/lib/catalog/placeholders.ts
+++ b/src/lib/catalog/placeholders.ts
@@ -130,16 +130,23 @@ export function generatePlaceholders(
     }
   }
 
-  // Flatten Map values into a single array and split out .webp sidecars
+  // Flatten Map values into a single array and split out cover sidecars
   const cloudFiles: CloudVolumeWithProvider[] = [];
-  const thumbnailMap = new Map<string, string>(); // basePath -> fileId
+  const thumbnailMap = new Map<string, { fileId: string; path: string }>(); // basePath -> sidecar info
   const mokuroMap = new Map<string, CloudVolumeWithProvider>(); // basePath -> sidecar metadata
+  const coverExtRegex = /\.(webp|jpe?g)$/i;
   for (const files of cloudFilesMap.values()) {
     for (const file of files) {
       const lowerPath = file.path.toLowerCase();
-      if (lowerPath.endsWith('.webp')) {
-        const basePath = file.path.replace(/\.webp$/i, '');
-        thumbnailMap.set(basePath, file.fileId);
+      const coverMatch = file.path.match(coverExtRegex);
+      if (coverMatch) {
+        const basePath = file.path.slice(0, -coverMatch[0].length);
+        // Prefer .webp over .jpg/.jpeg when both exist for the same base.
+        const existing = thumbnailMap.get(basePath);
+        const isWebp = coverMatch[1].toLowerCase() === 'webp';
+        if (!existing || isWebp) {
+          thumbnailMap.set(basePath, { fileId: file.fileId, path: file.path });
+        }
       } else if (lowerPath.endsWith('.mokuro.gz')) {
         const basePath = file.path.replace(/\.mokuro\.gz$/i, '');
         // Prefer plain .mokuro over .mokuro.gz when both exist.
@@ -173,9 +180,10 @@ export function generatePlaceholders(
     const placeholder = createPlaceholder(cloudFile, seriesUuid);
     if (placeholder) {
       const basePath = cloudFile.path.replace(/\.cbz$/i, '');
-      const thumbnailFileId = thumbnailMap.get(basePath);
-      if (thumbnailFileId) {
-        placeholder.cloudThumbnailFileId = thumbnailFileId;
+      const thumbnailInfo = thumbnailMap.get(basePath);
+      if (thumbnailInfo) {
+        placeholder.cloudThumbnailFileId = thumbnailInfo.fileId;
+        placeholder.cloudThumbnailPath = thumbnailInfo.path;
       }
       placeholders.push(placeholder);
     }

--- a/src/lib/catalog/thumbnails.ts
+++ b/src/lib/catalog/thumbnails.ts
@@ -167,7 +167,7 @@ export async function generateThumbnail(
   destCanvas.width = targetWidth;
   destCanvas.height = targetHeight;
 
-  const mimeType = file.type || 'image/jpeg';
+  const mimeType = 'image/webp';
   const sourcePixels = img.width * img.height;
 
   // On mobile with large images, skip straight to prescale strategy
@@ -228,8 +228,9 @@ export async function generateThumbnail(
     throw new Error('All thumbnail generation strategies failed');
   }
 
+  const baseName = file.name.replace(/\.[^.]+$/, '');
   return {
-    file: new File([blob], `thumbnail_${file.name}`, { type: mimeType }),
+    file: new File([blob], `thumbnail_${baseName}.webp`, { type: mimeType }),
     width: targetWidth,
     height: targetHeight
   };

--- a/src/lib/components/Reader/AnkiFieldModal.svelte
+++ b/src/lib/components/Reader/AnkiFieldModal.svelte
@@ -100,8 +100,11 @@
       vars.push({ template: '{page_filename}', value: store.pageFilename });
     }
 
-    // Image variable
+    // Image variables
     vars.push({ template: '{image}', value: '[current capture]', isImage: true });
+    if (metadata.coverImage) {
+      vars.push({ template: '{cover}', value: '[volume cover]', isImage: true });
+    }
 
     return vars;
   });
@@ -242,6 +245,9 @@
 
     if (template === '{image}') {
       return '[Image]';
+    }
+    if (template === '{cover}') {
+      return '[Cover]';
     }
 
     const resolved = resolveTemplate(

--- a/src/lib/components/Reader/MangaPage.svelte
+++ b/src/lib/components/Reader/MangaPage.svelte
@@ -62,6 +62,7 @@
 
 <div
   draggable="false"
+  data-page-index={pageIndex}
   style:width={`${page.img_width}px`}
   style:height={`${page.img_height}px`}
   style:background-image={url}

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -11,6 +11,7 @@
     zoomDefault,
     zoomDefaultWithLayoutWait,
     zoomFitToScreen,
+    getHorizontalPanEdgeState,
     handleWheel as panzoomHandleWheel
   } from '$lib/panzoom';
   import {
@@ -462,6 +463,12 @@
   let startY = 0;
   let touchStart: Date;
   let lastMultiTouchTime = 0; // Timestamp of last multi-touch event
+  // Pan-edge state captured at the start of a single-finger gesture.
+  // When the user begins a gesture while more content is hidden in a given
+  // direction, we treat any horizontal motion in that direction as a pan
+  // rather than a page-flip swipe (issue #186).
+  let canRevealLeftAtStart = false;
+  let canRevealRightAtStart = false;
 
   function handleTouchStart(event: TouchEvent) {
     if (!$settings.mobile) return;
@@ -473,6 +480,13 @@
     touchStart = new Date();
     startX = clientX;
     startY = clientY;
+
+    // Snapshot how much pannable content exists in each horizontal direction
+    // right now, so that a subsequent swipe can be classified as either a
+    // page-flip (only when already at the relevant edge) or an intra-page pan.
+    const edgeState = getHorizontalPanEdgeState();
+    canRevealLeftAtStart = edgeState.canRevealLeft;
+    canRevealRightAtStart = edgeState.canRevealRight;
   }
 
   function handlePointerUp(event: TouchEvent) {
@@ -502,9 +516,12 @@
     if (isSwipe && touchDuration < 500) {
       const swipeThreshold = ($settings.swipeThreshold / 100) * window.innerWidth;
 
-      if (distanceX > swipeThreshold) {
+      // Only flip if the user was already at the relevant pan edge when the
+      // gesture began. Otherwise the gesture is an intra-page pan and we
+      // leave page navigation alone (issue #186).
+      if (distanceX > swipeThreshold && !canRevealLeftAtStart) {
         left(event, true);
-      } else if (distanceX < -swipeThreshold) {
+      } else if (distanceX < -swipeThreshold && !canRevealRightAtStart) {
         right(event, true);
       }
     }

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -37,8 +37,10 @@
     getCardAgeInMin,
     extractFieldValues,
     getModelConfig,
+    blobToBase64,
     type VolumeMetadata
   } from '$lib/anki-connect';
+  import { db } from '$lib/catalog/db';
   import { showSnackbar } from '$lib/util';
   import {
     BackwardStepSolid,
@@ -966,6 +968,19 @@
       seriesTitle: volume.series_title,
       volumeTitle: volume.volume_title
     };
+
+    // Load cover image for {cover} template support
+    try {
+      const dbVolume = await db.volumes.get(volume.volume_uuid);
+      if (dbVolume?.thumbnail) {
+        const coverImage = await blobToBase64(dbVolume.thumbnail);
+        if (coverImage) {
+          volumeMetadata.coverImage = coverImage;
+        }
+      }
+    } catch {
+      // Continue without cover image
+    }
 
     // Use pre-captured image URL (captured at right-click time for reliability)
     const url = contextMenuData.imageUrl;

--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -12,8 +12,10 @@
     getCardAgeInMin,
     extractFieldValues,
     getModelConfig,
+    blobToBase64,
     type VolumeMetadata
   } from '$lib/anki-connect';
+  import { db } from '$lib/catalog/db';
 
   interface ContextMenuData {
     x: number;
@@ -140,6 +142,22 @@
     seriesTitle: $volumes[volumeUuid]?.series_title,
     volumeTitle: $volumes[volumeUuid]?.volume_title
   });
+
+  // Load volume cover image from DB and add to metadata
+  async function getMetadataWithCover(): Promise<VolumeMetadata> {
+    try {
+      const dbVolume = await db.volumes.get(volumeUuid);
+      if (dbVolume?.thumbnail) {
+        const coverImage = await blobToBase64(dbVolume.thumbnail);
+        if (coverImage) {
+          return { ...volumeMetadata, coverImage };
+        }
+      }
+    } catch {
+      // Fall through to return metadata without cover
+    }
+    return volumeMetadata;
+  }
 
   // Track adjusted font sizes for each textbox
   let adjustedFontSizes = $state<Map<number, string>>(new Map());
@@ -346,6 +364,9 @@
     // Use the explicit pageIndex prop (0-based) when available, otherwise fall back to progress
     const pageNumber = pageIndex != null ? pageIndex + 1 : $volumes[volumeUuid]?.progress || 1;
 
+    // Load cover image for {cover} template support
+    const metadataWithCover = await getMetadataWithCover();
+
     if (cardMode === 'update') {
       // Update mode: fetch previous card values with retry
       const maxRetries = 3;
@@ -406,7 +427,7 @@
           url,
           selectedText || fullSentence,
           fullSentence,
-          volumeMetadata,
+          metadataWithCover,
           textBox,
           previousValues,
           lastCard.noteId,
@@ -426,7 +447,7 @@
           selectedText || fullSentence,
           fullSentence,
           ankiTags,
-          volumeMetadata,
+          metadataWithCover,
           undefined,
           textBox,
           pageNumber,
@@ -445,7 +466,7 @@
           url,
           selectedText || fullSentence,
           fullSentence,
-          volumeMetadata,
+          metadataWithCover,
           textBox,
           undefined, // previousValues
           undefined, // previousCardId
@@ -460,7 +481,7 @@
           selectedText || fullSentence,
           fullSentence,
           ankiTags,
-          volumeMetadata,
+          metadataWithCover,
           undefined,
           textBox,
           pageNumber,

--- a/src/lib/panzoom/util.ts
+++ b/src/lib/panzoom/util.ts
@@ -283,6 +283,47 @@ export function keepInBounds() {
   }
 }
 
+/**
+ * Reports whether there is additional content hidden to the left or right
+ * of the current viewport at the current zoom/pan position.
+ *
+ * - `canRevealLeft`  - there is content further left that is not currently
+ *   visible (the user could drag the image rightward to reveal more).
+ * - `canRevealRight` - there is content further right that is not currently
+ *   visible.
+ *
+ * Used by the mobile swipe handler to distinguish "pan across the page" from
+ * "swipe to flip to the next/previous page" (see issue #186).
+ */
+export function getHorizontalPanEdgeState(): {
+  canRevealLeft: boolean;
+  canRevealRight: boolean;
+} {
+  if (!pz || !container) {
+    return { canRevealLeft: false, canRevealRight: false };
+  }
+  const { x, scale } = pz.getTransform();
+  const width = container.offsetWidth * scale;
+  const { innerWidth } = window;
+
+  // Image fits horizontally - there is nothing to pan to in either direction.
+  if (width <= innerWidth) {
+    return { canRevealLeft: false, canRevealRight: false };
+  }
+
+  // Mirrors keepInBounds()'s x-axis bounds when content overflows the viewport.
+  const minX = innerWidth - width;
+  const maxX = 0;
+  // Small tolerance for sub-pixel pan values so that "within a pixel of the
+  // edge" still counts as at-the-edge.
+  const epsilon = 1;
+
+  return {
+    canRevealLeft: x < maxX - epsilon,
+    canRevealRight: x > minX + epsilon
+  };
+}
+
 export function scrollImage(direction: 'up' | 'down') {
   if (!pz) return;
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -43,7 +43,8 @@ export interface VolumeMetadata {
   cloudModifiedTime?: string;
   cloudSize?: number;
   cloudPath?: string; // Full path for series extraction during download
-  cloudThumbnailFileId?: string; // Provider-specific file ID for cloud thumbnail (.webp)
+  cloudThumbnailFileId?: string; // Provider-specific file ID for cloud thumbnail sidecar
+  cloudThumbnailPath?: string; // Full path to the thumbnail sidecar (e.g. "Series/Volume.webp" or "Series/Volume.jpg")
 
   // Legacy Drive-specific fields (kept for backward compatibility)
   // When present without cloudProvider, assumed to be google-drive

--- a/src/lib/util/sync/folder-deduplicator.ts
+++ b/src/lib/util/sync/folder-deduplicator.ts
@@ -99,38 +99,47 @@ class FolderDeduplicator {
 
     this.runningProviders.add(provider);
 
+    // Cap pass count to prevent runaway loops if a provider keeps reporting duplicates
+    // (e.g., move/delete silently failing). Real-world depth is small.
+    const MAX_PASSES = 20;
+
     try {
-      // Fetch all folders with their parent relationships
-      const folders = await ops.listFolders();
+      for (let pass = 1; pass <= MAX_PASSES; pass++) {
+        const folders = await ops.listFolders();
+        if (folders.length === 0) break;
 
-      if (folders.length === 0) {
-        return result;
+        const duplicateGroups = this.findAllDuplicateGroups(folders);
+        if (duplicateGroups.length === 0) {
+          if (pass === 1) {
+            console.log(`[Dedup:${provider}] No duplicate folders found`);
+          }
+          break;
+        }
+
+        console.log(
+          `[Dedup:${provider}] Pass ${pass}: merging ${duplicateGroups.length} duplicate group(s)`
+        );
+
+        for (const group of duplicateGroups) {
+          const mergeResult = await this.mergeGroup(provider, ops, group);
+          result.groupsMerged++;
+          result.foldersDeleted += mergeResult.foldersDeleted;
+          result.itemsMoved += mergeResult.itemsMoved;
+        }
+
+        if (pass === MAX_PASSES) {
+          console.warn(
+            `[Dedup:${provider}] Hit MAX_PASSES (${MAX_PASSES}); stopping. Duplicates may remain.`
+          );
+        }
       }
 
-      // Find all duplicate groups (same name + same parent)
-      const duplicateGroups = this.findAllDuplicateGroups(folders);
-
-      if (duplicateGroups.length === 0) {
-        console.log(`[Dedup:${provider}] No duplicate folders found`);
-        return result;
+      if (result.groupsMerged > 0) {
+        console.log(
+          `[Dedup:${provider}] Merged ${result.groupsMerged} groups, ` +
+            `deleted ${result.foldersDeleted} folders, moved ${result.itemsMoved} items`
+        );
       }
-
-      console.log(
-        `[Dedup:${provider}] Found ${duplicateGroups.length} duplicate group(s) to merge`
-      );
-
-      // Merge each group
-      for (const group of duplicateGroups) {
-        const mergeResult = await this.mergeGroup(provider, ops, group);
-        result.groupsMerged++;
-        result.foldersDeleted += mergeResult.foldersDeleted;
-        result.itemsMoved += mergeResult.itemsMoved;
-      }
-
-      console.log(
-        `[Dedup:${provider}] Merged ${result.groupsMerged} groups, ` +
-          `deleted ${result.foldersDeleted} folders, moved ${result.itemsMoved} items`
-      );
 
       return result;
     } catch (error) {

--- a/src/lib/util/sync/providers/google-drive/drive-files-cache.ts
+++ b/src/lib/util/sync/providers/google-drive/drive-files-cache.ts
@@ -113,7 +113,7 @@ class DriveFilesCacheManager implements CloudCache<DriveFileMetadata> {
           } else if (
             item.name.endsWith('.mokuro') ||
             item.name.endsWith('.mokuro.gz') ||
-            item.name.endsWith('.webp')
+            /\.(webp|jpe?g)$/i.test(item.name)
           ) {
             sidecarFiles.push(item);
           } else if (item.name === GOOGLE_DRIVE_CONFIG.FILE_NAMES.VOLUME_DATA) {

--- a/src/lib/util/sync/providers/google-drive/google-drive-provider.ts
+++ b/src/lib/util/sync/providers/google-drive/google-drive-provider.ts
@@ -214,7 +214,7 @@ class GoogleDriveProvider implements SyncProvider {
         } else if (
           item.name.endsWith('.mokuro') ||
           item.name.endsWith('.mokuro.gz') ||
-          item.name.endsWith('.webp')
+          /\.(webp|jpe?g)$/i.test(item.name)
         ) {
           sidecarFiles.push(item);
         } else if (
@@ -321,11 +321,14 @@ class GoogleDriveProvider implements SyncProvider {
       const seriesTitle = pathParts.join('/');
 
       // Determine MIME type from extension
-      const mimeType = fileName.endsWith('.json')
+      const lowerFileName = fileName.toLowerCase();
+      const mimeType = lowerFileName.endsWith('.json')
         ? 'application/json'
-        : fileName.endsWith('.webp')
+        : lowerFileName.endsWith('.webp')
           ? 'image/webp'
-          : 'application/x-cbz';
+          : lowerFileName.endsWith('.jpg') || lowerFileName.endsWith('.jpeg')
+            ? 'image/jpeg'
+            : 'application/x-cbz';
 
       // Ensure folder structure exists
       const rootFolderId = await this.ensureReaderFolder();

--- a/src/lib/util/sync/providers/mega/mega-cache.ts
+++ b/src/lib/util/sync/providers/mega/mega-cache.ts
@@ -72,7 +72,33 @@ class MegaCacheManager implements CloudCache<CloudFileMetadata> {
     } finally {
       this.fetchingFlag = false;
       this.isFetchingStore.set(false);
+
+      // Run folder deduplication after cache load (incremental - one pass per call)
+      this.runDeduplication();
     }
+  }
+
+  /**
+   * Run folder deduplication asynchronously after a cache fetch completes.
+   * If duplicates were merged, refetch the cache so it reflects the merged state.
+   */
+  private runDeduplication(): void {
+    // Dynamic import to avoid circular dependency (mega-cache <-> mega-provider).
+    import('../../folder-deduplicator')
+      .then(async ({ folderDeduplicator }) => {
+        if (!megaProvider.isAuthenticated()) return;
+
+        const ops = megaProvider.getFolderOperations();
+        const result = await folderDeduplicator.deduplicateAll('mega', ops);
+
+        if (result.groupsMerged > 0) {
+          console.log('[MegaCache] Dedup merged folders, refetching cache...');
+          await this.fetch(true);
+        }
+      })
+      .catch((err) => {
+        console.error('[MegaCache] Deduplication failed:', err);
+      });
   }
 
   has(path: string): boolean {

--- a/src/lib/util/sync/providers/mega/mega-provider.ts
+++ b/src/lib/util/sync/providers/mega/mega-provider.ts
@@ -11,6 +11,7 @@ import { ProviderError } from '../../provider-interface';
 import { megaCache } from './mega-cache';
 import { cacheManager } from '../../cache-manager';
 import { setActiveProviderKey, clearActiveProviderKey } from '../../provider-detection';
+import type { FolderOperations, FolderInfo, FolderItem } from '../../folder-deduplicator';
 
 interface MegaCredentials {
   email: string;
@@ -145,6 +146,11 @@ export class MegaProvider implements SyncProvider {
   private workerShareLinksToCleanup = new Set<string>();
   private workerShareLinkMutex: Promise<void | { megaShareUrl: string }> = Promise.resolve();
   private static readonly WORKER_SHARE_LINK_THROTTLE_MS = 200;
+
+  // Mutexes preventing concurrent uploads from racing to create the same folder.
+  // Without these, N parallel uploads each find no folder and call mkdir N times.
+  private mokuroFolderPromise: Promise<any> | null = null;
+  private seriesFolderPromises = new Map<string, Promise<any>>();
 
   constructor() {
     if (browser) {
@@ -362,33 +368,49 @@ export class MegaProvider implements SyncProvider {
   }
 
   private async ensureMokuroFolder(): Promise<any> {
-    try {
-      // Always get fresh reference from storage.files to avoid stale references
-      const files = Object.values(this.storage.files || {});
-
-      // Find mokuro-reader folder anywhere, regardless of parent
-      // Note: We don't check parent because MEGA's root folder location varies by account/locale
-      let mokuroFolder = files.find((f: any) => f.name === MOKURO_FOLDER && f.directory);
-
-      if (!mokuroFolder) {
-        // Create folder using storage.mkdir
-        mokuroFolder = await this.createFolder(MOKURO_FOLDER);
-        console.log('Created mokuro-reader folder in MEGA');
-      }
-
-      // Cache for cleanup on logout, but don't use for operations
-      this.mokuroFolder = mokuroFolder;
-
-      // Return fresh reference for immediate use
-      return mokuroFolder;
-    } catch (error) {
-      console.error('ensureMokuroFolder error:', error);
-      throw new ProviderError(
-        `Failed to ensure mokuro folder exists: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        'mega',
-        'FOLDER_ERROR'
-      );
+    // Fast path: folder already exists in storage cache.
+    const existing = this.findMokuroFolder();
+    if (existing) {
+      this.mokuroFolder = existing;
+      return existing;
     }
+
+    // Coalesce concurrent calls so only one mkdir runs.
+    if (this.mokuroFolderPromise) {
+      return this.mokuroFolderPromise;
+    }
+
+    this.mokuroFolderPromise = (async () => {
+      try {
+        // Re-check after acquiring the mutex; another caller may have created it.
+        const recheck = this.findMokuroFolder();
+        if (recheck) {
+          this.mokuroFolder = recheck;
+          return recheck;
+        }
+
+        const folder = await this.createFolder(MOKURO_FOLDER);
+        console.log('Created mokuro-reader folder in MEGA');
+        this.mokuroFolder = folder;
+        return folder;
+      } catch (error) {
+        console.error('ensureMokuroFolder error:', error);
+        throw new ProviderError(
+          `Failed to ensure mokuro folder exists: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          'mega',
+          'FOLDER_ERROR'
+        );
+      } finally {
+        this.mokuroFolderPromise = null;
+      }
+    })();
+
+    return this.mokuroFolderPromise;
+  }
+
+  private findMokuroFolder(): any | null {
+    const files = Object.values(this.storage.files || {});
+    return files.find((f: any) => f.name === MOKURO_FOLDER && f.directory) || null;
   }
 
   private listFolder(folder: any): Promise<any[]> {
@@ -483,10 +505,11 @@ export class MegaProvider implements SyncProvider {
         // Check if file is a CBZ, sidecar, or JSON
         const name = (file as any).name || '';
         const isCbz = name.toLowerCase().endsWith('.cbz');
+        const lowerName = name.toLowerCase();
         const isSidecar =
-          name.toLowerCase().endsWith('.mokuro') ||
-          name.toLowerCase().endsWith('.mokuro.gz') ||
-          name.toLowerCase().endsWith('.webp');
+          lowerName.endsWith('.mokuro') ||
+          lowerName.endsWith('.mokuro.gz') ||
+          /\.(webp|jpe?g)$/i.test(lowerName);
         const isJson = name === 'volume-data.json' || name === 'profiles.json';
 
         if (!isCbz && !isSidecar && !isJson) continue;
@@ -1213,29 +1236,183 @@ export class MegaProvider implements SyncProvider {
    * Ensure a series folder exists (may be nested path like "Series/Subseries")
    */
   private async ensureSeriesFolder(folderPath: string, mokuroFolder: any): Promise<any> {
-    const pathParts = folderPath.split('/').filter(Boolean);
-    let currentFolder = mokuroFolder;
-
-    for (const folderName of pathParts) {
-      // Check if subfolder exists
-      const children = await this.listFolder(currentFolder);
-      let subfolder = children.find((f: any) => f.name === folderName && f.directory);
-
-      if (!subfolder) {
-        // Create subfolder under current folder
-        subfolder = await new Promise((resolve, reject) => {
-          currentFolder.mkdir(folderName, (error: Error | null, folder: any) => {
-            if (error) reject(error);
-            else resolve(folder);
-          });
-        });
-        console.log(`Created folder: ${folderName}`);
-      }
-
-      currentFolder = subfolder;
+    // Coalesce concurrent ensureSeriesFolder calls for the same path so parallel
+    // uploads to one series don't each mkdir the same intermediate folders.
+    const key = folderPath;
+    const inFlight = this.seriesFolderPromises.get(key);
+    if (inFlight) {
+      return inFlight;
     }
 
-    return currentFolder;
+    const promise = (async () => {
+      try {
+        const pathParts = folderPath.split('/').filter(Boolean);
+        let currentFolder = mokuroFolder;
+
+        for (const folderName of pathParts) {
+          const children = await this.listFolder(currentFolder);
+          let subfolder = children.find((f: any) => f.name === folderName && f.directory);
+
+          if (!subfolder) {
+            subfolder = await new Promise((resolve, reject) => {
+              currentFolder.mkdir(folderName, (error: Error | null, folder: any) => {
+                if (error) reject(error);
+                else resolve(folder);
+              });
+            });
+            console.log(`Created folder: ${folderName}`);
+          }
+
+          currentFolder = subfolder;
+        }
+
+        return currentFolder;
+      } finally {
+        this.seriesFolderPromises.delete(key);
+      }
+    })();
+
+    this.seriesFolderPromises.set(key, promise);
+    return promise;
+  }
+
+  private getFileNodeId(file: any): string | null {
+    return file?.nodeId || file?.id || null;
+  }
+
+  /**
+   * MEGA.js mutates node.parent only when the server's 'sc' (state-change) action
+   * stream arrives — the API callback for moveTo/delete fires earlier. Without
+   * waiting for the event, subsequent listFolders() reads stale parent refs and
+   * dedup pass 2 fails to group the now-sibling duplicates.
+   */
+  private waitForNodeEvent(node: any, eventName: string, timeoutMs = 5000): Promise<void> {
+    return new Promise<void>((resolve) => {
+      let done = false;
+      const handler = () => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        if (done) return;
+        done = true;
+        if (typeof node.off === 'function') node.off(eventName, handler);
+        else if (typeof node.removeListener === 'function') node.removeListener(eventName, handler);
+        console.warn(`[MEGA] '${eventName}' event timeout after ${timeoutMs}ms`);
+        resolve();
+      }, timeoutMs);
+      node.once(eventName, handler);
+    });
+  }
+
+  private isInTrash(file: any): boolean {
+    let parent = file?.parent;
+    while (parent) {
+      if (parent.name === 'Rubbish Bin') return true;
+      parent = parent.parent;
+    }
+    return false;
+  }
+
+  private findNodeById(id: string): any | null {
+    const files = Object.values(this.storage?.files || {}) as any[];
+    return files.find((f: any) => this.getFileNodeId(f) === id) || null;
+  }
+
+  /**
+   * FolderOperations interface used by FolderDeduplicator to merge duplicate folders.
+   */
+  getFolderOperations(): FolderOperations {
+    return {
+      rootFolderName: MOKURO_FOLDER,
+
+      listFolders: async (): Promise<FolderInfo[]> => {
+        await this.initPromise;
+        if (!this.storage) return [];
+        const files = Object.values(this.storage.files || {}) as any[];
+
+        const folders: FolderInfo[] = [];
+        for (const f of files) {
+          if (!f.directory) continue;
+          if (this.isInTrash(f)) continue;
+          const id = this.getFileNodeId(f);
+          if (!id) continue;
+          const parentId = f.parent ? this.getFileNodeId(f.parent) : null;
+          folders.push({
+            id,
+            name: f.name,
+            parentId,
+            createdTime: f.timestamp ? new Date(f.timestamp * 1000).toISOString() : undefined
+          });
+        }
+        return folders;
+      },
+
+      listFolderContents: async (folderId: string): Promise<FolderItem[]> => {
+        await this.initPromise;
+        if (!this.storage) return [];
+        const target = this.findNodeById(folderId);
+        if (!target) return [];
+
+        const files = Object.values(this.storage.files || {}) as any[];
+        const items: FolderItem[] = [];
+        for (const f of files) {
+          if (f.parent !== target) continue;
+          const id = this.getFileNodeId(f);
+          if (!id) continue;
+          items.push({ id, name: f.name, isFolder: !!f.directory });
+        }
+        return items;
+      },
+
+      moveItem: async (itemId, newParentId, _oldParentId): Promise<void> => {
+        const item = this.findNodeById(itemId);
+        const newParent = this.findNodeById(newParentId);
+        if (!item) throw new Error(`MEGA dedup: item ${itemId} not found`);
+        if (!newParent) throw new Error(`MEGA dedup: parent ${newParentId} not found`);
+        const stateSynced = this.waitForNodeEvent(item, 'move');
+        await item.moveTo(newParent);
+        await stateSynced;
+      },
+
+      deleteFolder: async (folderId): Promise<void> => {
+        const folder = this.findNodeById(folderId);
+        if (!folder) return;
+        const stateSynced = this.waitForNodeEvent(folder, 'delete');
+        await new Promise<void>((resolve, reject) => {
+          folder.delete(true, (error: Error | null) => {
+            if (error) reject(error);
+            else resolve();
+          });
+        });
+        await stateSynced;
+        // MEGA.js doesn't always remove from storage.files; clean up manually.
+        delete this.storage.files[folderId];
+      },
+
+      deleteFile: async (fileId): Promise<void> => {
+        const file = this.findNodeById(fileId);
+        if (!file) return;
+        const stateSynced = this.waitForNodeEvent(file, 'delete');
+        await new Promise<void>((resolve, reject) => {
+          file.delete(true, (error: Error | null) => {
+            if (error) reject(error);
+            else resolve();
+          });
+        });
+        await stateSynced;
+        delete this.storage.files[fileId];
+      },
+
+      onRootFolderConfirmed: (folderId): void => {
+        const canonical = this.findNodeById(folderId);
+        if (canonical) {
+          this.mokuroFolder = canonical;
+        }
+      }
+    };
   }
 }
 

--- a/src/lib/util/sync/providers/webdav/webdav-provider.ts
+++ b/src/lib/util/sync/providers/webdav/webdav-provider.ts
@@ -557,7 +557,7 @@ export class WebDAVProvider implements SyncProvider {
               name.endsWith('.cbz') ||
               name.endsWith('.mokuro') ||
               name.endsWith('.mokuro.gz') ||
-              name.endsWith('.webp') ||
+              /\.(webp|jpe?g)$/i.test(name) ||
               item.basename === 'volume-data.json' ||
               item.basename === 'profiles.json'
             ) {
@@ -619,7 +619,7 @@ export class WebDAVProvider implements SyncProvider {
           name.endsWith('.cbz') ||
           name.endsWith('.mokuro') ||
           name.endsWith('.mokuro.gz') ||
-          name.endsWith('.webp') ||
+          /\.(webp|jpe?g)$/i.test(name) ||
           item.basename === 'volume-data.json' ||
           item.basename === 'profiles.json'
         ) {
@@ -1006,7 +1006,9 @@ export class WebDAVProvider implements SyncProvider {
       if (lower.endsWith('.cbz')) return path.slice(0, -4);
       if (lower.endsWith('.mokuro.gz')) return path.slice(0, -10);
       if (lower.endsWith('.mokuro')) return path.slice(0, -7);
+      if (lower.endsWith('.jpeg')) return path.slice(0, -5);
       if (lower.endsWith('.webp')) return path.slice(0, -5);
+      if (lower.endsWith('.jpg')) return path.slice(0, -4);
       return path;
     };
 

--- a/src/lib/util/sync/unified-cloud-manager.ts
+++ b/src/lib/util/sync/unified-cloud-manager.ts
@@ -25,7 +25,9 @@ function stripManagedFileExtension(path: string): string {
   if (lower.endsWith('.cbz')) return path.slice(0, -4);
   if (lower.endsWith('.mokuro.gz')) return path.slice(0, -10);
   if (lower.endsWith('.mokuro')) return path.slice(0, -7);
+  if (lower.endsWith('.jpeg')) return path.slice(0, -5);
   if (lower.endsWith('.webp')) return path.slice(0, -5);
+  if (lower.endsWith('.jpg')) return path.slice(0, -4);
   return path;
 }
 

--- a/src/lib/views/SeriesView.svelte
+++ b/src/lib/views/SeriesView.svelte
@@ -136,7 +136,7 @@
   );
 
   // Sort mode state (persisted to localStorage)
-  type SortMode = 'unread-first' | 'alphabetical';
+  type SortMode = 'unread-first' | 'reverse-alphabetical' | 'alphabetical';
   let sortMode = $state<SortMode>(
     (browser && (localStorage.getItem('series-sort-mode') as SortMode)) || 'unread-first'
   );
@@ -154,7 +154,12 @@
   }
 
   function toggleSortMode() {
-    sortMode = sortMode === 'unread-first' ? 'alphabetical' : 'unread-first';
+    sortMode =
+      sortMode === 'unread-first'
+        ? 'alphabetical'
+        : sortMode === 'alphabetical'
+          ? 'reverse-alphabetical'
+          : 'unread-first';
   }
 
   // Reactive sorted volumes - uses currentSeries which handles title/UUID matching
@@ -181,6 +186,11 @@
         if (aComplete !== bComplete) {
           return aComplete ? 1 : -1; // Unread (false) comes before complete (true)
         }
+      } else if (sortMode === 'reverse-alphabetical') {
+        return b.volume_title.localeCompare(a.volume_title, undefined, {
+          numeric: true,
+          sensitivity: 'base'
+        });
       }
 
       // Within same completion status (or alphabetical mode), sort alphabetically
@@ -800,7 +810,15 @@
 
       <Button color="light" onclick={toggleSortMode} class="!min-w-0 self-stretch">
         <SortOutline class="me-2 h-5 w-5 shrink-0" />
-        <span class="break-words">{sortMode === 'unread-first' ? 'Unread first' : 'Default'}</span>
+        <span class="break-words">
+          {#if sortMode === 'unread-first'}
+            Unread first
+          {:else if sortMode === 'reverse-alphabetical'}
+            Reverse default
+          {:else}
+            Default
+          {/if}</span
+        >
       </Button>
 
       <Button color="light" onclick={toggleViewMode} class="!min-w-0 self-stretch">


### PR DESCRIPTION
## Summary

Release v1.5.8 — see CHANGELOG.md for full notes.

### Added
- `{cover}` Anki template variable (#205)
- Reverse alphabetical volume sort
- `data-page-index` DOM attribute on reader pages (#207)

### Fixed
- Swipe-to-flip while panning a zoomed page (#186)
- Thumbnails for archive-extracted pages now always WebP (no silent JPEG fallback)
- MEGA duplicate folder creation under parallel uploads
- MEGA folder deduplication

## Test plan
- [ ] CI passes
- [ ] Release workflow tags v1.5.8 and creates GitHub release on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)