### PR TITLE
fix(reader): restore Migaku popup scroll + multi-line sentence capture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mokuro-reader",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mokuro-reader",
-      "version": "1.5.7",
+      "version": "1.5.8",
       "dependencies": {
         "@types/gapi": "^0.0.47",
         "@vercel/analytics": "^1.5.0",

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -542,20 +542,19 @@
     }
   }
 
-  // Wheel handler wrapper that excludes settings drawer, popovers, and modals
+  // Wheel handler wrapper.
+  // We only intercept wheel events that originate inside our reader content
+  // (the Panzoom wrapper marked with data-mokuro-reader). Anything else —
+  // settings drawer, popovers, dialogs, and extension overlays like Migaku
+  // and Yomitan popups (which inject into <body>, often inside shadow DOM) —
+  // is left alone so the browser's default scroll handling can apply.
   function handleWheelEvent(e: WheelEvent) {
     // In continuous scroll mode, let ContinuousScrollReader handle wheel events
     if ($settings.continuousScroll) return;
 
     const target = e.target as HTMLElement;
-    // Don't capture wheel events from settings drawer, popovers, or modals
-    if (
-      target.closest('#settings') ||
-      target.closest('[data-popover]') ||
-      target.closest('dialog')
-    ) {
-      return;
-    }
+    if (!target.closest('[data-mokuro-reader]')) return;
+
     panzoomHandleWheel(e);
   }
 

--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -553,7 +553,7 @@
     {contenteditable}
   >
     <p>
-      {#each lines as line, i}{line}{#if i < lines.length - 1}<br />{/if}{/each}
+      {#each lines as line}<span class="ocr-line">{line}</span>{/each}
     </p>
   </div>
 {/each}
@@ -623,5 +623,13 @@
 
   .textBox.originalMode p {
     white-space: nowrap;
+  }
+
+  /* Use CSS-generated newline instead of <br/> so DOM walkers
+     (Migaku/Yomitan) see one continuous text node per textbox
+     and don't treat line breaks as sentence boundaries. */
+  .textBox .ocr-line:not(:last-child)::after {
+    content: '\A';
+    white-space: pre;
   }
 </style>

--- a/src/lib/panzoom/Panzoom.svelte
+++ b/src/lib/panzoom/Panzoom.svelte
@@ -8,6 +8,6 @@
   let { children }: Props = $props();
 </script>
 
-<div use:initPanzoom>
+<div use:initPanzoom data-mokuro-reader>
   {@render children?.()}
 </div>


### PR DESCRIPTION
## Summary

Two extension-compat regressions for Migaku users:

- **Migaku popup scroll was eaten by the reader.** The window-level wheel listener intercepted every wheel and called `preventDefault()` unconditionally. Now only wheels originating inside the Panzoom wrapper (marked with `data-mokuro-reader`) are intercepted. Everything outside it — settings drawer, popovers, dialogs, and extension overlays (including closed-shadow-DOM popups) — passes through to the browser's default scroll handling.
- **Migaku "capture sentence" / "read sentence" only saw the hovered line.** OCR lines were separated by `<br/>`, which Migaku treats as a sentence boundary. Lines are now wrapped in inline `<span class="ocr-line">`s with a CSS-generated newline (`::after { content: '\A'; white-space: pre }`). DOM walkers see one continuous text node per bubble; visual layout is unchanged; the existing `oncopy` stripper still removes `\n` on Ctrl+C, so Yomitan sentence/Anki capture is unaffected.

Also syncs `package-lock.json` to 1.5.8 (was at 1.5.7 after the recent version bump in 5b44116).

## Test plan

Tested manually in dev with both Migaku and Yomitan installed:

- [x] Migaku: "capture sentence" on multi-line speech bubble now grabs the full sentence (was: single line only)
- [x] Migaku popup overlay scrolls when wheel'd over (was: scroll eaten by reader)
- [x] Yomitan sentence capture unchanged — no double linebreaks regression
- [x] Visual: OCR overlays render line breaks at original OCR positions in both auto and original font modes
- [x] Visual: vertical writing mode still breaks correctly
- [x] Ctrl+C inside textbox produces text with no linebreaks
- [x] Zoom (ctrl+wheel) inside manga works
- [x] Keyboard nav (arrow keys / shortcuts) works
- [x] Settings drawer / popovers / dialogs unaffected by wheel handler change
- [x] `npm run check` clean, `npm run lint` clean, all 427 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)