### PR TITLE
feat: always show OCR toggle

### DIFF
--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -451,6 +451,13 @@
           showNotification(newVal ? 'Dividers On' : 'Dividers Off', 'page-dividers');
         }
         return;
+      case 'KeyT':
+        updateSetting('alwaysShowOCR', !$settings.alwaysShowOCR);
+        showNotification(
+          $settings.alwaysShowOCR ? 'Always Show OCR: Off' : 'Always Show OCR: On',
+          'always-show-ocr-toggle'
+        );
+        return;
       case 'KeyV':
         toggleContinuousScroll();
         return;

--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -128,6 +128,7 @@
 
   let fontWeight = $derived($settings.boldFont ? 'bold' : '400');
   let display = $derived($settings.displayOCR ? 'block' : 'none');
+  let alwaysShowOCR = $derived($settings.alwaysShowOCR);
   let border = $derived($settings.textBoxBorders ? '1px solid red' : 'none');
   let contenteditable = $derived($settings.textEditable);
 
@@ -535,6 +536,7 @@
     class="textBox"
     class:originalMode={isOriginalMode}
     class:forceVisible
+    class:alwaysVisible={alwaysShowOCR}
     style:width={isOriginalMode ? undefined : useMinDimensions ? undefined : width}
     style:height={isOriginalMode ? undefined : useMinDimensions ? undefined : height}
     style:min-width={isOriginalMode ? undefined : useMinDimensions ? width : undefined}
@@ -606,12 +608,14 @@
     visibility: visible;
   }
 
-  /* Force visibility for placeholder/missing pages */
-  .textBox.forceVisible {
+  /* Force visibility for placeholder/missing pages, or when always-show OCR is enabled */
+  .textBox.forceVisible,
+  .textBox.alwaysVisible {
     background: rgb(255, 255, 255);
   }
 
-  .textBox.forceVisible p {
+  .textBox.forceVisible p,
+  .textBox.alwaysVisible p {
     visibility: visible;
   }
 

--- a/src/lib/components/Settings/Reader/ReaderToggles.svelte
+++ b/src/lib/components/Settings/Reader/ReaderToggles.svelte
@@ -26,6 +26,12 @@
         { key: 'textEditable', text: 'Editable text', value: $settings.textEditable },
         { key: 'textBoxBorders', text: 'Text box borders', value: $settings.textBoxBorders },
         { key: 'displayOCR', text: 'OCR enabled', value: $settings.displayOCR },
+        {
+          key: 'alwaysShowOCR',
+          text: 'Always show OCR',
+          value: $settings.alwaysShowOCR,
+          shortcut: 'T'
+        },
         { key: 'boldFont', text: 'Bold font', value: $settings.boldFont },
         { key: 'pageNum', text: 'Show page number', value: $settings.pageNum },
         { key: 'charCount', text: 'Show character count', value: $settings.charCount },

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -126,6 +126,7 @@ export type Settings = {
   textEditable: boolean;
   textBoxBorders: boolean;
   displayOCR: boolean;
+  alwaysShowOCR: boolean;
   boldFont: boolean;
   pageNum: boolean;
   charCount: boolean;
@@ -244,6 +245,7 @@ export const DEFAULT_MODEL_CONFIGS: Record<string, Omit<ModelConfig, 'modelName'
 const defaultSettings: Settings = {
   defaultFullscreen: false,
   displayOCR: true,
+  alwaysShowOCR: false,
   textEditable: false,
   textBoxBorders: false,
   boldFont: false,


### PR DESCRIPTION
Based on an older PR: https://github.com/Gnathonic/mokuro-reader/pull/38

Adds an option to keep all OCR text boxes permanently visible instead of only on hover/focus.

## Changes
- New `alwaysShowOCR` boolean setting (default `false`)
- Toggle in the reader settings panel under OCR options, with `(T)` shortcut hint
- `T` keyboard shortcut to toggle while reading, with on-screen notification
- CSS reuses the existing `forceVisible` selector pattern

## Behaviour
- When enabled, all text boxes on the current page are immediately visible