### PR TITLE
chore: bump version to 1.5.9 and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.5.9] - 2026-05-17
+
+### Fixed
+
+- **Migaku popup scroll eaten by reader** - The reader's window-level wheel listener intercepted every wheel and blocked scrolling inside Migaku/Yomitan popup overlays. Wheel events are now only intercepted inside the reader content (#214)
+- **Migaku sentence capture stopped at line breaks** - "Capture sentence" / "read sentence" only saw the hovered OCR line because `<br/>` separators were treated as sentence boundaries. OCR lines now use a CSS-generated newline so DOM walkers see one continuous text node per speech bubble. Yomitan behaviour unchanged (#214)
+
 ## [1.5.8] - 2026-05-16
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mokuro-reader",
-      "version": "1.5.8",
+      "version": "1.5.9",
       "dependencies": {
         "@types/gapi": "^0.0.47",
         "@vercel/analytics": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mokuro-reader",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "private": true,
   "scripts": {
     "dev": "vite dev",


### PR DESCRIPTION
## Summary

Version bump for the Migaku compat fixes that landed in #214.

- 1.5.8 → 1.5.9
- Changelog entry under `Fixed`: Migaku popup scroll + multi-line sentence capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)