### PR TITLE
feat(reader): B&W (grayscale) filter with shared scheduled-filter control (#221)

### DIFF
--- a/docs/superpowers/plans/2026-06-06-bw-filter.md
+++ b/docs/superpowers/plans/2026-06-06-bw-filter.md
@@ -14,24 +14,25 @@
 
 ## File Structure
 
-| File | Change | Responsibility |
-| ---- | ------ | -------------- |
-| `src/lib/settings/settings.ts` | Modify | `grayscale`/`grayscaleSchedule` setting, `ScheduleSettingKey`, defaults, migration, `grayscaleActive` + `imageFilter` stores |
-| `src/lib/settings/settings.test.ts` | Create | Unit tests for `grayscaleActive` and `imageFilter` |
-| `src/lib/components/Settings/Reader/ScheduledFilterCard.svelte` | Create | Reusable Manual/Scheduled filter settings card |
-| `src/lib/components/Settings/Reader/__tests__/ScheduledFilterCard.test.ts` | Create | Render tests for the card |
-| `src/lib/components/Settings/Reader/ReaderToggles.svelte` | Rewrite | Use `ScheduledFilterCard` ×3 (night/invert/B&W) |
-| `src/lib/components/Reader/Reader.svelte` | Modify | `imageFilter` on panel + `toggleScheduledFilter` helper + `KeyG` |
-| `src/lib/components/Reader/HorizontalScrollReader.svelte` | Modify | Use `imageFilter` |
-| `src/lib/components/Reader/VerticalScrollReader.svelte` | Modify | Use `imageFilter` |
+| File                                                                       | Change  | Responsibility                                                                                                               |
+| -------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/settings/settings.ts`                                             | Modify  | `grayscale`/`grayscaleSchedule` setting, `ScheduleSettingKey`, defaults, migration, `grayscaleActive` + `imageFilter` stores |
+| `src/lib/settings/settings.test.ts`                                        | Create  | Unit tests for `grayscaleActive` and `imageFilter`                                                                           |
+| `src/lib/components/Settings/Reader/ScheduledFilterCard.svelte`            | Create  | Reusable Manual/Scheduled filter settings card                                                                               |
+| `src/lib/components/Settings/Reader/__tests__/ScheduledFilterCard.test.ts` | Create  | Render tests for the card                                                                                                    |
+| `src/lib/components/Settings/Reader/ReaderToggles.svelte`                  | Rewrite | Use `ScheduledFilterCard` ×3 (night/invert/B&W)                                                                              |
+| `src/lib/components/Reader/Reader.svelte`                                  | Modify  | `imageFilter` on panel + `toggleScheduledFilter` helper + `KeyG`                                                             |
+| `src/lib/components/Reader/HorizontalScrollReader.svelte`                  | Modify  | Use `imageFilter`                                                                                                            |
+| `src/lib/components/Reader/VerticalScrollReader.svelte`                    | Modify  | Use `imageFilter`                                                                                                            |
 
-**Note on existing behavior:** The three existing inline filters use `invert(${$invertColorsActive ? 1 : 0})`. `invert()` and `grayscale()` commute, so combining them in one string is mathematically safe regardless of order. The hotkey refactor preserves the existing read-after-`updateSetting` notification pattern exactly (it relies on the `$settings` store value being stale within the synchronous handler — do not "simplify" it). One intentional, accepted cosmetic change: the night-mode *scheduled* toast normalizes from "Night mode is on automatic schedule" to "Night Mode is on automatic schedule" (capital M) so all three filters share one label parameter.
+**Note on existing behavior:** The three existing inline filters use `invert(${$invertColorsActive ? 1 : 0})`. `invert()` and `grayscale()` commute, so combining them in one string is mathematically safe regardless of order. The hotkey refactor preserves the existing read-after-`updateSetting` notification pattern exactly (it relies on the `$settings` store value being stale within the synchronous handler — do not "simplify" it). One intentional, accepted cosmetic change: the night-mode _scheduled_ toast normalizes from "Night mode is on automatic schedule" to "Night Mode is on automatic schedule" (capital M) so all three filters share one label parameter.
 
 ---
 
 ## Task 1: Grayscale setting + `grayscaleActive` store
 
 **Files:**
+
 - Create: `src/lib/settings/settings.test.ts`
 - Modify: `src/lib/settings/settings.ts`
 
@@ -96,17 +97,17 @@ Expected: FAIL — `grayscaleActive` is not exported yet, so `get(grayscaleActiv
 In `src/lib/settings/settings.ts`, find:
 
 ```ts
-  invertColors: boolean;
-  invertColorsSchedule: TimeSchedule;
+invertColors: boolean;
+invertColorsSchedule: TimeSchedule;
 ```
 
 Replace with:
 
 ```ts
-  invertColors: boolean;
-  invertColorsSchedule: TimeSchedule;
-  grayscale: boolean;
-  grayscaleSchedule: TimeSchedule;
+invertColors: boolean;
+invertColorsSchedule: TimeSchedule;
+grayscale: boolean;
+grayscaleSchedule: TimeSchedule;
 ```
 
 - [ ] **Step 4: Extend `ScheduleSettingKey`**
@@ -120,10 +121,7 @@ export type ScheduleSettingKey = 'nightModeSchedule' | 'invertColorsSchedule';
 Replace with:
 
 ```ts
-export type ScheduleSettingKey =
-  | 'nightModeSchedule'
-  | 'invertColorsSchedule'
-  | 'grayscaleSchedule';
+export type ScheduleSettingKey = 'nightModeSchedule' | 'invertColorsSchedule' | 'grayscaleSchedule';
 ```
 
 - [ ] **Step 5: Add default values**
@@ -161,24 +159,24 @@ Replace with:
 Find:
 
 ```ts
-    migratedProfile.invertColorsSchedule = {
-      ...defaultSettings.invertColorsSchedule,
-      ...(profile.invertColorsSchedule || {})
-    };
+migratedProfile.invertColorsSchedule = {
+  ...defaultSettings.invertColorsSchedule,
+  ...(profile.invertColorsSchedule || {})
+};
 ```
 
 Replace with:
 
 ```ts
-    migratedProfile.invertColorsSchedule = {
-      ...defaultSettings.invertColorsSchedule,
-      ...(profile.invertColorsSchedule || {})
-    };
+migratedProfile.invertColorsSchedule = {
+  ...defaultSettings.invertColorsSchedule,
+  ...(profile.invertColorsSchedule || {})
+};
 
-    migratedProfile.grayscaleSchedule = {
-      ...defaultSettings.grayscaleSchedule,
-      ...(profile.grayscaleSchedule || {})
-    };
+migratedProfile.grayscaleSchedule = {
+  ...defaultSettings.grayscaleSchedule,
+  ...(profile.grayscaleSchedule || {})
+};
 ```
 
 - [ ] **Step 7: Add the `grayscaleActive` derived store**
@@ -237,6 +235,7 @@ EOF
 ## Task 2: Combined `imageFilter` derived store
 
 **Files:**
+
 - Modify: `src/lib/settings/settings.ts`
 - Modify: `src/lib/settings/settings.test.ts`
 
@@ -310,7 +309,6 @@ export const grayscaleActive = derived([settings, currentMinute], ([$settings, _
 Add immediately after it:
 
 ```ts
-
 /**
  * Combined CSS filter string for the manga image layer. invert() and
  * grayscale() commute, so order is irrelevant. Night mode is applied
@@ -345,6 +343,7 @@ EOF
 ## Task 3: Reusable `ScheduledFilterCard` component
 
 **Files:**
+
 - Create: `src/lib/components/Settings/Reader/ScheduledFilterCard.svelte`
 - Create: `src/lib/components/Settings/Reader/__tests__/ScheduledFilterCard.test.ts`
 
@@ -525,6 +524,7 @@ EOF
 ## Task 4: Use `ScheduledFilterCard` in `ReaderToggles.svelte`
 
 **Files:**
+
 - Modify (full rewrite): `src/lib/components/Settings/Reader/ReaderToggles.svelte`
 
 - [ ] **Step 1: Replace the file contents**
@@ -669,22 +669,24 @@ EOF
 ## Task 5: Apply `imageFilter` in the reader components
 
 **Files:**
+
 - Modify: `src/lib/components/Reader/HorizontalScrollReader.svelte`
 - Modify: `src/lib/components/Reader/VerticalScrollReader.svelte`
-- Modify: `src/lib/components/Reader/Reader.svelte` (filter only; hotkey is Task 6)
+
+(`Reader.svelte`'s filter line is changed in Task 6, together with its import-block rewrite, so the file never has an undefined `$imageFilter` or an unused `invertColorsActive` import.)
 
 - [ ] **Step 1: HorizontalScrollReader — update import**
 
 Find:
 
 ```svelte
-  import { settings, invertColorsActive } from '$lib/settings';
+import {(settings, invertColorsActive)} from '$lib/settings';
 ```
 
 Replace with:
 
 ```svelte
-  import { settings, imageFilter } from '$lib/settings';
+import {(settings, imageFilter)} from '$lib/settings';
 ```
 
 - [ ] **Step 2: HorizontalScrollReader — update filter**
@@ -692,13 +694,13 @@ Replace with:
 Find:
 
 ```svelte
-      style:filter={`invert(${$invertColorsActive ? 1 : 0})`}
+style:filter={`invert(${$invertColorsActive ? 1 : 0})`}
 ```
 
 Replace with:
 
 ```svelte
-      style:filter={$imageFilter}
+style:filter={$imageFilter}
 ```
 
 - [ ] **Step 3: VerticalScrollReader — update import**
@@ -706,13 +708,13 @@ Replace with:
 Find:
 
 ```svelte
-  import { settings, invertColorsActive } from '$lib/settings';
+import {(settings, invertColorsActive)} from '$lib/settings';
 ```
 
 Replace with:
 
 ```svelte
-  import { settings, imageFilter } from '$lib/settings';
+import {(settings, imageFilter)} from '$lib/settings';
 ```
 
 - [ ] **Step 4: VerticalScrollReader — update filter**
@@ -729,26 +731,15 @@ Replace with:
     <div bind:this={zoomSpacerEl} style:filter={$imageFilter}>
 ```
 
-- [ ] **Step 5: Reader.svelte — update the panel filter**
+- [ ] **Step 5: Type-check**
 
-Find:
-
-```svelte
-          style:filter={`invert(${$invertColorsActive ? 1 : 0})`}
-```
-
-Replace with:
-
-```svelte
-          style:filter={$imageFilter}
-```
-
-(The `invertColorsActive` import in Reader.svelte is removed in Task 6, where `imageFilter` is added to its import block. Until then `npm run check` may warn about the unused `invertColorsActive` import in Reader.svelte — that is resolved in Task 6. The two scroll readers already type-check after this task.)
+Run: `npm run check`
+Expected: 0 errors. Both scroll readers are self-consistent (import + filter changed together). `Reader.svelte` is intentionally untouched in this task.
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add src/lib/components/Reader/HorizontalScrollReader.svelte src/lib/components/Reader/VerticalScrollReader.svelte src/lib/components/Reader/Reader.svelte
+git add src/lib/components/Reader/HorizontalScrollReader.svelte src/lib/components/Reader/VerticalScrollReader.svelte
 git commit -m "$(cat <<'EOF'
 feat(reader): apply combined imageFilter (invert + grayscale) in readers
 
@@ -762,9 +753,10 @@ EOF
 ## Task 6: B&W hotkey via shared `toggleScheduledFilter` helper
 
 **Files:**
+
 - Modify: `src/lib/components/Reader/Reader.svelte`
 
-- [ ] **Step 1: Update the `$lib/settings` import block**
+- [ ] **Step 1: Update the import block and apply `imageFilter` to the panel**
 
 Find:
 
@@ -801,6 +793,20 @@ Replace with:
   } from '$lib/settings';
 ```
 
+Then update the manga-panel filter in the same file. Find:
+
+```svelte
+style:filter={`invert(${$invertColorsActive ? 1 : 0})`}
+```
+
+Replace with:
+
+```svelte
+style:filter={$imageFilter}
+```
+
+(After this, `invertColorsActive` is no longer referenced in `Reader.svelte` — its import was removed above and `imageFilter` is now imported and used, so the file type-checks cleanly.)
+
 - [ ] **Step 2: Add the `toggleScheduledFilter` helper**
 
 Find the end of the `showNotification` function:
@@ -817,29 +823,28 @@ Find the end of the `showNotification` function:
 Add immediately after it:
 
 ```ts
-
-  // Shared toggle for the Manual/Scheduled display filters (night, invert, B&W).
-  // Mirrors the original inline handlers: when the schedule owns the filter we
-  // only notify; otherwise we flip the manual boolean. The notification reads
-  // $settings AFTER updateSetting on purpose — the store value is still the
-  // pre-update value within this synchronous handler, which yields the correct
-  // On/Off label. Do not "simplify" this.
-  function toggleScheduledFilter(
-    settingKey: 'nightMode' | 'invertColors' | 'grayscale',
-    scheduleKey: ScheduleSettingKey,
-    label: string,
-    notifPrefix: string
-  ) {
-    if ($settings[scheduleKey].enabled) {
-      showNotification(`${label} is on automatic schedule`, `${notifPrefix}-scheduled`);
-    } else {
-      updateSetting(settingKey, !$settings[settingKey]);
-      showNotification(
-        $settings[settingKey] ? `${label} Off` : `${label} On`,
-        `${notifPrefix}-toggle`
-      );
-    }
+// Shared toggle for the Manual/Scheduled display filters (night, invert, B&W).
+// Mirrors the original inline handlers: when the schedule owns the filter we
+// only notify; otherwise we flip the manual boolean. The notification reads
+// $settings AFTER updateSetting on purpose — the store value is still the
+// pre-update value within this synchronous handler, which yields the correct
+// On/Off label. Do not "simplify" this.
+function toggleScheduledFilter(
+  settingKey: 'nightMode' | 'invertColors' | 'grayscale',
+  scheduleKey: ScheduleSettingKey,
+  label: string,
+  notifPrefix: string
+) {
+  if ($settings[scheduleKey].enabled) {
+    showNotification(`${label} is on automatic schedule`, `${notifPrefix}-scheduled`);
+  } else {
+    updateSetting(settingKey, !$settings[settingKey]);
+    showNotification(
+      $settings[settingKey] ? `${label} Off` : `${label} On`,
+      `${notifPrefix}-toggle`
+    );
   }
+}
 ```
 
 - [ ] **Step 3: Replace the `KeyI` handler**
@@ -960,6 +965,7 @@ Expected: build succeeds.
 - [ ] **Step 6: Manual QA** (run `npm run dev`, open a volume in the reader)
 
 Verify each item:
+
 - Settings → Reader shows three matching cards: Night mode, Invert colors, Black & white.
 - Toggling "Enable black & white" applies grayscale to the page; the card shows "(active)".
 - Pressing **G** toggles B&W and shows a "B&W On" / "B&W Off" toast; the settings toggle reflects it.

--- a/docs/superpowers/plans/2026-06-06-bw-filter.md
+++ b/docs/superpowers/plans/2026-06-06-bw-filter.md
@@ -1,0 +1,978 @@
+# B&W (Grayscale) Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a black-and-white (grayscale) reader filter that mirrors the existing invert filter (manual toggle + time schedule + hotkey), and refactor the duplicated night/invert/B&W settings control into one reusable component.
+
+**Architecture:** A new `grayscale` boolean + `grayscaleSchedule` are added to `Settings`, with a `grayscaleActive` derived store mirroring `invertColorsActive`. A new `imageFilter` derived store combines invert + grayscale into one CSS filter string, consumed by all three reader components. The night/invert/B&W settings cards collapse into one `ScheduledFilterCard.svelte`, and the `KeyN`/`KeyI`/`KeyG` handlers collapse into one `toggleScheduledFilter` helper.
+
+**Tech Stack:** SvelteKit 5 (runes), Svelte stores, Flowbite Svelte, Vitest + @testing-library/svelte.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-bw-filter-design.md` (Issue #221).
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+| ---- | ------ | -------------- |
+| `src/lib/settings/settings.ts` | Modify | `grayscale`/`grayscaleSchedule` setting, `ScheduleSettingKey`, defaults, migration, `grayscaleActive` + `imageFilter` stores |
+| `src/lib/settings/settings.test.ts` | Create | Unit tests for `grayscaleActive` and `imageFilter` |
+| `src/lib/components/Settings/Reader/ScheduledFilterCard.svelte` | Create | Reusable Manual/Scheduled filter settings card |
+| `src/lib/components/Settings/Reader/__tests__/ScheduledFilterCard.test.ts` | Create | Render tests for the card |
+| `src/lib/components/Settings/Reader/ReaderToggles.svelte` | Rewrite | Use `ScheduledFilterCard` ×3 (night/invert/B&W) |
+| `src/lib/components/Reader/Reader.svelte` | Modify | `imageFilter` on panel + `toggleScheduledFilter` helper + `KeyG` |
+| `src/lib/components/Reader/HorizontalScrollReader.svelte` | Modify | Use `imageFilter` |
+| `src/lib/components/Reader/VerticalScrollReader.svelte` | Modify | Use `imageFilter` |
+
+**Note on existing behavior:** The three existing inline filters use `invert(${$invertColorsActive ? 1 : 0})`. `invert()` and `grayscale()` commute, so combining them in one string is mathematically safe regardless of order. The hotkey refactor preserves the existing read-after-`updateSetting` notification pattern exactly (it relies on the `$settings` store value being stale within the synchronous handler — do not "simplify" it). One intentional, accepted cosmetic change: the night-mode *scheduled* toast normalizes from "Night mode is on automatic schedule" to "Night Mode is on automatic schedule" (capital M) so all three filters share one label parameter.
+
+---
+
+## Task 1: Grayscale setting + `grayscaleActive` store
+
+**Files:**
+- Create: `src/lib/settings/settings.test.ts`
+- Modify: `src/lib/settings/settings.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/settings/settings.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { grayscaleActive, updateSetting, updateScheduleSetting } from './settings';
+
+describe('grayscaleActive', () => {
+  beforeEach(() => {
+    // Known baseline: manual mode, filter off
+    updateScheduleSetting('grayscaleSchedule', 'enabled', false);
+    updateSetting('grayscale', false);
+  });
+
+  it('reflects the manual toggle when the schedule is disabled', () => {
+    updateSetting('grayscale', true);
+    expect(get(grayscaleActive)).toBe(true);
+
+    updateSetting('grayscale', false);
+    expect(get(grayscaleActive)).toBe(false);
+  });
+
+  describe('scheduled mode', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('is active when the current time is within a crossing-midnight schedule', () => {
+      vi.setSystemTime(new Date(2026, 0, 1, 22, 0, 0)); // 22:00
+      updateScheduleSetting('grayscaleSchedule', 'startTime', '21:00');
+      updateScheduleSetting('grayscaleSchedule', 'endTime', '06:00');
+      updateScheduleSetting('grayscaleSchedule', 'enabled', true);
+      expect(get(grayscaleActive)).toBe(true);
+    });
+
+    it('is inactive when the current time is outside the schedule', () => {
+      vi.setSystemTime(new Date(2026, 0, 1, 12, 0, 0)); // 12:00
+      updateScheduleSetting('grayscaleSchedule', 'startTime', '21:00');
+      updateScheduleSetting('grayscaleSchedule', 'endTime', '06:00');
+      updateScheduleSetting('grayscaleSchedule', 'enabled', true);
+      expect(get(grayscaleActive)).toBe(false);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/settings/settings.test.ts`
+Expected: FAIL — `grayscaleActive` is not exported yet, so `get(grayscaleActive)` throws (`store` is undefined).
+
+- [ ] **Step 3: Add the setting to the `Settings` type**
+
+In `src/lib/settings/settings.ts`, find:
+
+```ts
+  invertColors: boolean;
+  invertColorsSchedule: TimeSchedule;
+```
+
+Replace with:
+
+```ts
+  invertColors: boolean;
+  invertColorsSchedule: TimeSchedule;
+  grayscale: boolean;
+  grayscaleSchedule: TimeSchedule;
+```
+
+- [ ] **Step 4: Extend `ScheduleSettingKey`**
+
+Find:
+
+```ts
+export type ScheduleSettingKey = 'nightModeSchedule' | 'invertColorsSchedule';
+```
+
+Replace with:
+
+```ts
+export type ScheduleSettingKey =
+  | 'nightModeSchedule'
+  | 'invertColorsSchedule'
+  | 'grayscaleSchedule';
+```
+
+- [ ] **Step 5: Add default values**
+
+Find:
+
+```ts
+  invertColors: false,
+  invertColorsSchedule: {
+    enabled: false,
+    startTime: '21:00',
+    endTime: '06:00'
+  },
+```
+
+Replace with:
+
+```ts
+  invertColors: false,
+  invertColorsSchedule: {
+    enabled: false,
+    startTime: '21:00',
+    endTime: '06:00'
+  },
+  grayscale: false,
+  grayscaleSchedule: {
+    enabled: false,
+    startTime: '21:00',
+    endTime: '06:00'
+  },
+```
+
+- [ ] **Step 6: Add the migration block**
+
+Find:
+
+```ts
+    migratedProfile.invertColorsSchedule = {
+      ...defaultSettings.invertColorsSchedule,
+      ...(profile.invertColorsSchedule || {})
+    };
+```
+
+Replace with:
+
+```ts
+    migratedProfile.invertColorsSchedule = {
+      ...defaultSettings.invertColorsSchedule,
+      ...(profile.invertColorsSchedule || {})
+    };
+
+    migratedProfile.grayscaleSchedule = {
+      ...defaultSettings.grayscaleSchedule,
+      ...(profile.grayscaleSchedule || {})
+    };
+```
+
+- [ ] **Step 7: Add the `grayscaleActive` derived store**
+
+Find:
+
+```ts
+export const invertColorsActive = derived([settings, currentMinute], ([$settings, _]) => {
+  if (!$settings) return false;
+  if ($settings.invertColorsSchedule?.enabled) {
+    return isWithinSchedule($settings.invertColorsSchedule);
+  }
+  return $settings.invertColors ?? false;
+});
+```
+
+Replace with:
+
+```ts
+export const invertColorsActive = derived([settings, currentMinute], ([$settings, _]) => {
+  if (!$settings) return false;
+  if ($settings.invertColorsSchedule?.enabled) {
+    return isWithinSchedule($settings.invertColorsSchedule);
+  }
+  return $settings.invertColors ?? false;
+});
+
+export const grayscaleActive = derived([settings, currentMinute], ([$settings, _]) => {
+  if (!$settings) return false;
+  if ($settings.grayscaleSchedule?.enabled) {
+    return isWithinSchedule($settings.grayscaleSchedule);
+  }
+  return $settings.grayscale ?? false;
+});
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/settings/settings.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/lib/settings/settings.ts src/lib/settings/settings.test.ts
+git commit -m "$(cat <<'EOF'
+feat(settings): add grayscale setting, schedule, and grayscaleActive store
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Combined `imageFilter` derived store
+
+**Files:**
+- Modify: `src/lib/settings/settings.ts`
+- Modify: `src/lib/settings/settings.test.ts`
+
+- [ ] **Step 1: Add the failing test**
+
+In `src/lib/settings/settings.test.ts`, update the import line:
+
+```ts
+import { grayscaleActive, updateSetting, updateScheduleSetting } from './settings';
+```
+
+to:
+
+```ts
+import { grayscaleActive, imageFilter, updateSetting, updateScheduleSetting } from './settings';
+```
+
+Then append this describe block to the end of the file:
+
+```ts
+describe('imageFilter', () => {
+  beforeEach(() => {
+    // Manual mode for both filters, both off
+    updateScheduleSetting('invertColorsSchedule', 'enabled', false);
+    updateScheduleSetting('grayscaleSchedule', 'enabled', false);
+    updateSetting('invertColors', false);
+    updateSetting('grayscale', false);
+  });
+
+  it('is both-off by default', () => {
+    expect(get(imageFilter)).toBe('invert(0) grayscale(0)');
+  });
+
+  it('reflects invert only', () => {
+    updateSetting('invertColors', true);
+    expect(get(imageFilter)).toBe('invert(1) grayscale(0)');
+  });
+
+  it('reflects grayscale only', () => {
+    updateSetting('grayscale', true);
+    expect(get(imageFilter)).toBe('invert(0) grayscale(1)');
+  });
+
+  it('reflects both on', () => {
+    updateSetting('invertColors', true);
+    updateSetting('grayscale', true);
+    expect(get(imageFilter)).toBe('invert(1) grayscale(1)');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/settings/settings.test.ts`
+Expected: FAIL — `imageFilter` is undefined; the new describe block throws on `get(imageFilter)`.
+
+- [ ] **Step 3: Add the `imageFilter` store**
+
+In `src/lib/settings/settings.ts`, find the `grayscaleActive` store added in Task 1:
+
+```ts
+export const grayscaleActive = derived([settings, currentMinute], ([$settings, _]) => {
+  if (!$settings) return false;
+  if ($settings.grayscaleSchedule?.enabled) {
+    return isWithinSchedule($settings.grayscaleSchedule);
+  }
+  return $settings.grayscale ?? false;
+});
+```
+
+Add immediately after it:
+
+```ts
+
+/**
+ * Combined CSS filter string for the manga image layer. invert() and
+ * grayscale() commute, so order is irrelevant. Night mode is applied
+ * separately via NightModeFilter.svelte and is intentionally not included.
+ */
+export const imageFilter = derived(
+  [invertColorsActive, grayscaleActive],
+  ([$invertColorsActive, $grayscaleActive]) =>
+    `invert(${$invertColorsActive ? 1 : 0}) grayscale(${$grayscaleActive ? 1 : 0})`
+);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/settings/settings.test.ts`
+Expected: PASS (7 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/settings/settings.ts src/lib/settings/settings.test.ts
+git commit -m "$(cat <<'EOF'
+feat(settings): add combined imageFilter derived store
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Reusable `ScheduledFilterCard` component
+
+**Files:**
+- Create: `src/lib/components/Settings/Reader/ScheduledFilterCard.svelte`
+- Create: `src/lib/components/Settings/Reader/__tests__/ScheduledFilterCard.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/components/Settings/Reader/__tests__/ScheduledFilterCard.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import ScheduledFilterCard from '../ScheduledFilterCard.svelte';
+
+const baseProps = {
+  title: 'Black & white',
+  enableLabel: 'Enable black & white',
+  hotkeyHint: 'G',
+  settingKey: 'grayscale',
+  scheduleKey: 'grayscaleSchedule'
+} as const;
+
+describe('ScheduledFilterCard', () => {
+  it('renders the title and the manual hotkey hint', () => {
+    const { getByText } = render(ScheduledFilterCard, {
+      props: { ...baseProps, active: false }
+    });
+    expect(getByText('Black & white')).toBeTruthy();
+    expect(getByText('Manual (G)')).toBeTruthy();
+  });
+
+  it('shows the active indicator when active', () => {
+    const { getByText } = render(ScheduledFilterCard, {
+      props: { ...baseProps, active: true }
+    });
+    expect(getByText('(active)')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/components/Settings/Reader/__tests__/ScheduledFilterCard.test.ts`
+Expected: FAIL — cannot resolve `../ScheduledFilterCard.svelte` (file does not exist).
+
+- [ ] **Step 3: Create the component**
+
+Create `src/lib/components/Settings/Reader/ScheduledFilterCard.svelte`:
+
+```svelte
+<script lang="ts">
+  import {
+    settings,
+    updateSetting,
+    updateScheduleSetting,
+    type ScheduleSettingKey
+  } from '$lib/settings';
+  import { Toggle, Label } from 'flowbite-svelte';
+  import TimePicker from '../TimePicker.svelte';
+
+  let {
+    title,
+    enableLabel,
+    hotkeyHint,
+    settingKey,
+    scheduleKey,
+    active
+  }: {
+    title: string;
+    enableLabel: string;
+    hotkeyHint: string;
+    settingKey: 'nightMode' | 'invertColors' | 'grayscale';
+    scheduleKey: ScheduleSettingKey;
+    active: boolean;
+  } = $props();
+
+  let mode = $derived($settings[scheduleKey].enabled ? 'scheduled' : 'manual');
+  // Unique radio-group name so multiple cards on the page stay independent.
+  let groupName = $derived(`${scheduleKey}-mode`);
+
+  function setMode(next: 'manual' | 'scheduled') {
+    if (next === 'manual') {
+      updateScheduleSetting(scheduleKey, 'enabled', false);
+    } else {
+      updateScheduleSetting(scheduleKey, 'enabled', true);
+      // Turn off the manual toggle when switching to scheduled
+      if ($settings[settingKey]) {
+        updateSetting(settingKey, false);
+      }
+    }
+  }
+</script>
+
+<div class="mt-2 rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+  <div class="mb-2 flex items-center justify-between">
+    <span class="text-sm font-medium text-gray-900 dark:text-white">
+      {title}
+      {#if active}
+        <span class="ml-1 text-xs text-green-600 dark:text-green-400">(active)</span>
+      {/if}
+    </span>
+  </div>
+
+  <div class="mb-3 flex gap-4">
+    <label class="flex cursor-pointer items-center gap-2">
+      <input
+        type="radio"
+        name={groupName}
+        checked={mode === 'manual'}
+        onchange={() => setMode('manual')}
+        class="h-4 w-4 text-primary-600"
+      />
+      <span class="text-sm text-gray-700 dark:text-gray-300">Manual ({hotkeyHint})</span>
+    </label>
+    <label class="flex cursor-pointer items-center gap-2">
+      <input
+        type="radio"
+        name={groupName}
+        checked={mode === 'scheduled'}
+        onchange={() => setMode('scheduled')}
+        class="h-4 w-4 text-primary-600"
+      />
+      <span class="text-sm text-gray-700 dark:text-gray-300">Scheduled</span>
+    </label>
+  </div>
+
+  {#if mode === 'manual'}
+    <Toggle
+      size="small"
+      checked={$settings[settingKey]}
+      onchange={() => updateSetting(settingKey, !$settings[settingKey])}
+    >
+      {enableLabel}
+    </Toggle>
+  {:else}
+    <div class="space-y-2">
+      <div class="flex items-center gap-2">
+        <Label class="w-12 text-xs text-gray-700 dark:text-gray-300">Start:</Label>
+        <TimePicker
+          value={$settings[scheduleKey].startTime}
+          onchange={(val) => updateScheduleSetting(scheduleKey, 'startTime', val)}
+        />
+      </div>
+      <div class="flex items-center gap-2">
+        <Label class="w-12 text-xs text-gray-700 dark:text-gray-300">End:</Label>
+        <TimePicker
+          value={$settings[scheduleKey].endTime}
+          onchange={(val) => updateScheduleSetting(scheduleKey, 'endTime', val)}
+        />
+      </div>
+    </div>
+  {/if}
+</div>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/components/Settings/Reader/__tests__/ScheduledFilterCard.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Type-check**
+
+Run: `npm run check`
+Expected: no new errors referencing `ScheduledFilterCard.svelte`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/components/Settings/Reader/ScheduledFilterCard.svelte src/lib/components/Settings/Reader/__tests__/ScheduledFilterCard.test.ts
+git commit -m "$(cat <<'EOF'
+feat(reader): add reusable ScheduledFilterCard settings component
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Use `ScheduledFilterCard` in `ReaderToggles.svelte`
+
+**Files:**
+- Modify (full rewrite): `src/lib/components/Settings/Reader/ReaderToggles.svelte`
+
+- [ ] **Step 1: Replace the file contents**
+
+Overwrite `src/lib/components/Settings/Reader/ReaderToggles.svelte` with:
+
+```svelte
+<script lang="ts">
+  import {
+    settings,
+    nightModeActive,
+    invertColorsActive,
+    grayscaleActive,
+    type SettingsKey,
+    updateSetting
+  } from '$lib/settings';
+  import { Toggle, Range, Label } from 'flowbite-svelte';
+  import ScheduledFilterCard from './ScheduledFilterCard.svelte';
+
+  let isContinuous = $derived($settings.continuousScroll);
+
+  // Keys hidden in continuous scroll mode (not applicable)
+  const continuousHidden = new Set<SettingsKey>(['bounds', 'mobile']);
+
+  let toggles = $derived(
+    (
+      [
+        {
+          key: 'defaultFullscreen',
+          text: 'Open reader in fullscreen',
+          value: $settings.defaultFullscreen
+        },
+        { key: 'textEditable', text: 'Editable text', value: $settings.textEditable },
+        { key: 'textBoxBorders', text: 'Text box borders', value: $settings.textBoxBorders },
+        { key: 'displayOCR', text: 'OCR enabled', value: $settings.displayOCR },
+        { key: 'boldFont', text: 'Bold font', value: $settings.boldFont },
+        { key: 'pageNum', text: 'Show page number', value: $settings.pageNum },
+        { key: 'charCount', text: 'Show character count', value: $settings.charCount },
+        { key: 'bounds', text: 'Bounds', value: $settings.bounds },
+        { key: 'mobile', text: 'Mobile', value: $settings.mobile },
+        { key: 'showTimer', text: 'Show timer', value: $settings.showTimer },
+        { key: 'quickActions', text: 'Show quick actions', value: $settings.quickActions },
+        {
+          key: 'swapWheelBehavior',
+          text: 'Swap mouse wheel scroll/zoom',
+          value: $settings.swapWheelBehavior
+        },
+        {
+          key: 'textBoxContextMenu',
+          text: 'Custom text box menu',
+          value: $settings.textBoxContextMenu,
+          description: 'Quick copy and Anki card creation on right-click/long-press'
+        }
+      ] as { key: SettingsKey; text: string; value: any; shortcut?: string; description?: string }[]
+    ).filter((t) => !isContinuous || !continuousHidden.has(t.key))
+  );
+</script>
+
+{#each toggles as { key, text, value, shortcut, description }}
+  <div>
+    <Toggle size="small" checked={value} onchange={() => updateSetting(key, !value)}>
+      {text}
+      {#if shortcut}
+        <span class="ml-2 text-xs text-gray-500 dark:text-gray-400">({shortcut})</span>
+      {/if}
+    </Toggle>
+    {#if description}
+      <p class="mt-0.5 ml-11 text-xs text-gray-500 dark:text-gray-400">{description}</p>
+    {/if}
+  </div>
+{/each}
+
+<!-- Display filters (Manual or Scheduled) — shared control -->
+<ScheduledFilterCard
+  title="Night mode"
+  enableLabel="Enable night mode"
+  hotkeyHint="N"
+  settingKey="nightMode"
+  scheduleKey="nightModeSchedule"
+  active={$nightModeActive}
+/>
+
+<ScheduledFilterCard
+  title="Invert colors"
+  enableLabel="Enable invert colors"
+  hotkeyHint="I"
+  settingKey="invertColors"
+  scheduleKey="invertColorsSchedule"
+  active={$invertColorsActive}
+/>
+
+<ScheduledFilterCard
+  title="Black & white"
+  enableLabel="Enable black & white"
+  hotkeyHint="G"
+  settingKey="grayscale"
+  scheduleKey="grayscaleSchedule"
+  active={$grayscaleActive}
+/>
+
+<div class="mt-4">
+  <Label class="mb-2 text-gray-900 dark:text-white">
+    Inactivity timeout: {$settings.inactivityTimeoutMinutes} minutes
+    <span class="ml-2 text-xs text-gray-500 dark:text-gray-400"
+      >(Auto-stop timer and sync after inactivity)</span
+    >
+  </Label>
+  <Range
+    min="1"
+    max="30"
+    value={$settings.inactivityTimeoutMinutes}
+    onchange={(e) =>
+      updateSetting('inactivityTimeoutMinutes', Number((e.target as HTMLInputElement).value))}
+  />
+</div>
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npm run check`
+Expected: no errors. (Confirms `updateScheduleSetting`/`TimePicker` are no longer referenced here and the three cards type-check.)
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `npx vitest run`
+Expected: PASS (all existing tests + the new settings/card tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/components/Settings/Reader/ReaderToggles.svelte
+git commit -m "$(cat <<'EOF'
+refactor(settings-ui): use ScheduledFilterCard for night/invert/B&W
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Apply `imageFilter` in the reader components
+
+**Files:**
+- Modify: `src/lib/components/Reader/HorizontalScrollReader.svelte`
+- Modify: `src/lib/components/Reader/VerticalScrollReader.svelte`
+- Modify: `src/lib/components/Reader/Reader.svelte` (filter only; hotkey is Task 6)
+
+- [ ] **Step 1: HorizontalScrollReader — update import**
+
+Find:
+
+```svelte
+  import { settings, invertColorsActive } from '$lib/settings';
+```
+
+Replace with:
+
+```svelte
+  import { settings, imageFilter } from '$lib/settings';
+```
+
+- [ ] **Step 2: HorizontalScrollReader — update filter**
+
+Find:
+
+```svelte
+      style:filter={`invert(${$invertColorsActive ? 1 : 0})`}
+```
+
+Replace with:
+
+```svelte
+      style:filter={$imageFilter}
+```
+
+- [ ] **Step 3: VerticalScrollReader — update import**
+
+Find:
+
+```svelte
+  import { settings, invertColorsActive } from '$lib/settings';
+```
+
+Replace with:
+
+```svelte
+  import { settings, imageFilter } from '$lib/settings';
+```
+
+- [ ] **Step 4: VerticalScrollReader — update filter**
+
+Find:
+
+```svelte
+    <div bind:this={zoomSpacerEl} style:filter={`invert(${$invertColorsActive ? 1 : 0})`}>
+```
+
+Replace with:
+
+```svelte
+    <div bind:this={zoomSpacerEl} style:filter={$imageFilter}>
+```
+
+- [ ] **Step 5: Reader.svelte — update the panel filter**
+
+Find:
+
+```svelte
+          style:filter={`invert(${$invertColorsActive ? 1 : 0})`}
+```
+
+Replace with:
+
+```svelte
+          style:filter={$imageFilter}
+```
+
+(The `invertColorsActive` import in Reader.svelte is removed in Task 6, where `imageFilter` is added to its import block. Until then `npm run check` may warn about the unused `invertColorsActive` import in Reader.svelte — that is resolved in Task 6. The two scroll readers already type-check after this task.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/components/Reader/HorizontalScrollReader.svelte src/lib/components/Reader/VerticalScrollReader.svelte src/lib/components/Reader/Reader.svelte
+git commit -m "$(cat <<'EOF'
+feat(reader): apply combined imageFilter (invert + grayscale) in readers
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: B&W hotkey via shared `toggleScheduledFilter` helper
+
+**Files:**
+- Modify: `src/lib/components/Reader/Reader.svelte`
+
+- [ ] **Step 1: Update the `$lib/settings` import block**
+
+Find:
+
+```svelte
+  import {
+    effectiveVolumeSettings,
+    invertColorsActive,
+    progress,
+    settings,
+    updateProgress,
+    updateSetting,
+    updateVolumeSetting,
+    volumes,
+    type VolumeSettings,
+    type ContinuousZoomMode
+  } from '$lib/settings';
+```
+
+Replace with:
+
+```svelte
+  import {
+    effectiveVolumeSettings,
+    imageFilter,
+    progress,
+    settings,
+    updateProgress,
+    updateSetting,
+    updateVolumeSetting,
+    volumes,
+    type VolumeSettings,
+    type ContinuousZoomMode,
+    type ScheduleSettingKey
+  } from '$lib/settings';
+```
+
+- [ ] **Step 2: Add the `toggleScheduledFilter` helper**
+
+Find the end of the `showNotification` function:
+
+```ts
+    // Hide notification after 2 seconds
+    notificationTimeout = window.setTimeout(() => {
+      notificationMessage = '';
+      notificationKey = '';
+    }, 2000);
+  }
+```
+
+Add immediately after it:
+
+```ts
+
+  // Shared toggle for the Manual/Scheduled display filters (night, invert, B&W).
+  // Mirrors the original inline handlers: when the schedule owns the filter we
+  // only notify; otherwise we flip the manual boolean. The notification reads
+  // $settings AFTER updateSetting on purpose — the store value is still the
+  // pre-update value within this synchronous handler, which yields the correct
+  // On/Off label. Do not "simplify" this.
+  function toggleScheduledFilter(
+    settingKey: 'nightMode' | 'invertColors' | 'grayscale',
+    scheduleKey: ScheduleSettingKey,
+    label: string,
+    notifPrefix: string
+  ) {
+    if ($settings[scheduleKey].enabled) {
+      showNotification(`${label} is on automatic schedule`, `${notifPrefix}-scheduled`);
+    } else {
+      updateSetting(settingKey, !$settings[settingKey]);
+      showNotification(
+        $settings[settingKey] ? `${label} Off` : `${label} On`,
+        `${notifPrefix}-toggle`
+      );
+    }
+  }
+```
+
+- [ ] **Step 3: Replace the `KeyI` handler**
+
+Find:
+
+```ts
+      case 'KeyI':
+        if ($settings.invertColorsSchedule.enabled) {
+          showNotification('Invert is on automatic schedule', 'invert-scheduled');
+        } else {
+          updateSetting('invertColors', !$settings.invertColors);
+          showNotification($settings.invertColors ? 'Invert Off' : 'Invert On', 'invert-toggle');
+        }
+        return;
+```
+
+Replace with:
+
+```ts
+      case 'KeyI':
+        toggleScheduledFilter('invertColors', 'invertColorsSchedule', 'Invert', 'invert');
+        return;
+```
+
+- [ ] **Step 4: Replace the `KeyN` handler and add `KeyG`**
+
+Find:
+
+```ts
+      case 'KeyN':
+        if ($settings.nightModeSchedule.enabled) {
+          showNotification('Night mode is on automatic schedule', 'nightmode-scheduled');
+        } else {
+          updateSetting('nightMode', !$settings.nightMode);
+          showNotification(
+            $settings.nightMode ? 'Night Mode Off' : 'Night Mode On',
+            'nightmode-toggle'
+          );
+        }
+        return;
+```
+
+Replace with:
+
+```ts
+      case 'KeyN':
+        toggleScheduledFilter('nightMode', 'nightModeSchedule', 'Night Mode', 'nightmode');
+        return;
+      case 'KeyG':
+        toggleScheduledFilter('grayscale', 'grayscaleSchedule', 'B&W', 'grayscale');
+        return;
+```
+
+- [ ] **Step 5: Type-check**
+
+Run: `npm run check`
+Expected: no errors (the previously-unused `invertColorsActive` import is now gone; `imageFilter` and `ScheduleSettingKey` are used).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/components/Reader/Reader.svelte
+git commit -m "$(cat <<'EOF'
+feat(reader): add B&W (G) hotkey via shared toggleScheduledFilter helper
+
+Routes KeyN/KeyI/KeyG through one helper. Adds the G shortcut for the
+new grayscale filter (issue #221). Night mode's scheduled toast casing
+is normalized to "Night Mode" to share one label.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Full verification + manual QA
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Format**
+
+Run: `npm run format`
+Then check for changes: `git status --porcelain`
+If any files changed, commit:
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+style: prettier formatting for B&W filter changes
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+Expected: passes (Prettier check + ESLint clean).
+
+- [ ] **Step 3: Type-check**
+
+Run: `npm run check`
+Expected: 0 errors.
+
+- [ ] **Step 4: Full test suite**
+
+Run: `npx vitest run`
+Expected: all tests pass, including `settings.test.ts` (7) and `ScheduledFilterCard.test.ts` (2).
+
+- [ ] **Step 5: Production build**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 6: Manual QA** (run `npm run dev`, open a volume in the reader)
+
+Verify each item:
+- Settings → Reader shows three matching cards: Night mode, Invert colors, Black & white.
+- Toggling "Enable black & white" applies grayscale to the page; the card shows "(active)".
+- Pressing **G** toggles B&W and shows a "B&W On" / "B&W Off" toast; the settings toggle reflects it.
+- B&W works in all three reader modes: paged, horizontal scroll, vertical scroll.
+- B&W + Invert together produce inverted grayscale (press **G** and **I**).
+- Switch the B&W card to **Scheduled**, set a window that includes now → filter activates; pressing **G** shows "B&W is on automatic schedule".
+- Reload the page → the B&W setting persists.
+- Confirm **N** (night mode) and **I** (invert) still behave exactly as before.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** setting + schedule + migration (T1), derived store (T1), centralized filter (T2, T5), reusable card (T3), card adoption ×3 (T4), hotkey G + DRY helper (T6), tests for `grayscaleActive`/`imageFilter` (T1/T2) and the card (T3), manual QA + persistence (T7). All spec sections mapped.
+- **Type consistency:** `settingKey` is the literal union `'nightMode' | 'invertColors' | 'grayscale'` in both `ScheduledFilterCard.svelte` and `toggleScheduledFilter` (keeps `$settings[settingKey]` boolean). `scheduleKey` is `ScheduleSettingKey` everywhere. Store names `grayscaleActive` / `imageFilter` are used identically across tasks.
+- **Accepted behavior change:** night-mode scheduled toast casing "Night mode" → "Night Mode" (documented in T6 commit body).

--- a/docs/superpowers/specs/2026-06-06-bw-filter-design.md
+++ b/docs/superpowers/specs/2026-06-06-bw-filter-design.md
@@ -1,0 +1,190 @@
+# B&W (Grayscale) Filter — Design
+
+**Issue:** [#221 — \[Feature\] B&W filter](https://github.com/Gnathonic/mokuro-reader/issues/221)
+**Date:** 2026-06-06
+**Branch:** `feat/bw-filter` (based on `develop`)
+
+## Problem
+
+Readers want to apply a black-and-white (grayscale) filter to pages. Use cases
+from the issue:
+
+- A scan is "mostly" grayscale but not pure grayscale, and the color tint is
+  distracting.
+- A colored scan is higher quality than the available B&W scan, but the reader
+  prefers to read in black and white.
+
+The reader already has a **night mode** filter and an **invert colors** filter,
+each with a Manual/Scheduled control and (for invert) a hotkey. B&W should fit
+in as a third member of that family.
+
+## Goals
+
+1. Add a B&W (grayscale) filter that mirrors the existing invert filter exactly:
+   Manual toggle **and** time-based Scheduled mode, an "(active)" indicator, and
+   a keyboard shortcut.
+2. Refactor the duplicated settings control so night mode, invert colors, and
+   B&W all share **one reusable component** instead of three hand-written copies.
+3. Centralize the manga-panel CSS filter string so it lives in one place rather
+   than being duplicated across the three reader components.
+
+## Non-Goals
+
+- Changing how **night mode** is *applied*. Night mode uses a separate global
+  mechanism (`NightModeFilter.svelte`, the `<dialog>` filter trick). Only its
+  *settings card* is unified with invert/B&W; its application is untouched.
+- Adjustable filter intensity (e.g. partial grayscale). The filter is on/off,
+  matching invert.
+- Per-volume B&W overrides beyond what the existing profile/volume settings
+  system already provides for every setting.
+
+## Approach
+
+Chosen: **reusable card component + centralized filter store + DRY'd hotkey
+handler.** This adds the feature and removes the duplication in the same change,
+which is cleaner than copy-pasting a third filter card/handler/filter-string.
+
+### 1. New setting (`src/lib/settings/settings.ts`)
+
+Mirror `invertColors` / `invertColorsSchedule`:
+
+- Add to the `Settings` type:
+  - `grayscale: boolean`
+  - `grayscaleSchedule: TimeSchedule`
+- Add to `defaultSettings`:
+  - `grayscale: false`
+  - `grayscaleSchedule: { enabled: false, startTime: '21:00', endTime: '06:00' }`
+- Add `'grayscaleSchedule'` to the `ScheduleSettingKey` union.
+- Add a migration block mirroring the `invertColorsSchedule` one so existing
+  profiles get the new schedule object:
+  ```ts
+  migratedProfile.grayscaleSchedule = {
+    ...defaultSettings.grayscaleSchedule,
+    ...(profile.grayscaleSchedule || {})
+  };
+  ```
+- Add a derived store mirroring `invertColorsActive`:
+  ```ts
+  export const grayscaleActive = derived([settings, currentMinute], ([$settings, _]) => {
+    if (!$settings) return false;
+    if ($settings.grayscaleSchedule?.enabled) {
+      return isWithinSchedule($settings.grayscaleSchedule);
+    }
+    return $settings.grayscale ?? false;
+  });
+  ```
+
+### 2. New reusable component — `src/lib/components/Settings/Reader/ScheduledFilterCard.svelte`
+
+Encapsulates the bordered card currently duplicated for night mode and invert:
+title + "(active)" badge, Manual/Scheduled radio pair (with hotkey hint on the
+Manual label), and either the enable toggle (manual) or the Start/End time
+pickers (scheduled).
+
+Props:
+
+| Prop          | Type                | Example                                   |
+| ------------- | ------------------- | ----------------------------------------- |
+| `title`       | `string`            | `'Black & white'`                         |
+| `enableLabel` | `string`            | `'Enable black & white'`                  |
+| `hotkeyHint`  | `string`            | `'G'`                                      |
+| `settingKey`  | `SettingsKey`       | `'grayscale'`                             |
+| `scheduleKey` | `ScheduleSettingKey`| `'grayscaleSchedule'`                     |
+| `active`      | `boolean`           | `$grayscaleActive`                        |
+
+Internally it owns the `mode` derivation (`$settings[scheduleKey].enabled ?
+'scheduled' : 'manual'`) and the `setMode` logic that currently lives in
+`ReaderToggles.svelte` (switching to scheduled turns off the manual boolean).
+The radio-group `name` is derived from `scheduleKey` so the three card instances
+remain independent.
+
+### 3. `src/lib/components/Settings/Reader/ReaderToggles.svelte`
+
+Replace the two hand-written cards (night, invert) with **three**
+`<ScheduledFilterCard>` instances:
+
+- Night mode — `settingKey="nightMode"`, `scheduleKey="nightModeSchedule"`,
+  `hotkeyHint="N"`, `active={$nightModeActive}`
+- Invert colors — `settingKey="invertColors"`,
+  `scheduleKey="invertColorsSchedule"`, `hotkeyHint="I"`,
+  `active={$invertColorsActive}`
+- Black & white — `settingKey="grayscale"`,
+  `scheduleKey="grayscaleSchedule"`, `hotkeyHint="G"`, `active={$grayscaleActive}`
+
+Removes the now-unused `nightModeMode`, `invertMode`, `setNightModeMode`, and
+`setInvertMode` locals (moved into the component).
+
+### 4. Centralized filter store (`settings.ts` + 3 readers)
+
+Add a derived store combining the manga-panel filters:
+
+```ts
+export const imageFilter = derived(
+  [invertColorsActive, grayscaleActive],
+  ([$inv, $gray]) => `invert(${$inv ? 1 : 0}) grayscale(${$gray ? 1 : 0})`
+);
+```
+
+`invert()` and `grayscale()` commute (grayscale is linear, invert is `1 − x`),
+so combining them in one string is correct regardless of order.
+
+Replace the three inline usages of
+`style:filter={`invert(${$invertColorsActive ? 1 : 0})`}` with
+`style:filter={$imageFilter}` in:
+
+- `src/lib/components/Reader/Reader.svelte`
+- `src/lib/components/Reader/HorizontalScrollReader.svelte`
+- `src/lib/components/Reader/VerticalScrollReader.svelte`
+
+### 5. Hotkey (`src/lib/components/Reader/Reader.svelte`)
+
+The `KeyN` and `KeyI` handlers share an identical shape: if the schedule is
+enabled, show an "on automatic schedule" notification; otherwise toggle the
+manual boolean and show an On/Off notification. Extract a helper:
+
+```ts
+function toggleScheduledFilter(
+  settingKey: 'nightMode' | 'invertColors' | 'grayscale',
+  scheduleKey: ScheduleSettingKey,
+  label: string,      // e.g. 'Black & white', 'Invert', 'Night mode'
+  notifPrefix: string // e.g. 'grayscale'
+) { ... }
+```
+
+Route `KeyN`, `KeyI`, and the new **`KeyG`** through it. Keeps the three
+behaviors identical and adds B&W with one line.
+
+Hotkey choice: **G** (grayscale). `B` was the alternative; `G` chosen.
+
+## Testing
+
+No tests currently cover `invertColorsActive` / `nightModeActive`. Add Vitest
+unit tests (TDD) for the new logic:
+
+- `grayscaleActive`: returns the manual boolean when the schedule is disabled;
+  returns the schedule result when enabled.
+- `imageFilter`: produces the correct combined string for each of the four
+  invert/grayscale on/off combinations.
+
+Manual verification:
+
+- Toggle B&W via the settings card and via the **G** hotkey; both reflect each
+  other and show the correct notification.
+- Filter applies in all three reader modes (paged, horizontal scroll, vertical
+  scroll).
+- B&W combines correctly with invert (both on = inverted grayscale).
+- Scheduled mode activates/deactivates by time, and the "G" hotkey shows the
+  "on automatic schedule" notice when scheduled.
+- Setting persists across reload and is included in profile export/sync like
+  other settings.
+
+## Files Touched
+
+- `src/lib/settings/settings.ts` — type, defaults, `ScheduleSettingKey`,
+  migration, `grayscaleActive`, `imageFilter`
+- `src/lib/components/Settings/Reader/ScheduledFilterCard.svelte` — **new**
+- `src/lib/components/Settings/Reader/ReaderToggles.svelte` — use the component ×3
+- `src/lib/components/Reader/Reader.svelte` — hotkey helper + `KeyG` + `imageFilter`
+- `src/lib/components/Reader/HorizontalScrollReader.svelte` — `imageFilter`
+- `src/lib/components/Reader/VerticalScrollReader.svelte` — `imageFilter`
+- Test file(s) for `grayscaleActive` / `imageFilter`

--- a/docs/superpowers/specs/2026-06-06-bw-filter-design.md
+++ b/docs/superpowers/specs/2026-06-06-bw-filter-design.md
@@ -30,9 +30,9 @@ in as a third member of that family.
 
 ## Non-Goals
 
-- Changing how **night mode** is *applied*. Night mode uses a separate global
+- Changing how **night mode** is _applied_. Night mode uses a separate global
   mechanism (`NightModeFilter.svelte`, the `<dialog>` filter trick). Only its
-  *settings card* is unified with invert/B&W; its application is untouched.
+  _settings card_ is unified with invert/B&W; its application is untouched.
 - Adjustable filter intensity (e.g. partial grayscale). The filter is on/off,
   matching invert.
 - Per-volume B&W overrides beyond what the existing profile/volume settings
@@ -83,14 +83,14 @@ pickers (scheduled).
 
 Props:
 
-| Prop          | Type                | Example                                   |
-| ------------- | ------------------- | ----------------------------------------- |
-| `title`       | `string`            | `'Black & white'`                         |
-| `enableLabel` | `string`            | `'Enable black & white'`                  |
-| `hotkeyHint`  | `string`            | `'G'`                                      |
-| `settingKey`  | `SettingsKey`       | `'grayscale'`                             |
-| `scheduleKey` | `ScheduleSettingKey`| `'grayscaleSchedule'`                     |
-| `active`      | `boolean`           | `$grayscaleActive`                        |
+| Prop          | Type                 | Example                  |
+| ------------- | -------------------- | ------------------------ |
+| `title`       | `string`             | `'Black & white'`        |
+| `enableLabel` | `string`             | `'Enable black & white'` |
+| `hotkeyHint`  | `string`             | `'G'`                    |
+| `settingKey`  | `SettingsKey`        | `'grayscale'`            |
+| `scheduleKey` | `ScheduleSettingKey` | `'grayscaleSchedule'`    |
+| `active`      | `boolean`            | `$grayscaleActive`       |
 
 Internally it owns the `mode` derivation (`$settings[scheduleKey].enabled ?
 'scheduled' : 'manual'`) and the `setMode` logic that currently lives in

--- a/src/lib/components/Reader/HorizontalScrollReader.svelte
+++ b/src/lib/components/Reader/HorizontalScrollReader.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Page, VolumeMetadata } from '$lib/types';
   import type { VolumeSettings } from '$lib/settings/volume-data';
-  import { settings, invertColorsActive } from '$lib/settings';
+  import { settings, imageFilter } from '$lib/settings';
   import { matchFilesToPages } from '$lib/reader/image-cache';
   import { getCharCount } from '$lib/util/count-chars';
   import { activityTracker } from '$lib/util/activity-tracker';
@@ -656,7 +656,7 @@
       class="flex"
       style:align-items={userZoom > 1 ? 'flex-start' : 'center'}
       style:direction={rtl ? 'rtl' : 'ltr'}
-      style:filter={`invert(${$invertColorsActive ? 1 : 0})`}
+      style:filter={$imageFilter}
     >
       <div
         bind:this={zoomWrapperEl}

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -16,7 +16,7 @@
   } from '$lib/panzoom';
   import {
     effectiveVolumeSettings,
-    invertColorsActive,
+    imageFilter,
     progress,
     settings,
     updateProgress,
@@ -24,7 +24,8 @@
     updateVolumeSetting,
     volumes,
     type VolumeSettings,
-    type ContinuousZoomMode
+    type ContinuousZoomMode,
+    type ScheduleSettingKey
   } from '$lib/settings';
   import { clamp, debounce, fireExstaticEvent, resetScrollPosition } from '$lib/util';
   import { Input, Popover, Range, Spinner } from 'flowbite-svelte';
@@ -408,23 +409,13 @@
         toggleFullScreen();
         return;
       case 'KeyI':
-        if ($settings.invertColorsSchedule.enabled) {
-          showNotification('Invert is on automatic schedule', 'invert-scheduled');
-        } else {
-          updateSetting('invertColors', !$settings.invertColors);
-          showNotification($settings.invertColors ? 'Invert Off' : 'Invert On', 'invert-toggle');
-        }
+        toggleScheduledFilter('invertColors', 'invertColorsSchedule', 'Invert', 'invert');
         return;
       case 'KeyN':
-        if ($settings.nightModeSchedule.enabled) {
-          showNotification('Night mode is on automatic schedule', 'nightmode-scheduled');
-        } else {
-          updateSetting('nightMode', !$settings.nightMode);
-          showNotification(
-            $settings.nightMode ? 'Night Mode Off' : 'Night Mode On',
-            'nightmode-toggle'
-          );
-        }
+        toggleScheduledFilter('nightMode', 'nightModeSchedule', 'Night Mode', 'nightmode');
+        return;
+      case 'KeyG':
+        toggleScheduledFilter('grayscale', 'grayscaleSchedule', 'B&W', 'grayscale');
         return;
       case 'KeyC':
         if (volume) {
@@ -1127,6 +1118,28 @@
     }, 2000);
   }
 
+  // Shared toggle for the Manual/Scheduled display filters (night, invert, B&W).
+  // When the schedule owns the filter we only notify; otherwise we flip the
+  // manual boolean. This reproduces the original inline KeyI/KeyN handlers
+  // exactly, including reading $settings right after updateSetting for the
+  // On/Off label — keep this order and pattern; do not "simplify" it.
+  function toggleScheduledFilter(
+    settingKey: 'nightMode' | 'invertColors' | 'grayscale',
+    scheduleKey: ScheduleSettingKey,
+    label: string,
+    notifPrefix: string
+  ) {
+    if ($settings[scheduleKey].enabled) {
+      showNotification(`${label} is on automatic schedule`, `${notifPrefix}-scheduled`);
+    } else {
+      updateSetting(settingKey, !$settings[settingKey]);
+      showNotification(
+        $settings[settingKey] ? `${label} Off` : `${label} On`,
+        `${notifPrefix}-toggle`
+      );
+    }
+  }
+
   function rotateScrollMode() {
     const current = $settings.scrollMode;
     const order = ['auto', 'vertical', 'horizontal'] as const;
@@ -1413,7 +1426,7 @@
         ></button>
         <div
           class="grid"
-          style:filter={`invert(${$invertColorsActive ? 1 : 0})`}
+          style:filter={$imageFilter}
           ondblclick={onDoubleTap}
           onpointerdown={handleOverlayPointerDown}
           onclick={handleOverlayToggle}

--- a/src/lib/components/Reader/VerticalScrollReader.svelte
+++ b/src/lib/components/Reader/VerticalScrollReader.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Page, VolumeMetadata } from '$lib/types';
   import type { VolumeSettings } from '$lib/settings/volume-data';
-  import { settings, invertColorsActive } from '$lib/settings';
+  import { settings, imageFilter } from '$lib/settings';
   import { matchFilesToPages } from '$lib/reader/image-cache';
   import { getCharCount } from '$lib/util/count-chars';
   import { activityTracker } from '$lib/util/activity-tracker';
@@ -587,7 +587,7 @@
     style:overscroll-behavior="none"
     onscroll={handleScroll}
   >
-    <div bind:this={zoomSpacerEl} style:filter={`invert(${$invertColorsActive ? 1 : 0})`}>
+    <div bind:this={zoomSpacerEl} style:filter={$imageFilter}>
       <div bind:this={zoomWrapperEl} style:transform-origin="top left">
         <!-- Centering spacer -->
         <div style:height="50vh"></div>

--- a/src/lib/components/Settings/Reader/ReaderToggles.svelte
+++ b/src/lib/components/Settings/Reader/ReaderToggles.svelte
@@ -3,12 +3,12 @@
     settings,
     nightModeActive,
     invertColorsActive,
+    grayscaleActive,
     type SettingsKey,
-    updateSetting,
-    updateScheduleSetting
+    updateSetting
   } from '$lib/settings';
   import { Toggle, Range, Label } from 'flowbite-svelte';
-  import TimePicker from '../TimePicker.svelte';
+  import ScheduledFilterCard from './ScheduledFilterCard.svelte';
 
   let isContinuous = $derived($settings.continuousScroll);
 
@@ -47,34 +47,6 @@
       ] as { key: SettingsKey; text: string; value: any; shortcut?: string; description?: string }[]
     ).filter((t) => !isContinuous || !continuousHidden.has(t.key))
   );
-
-  // Mode selection: 'manual' or 'scheduled'
-  let nightModeMode = $derived($settings.nightModeSchedule.enabled ? 'scheduled' : 'manual');
-  let invertMode = $derived($settings.invertColorsSchedule.enabled ? 'scheduled' : 'manual');
-
-  function setNightModeMode(mode: 'manual' | 'scheduled') {
-    if (mode === 'manual') {
-      updateScheduleSetting('nightModeSchedule', 'enabled', false);
-    } else {
-      updateScheduleSetting('nightModeSchedule', 'enabled', true);
-      // Turn off manual when switching to scheduled
-      if ($settings.nightMode) {
-        updateSetting('nightMode', false);
-      }
-    }
-  }
-
-  function setInvertMode(mode: 'manual' | 'scheduled') {
-    if (mode === 'manual') {
-      updateScheduleSetting('invertColorsSchedule', 'enabled', false);
-    } else {
-      updateScheduleSetting('invertColorsSchedule', 'enabled', true);
-      // Turn off manual when switching to scheduled
-      if ($settings.invertColors) {
-        updateSetting('invertColors', false);
-      }
-    }
-  }
 </script>
 
 {#each toggles as { key, text, value, shortcut, description }}
@@ -91,129 +63,33 @@
   </div>
 {/each}
 
-<!-- Night Mode with Schedule -->
-<div class="mt-2 rounded-lg border border-gray-200 p-3 dark:border-gray-700">
-  <div class="mb-2 flex items-center justify-between">
-    <span class="text-sm font-medium text-gray-900 dark:text-white">
-      Night mode
-      {#if $nightModeActive}
-        <span class="ml-1 text-xs text-green-600 dark:text-green-400">(active)</span>
-      {/if}
-    </span>
-  </div>
+<!-- Display filters (Manual or Scheduled) — shared control -->
+<ScheduledFilterCard
+  title="Night mode"
+  enableLabel="Enable night mode"
+  hotkeyHint="N"
+  settingKey="nightMode"
+  scheduleKey="nightModeSchedule"
+  active={$nightModeActive}
+/>
 
-  <div class="mb-3 flex gap-4">
-    <label class="flex cursor-pointer items-center gap-2">
-      <input
-        type="radio"
-        name="nightModeMode"
-        checked={nightModeMode === 'manual'}
-        onchange={() => setNightModeMode('manual')}
-        class="h-4 w-4 text-primary-600"
-      />
-      <span class="text-sm text-gray-700 dark:text-gray-300">Manual (N)</span>
-    </label>
-    <label class="flex cursor-pointer items-center gap-2">
-      <input
-        type="radio"
-        name="nightModeMode"
-        checked={nightModeMode === 'scheduled'}
-        onchange={() => setNightModeMode('scheduled')}
-        class="h-4 w-4 text-primary-600"
-      />
-      <span class="text-sm text-gray-700 dark:text-gray-300">Scheduled</span>
-    </label>
-  </div>
+<ScheduledFilterCard
+  title="Invert colors"
+  enableLabel="Enable invert colors"
+  hotkeyHint="I"
+  settingKey="invertColors"
+  scheduleKey="invertColorsSchedule"
+  active={$invertColorsActive}
+/>
 
-  {#if nightModeMode === 'manual'}
-    <Toggle
-      size="small"
-      checked={$settings.nightMode}
-      onchange={() => updateSetting('nightMode', !$settings.nightMode)}
-    >
-      Enable night mode
-    </Toggle>
-  {:else}
-    <div class="space-y-2">
-      <div class="flex items-center gap-2">
-        <Label class="w-12 text-xs text-gray-700 dark:text-gray-300">Start:</Label>
-        <TimePicker
-          value={$settings.nightModeSchedule.startTime}
-          onchange={(val) => updateScheduleSetting('nightModeSchedule', 'startTime', val)}
-        />
-      </div>
-      <div class="flex items-center gap-2">
-        <Label class="w-12 text-xs text-gray-700 dark:text-gray-300">End:</Label>
-        <TimePicker
-          value={$settings.nightModeSchedule.endTime}
-          onchange={(val) => updateScheduleSetting('nightModeSchedule', 'endTime', val)}
-        />
-      </div>
-    </div>
-  {/if}
-</div>
-
-<!-- Invert Colors with Schedule -->
-<div class="mt-2 rounded-lg border border-gray-200 p-3 dark:border-gray-700">
-  <div class="mb-2 flex items-center justify-between">
-    <span class="text-sm font-medium text-gray-900 dark:text-white">
-      Invert colors
-      {#if $invertColorsActive}
-        <span class="ml-1 text-xs text-green-600 dark:text-green-400">(active)</span>
-      {/if}
-    </span>
-  </div>
-
-  <div class="mb-3 flex gap-4">
-    <label class="flex cursor-pointer items-center gap-2">
-      <input
-        type="radio"
-        name="invertMode"
-        checked={invertMode === 'manual'}
-        onchange={() => setInvertMode('manual')}
-        class="h-4 w-4 text-primary-600"
-      />
-      <span class="text-sm text-gray-700 dark:text-gray-300">Manual (I)</span>
-    </label>
-    <label class="flex cursor-pointer items-center gap-2">
-      <input
-        type="radio"
-        name="invertMode"
-        checked={invertMode === 'scheduled'}
-        onchange={() => setInvertMode('scheduled')}
-        class="h-4 w-4 text-primary-600"
-      />
-      <span class="text-sm text-gray-700 dark:text-gray-300">Scheduled</span>
-    </label>
-  </div>
-
-  {#if invertMode === 'manual'}
-    <Toggle
-      size="small"
-      checked={$settings.invertColors}
-      onchange={() => updateSetting('invertColors', !$settings.invertColors)}
-    >
-      Enable invert colors
-    </Toggle>
-  {:else}
-    <div class="space-y-2">
-      <div class="flex items-center gap-2">
-        <Label class="w-12 text-xs text-gray-700 dark:text-gray-300">Start:</Label>
-        <TimePicker
-          value={$settings.invertColorsSchedule.startTime}
-          onchange={(val) => updateScheduleSetting('invertColorsSchedule', 'startTime', val)}
-        />
-      </div>
-      <div class="flex items-center gap-2">
-        <Label class="w-12 text-xs text-gray-700 dark:text-gray-300">End:</Label>
-        <TimePicker
-          value={$settings.invertColorsSchedule.endTime}
-          onchange={(val) => updateScheduleSetting('invertColorsSchedule', 'endTime', val)}
-        />
-      </div>
-    </div>
-  {/if}
-</div>
+<ScheduledFilterCard
+  title="Black & white"
+  enableLabel="Enable black & white"
+  hotkeyHint="G"
+  settingKey="grayscale"
+  scheduleKey="grayscaleSchedule"
+  active={$grayscaleActive}
+/>
 
 <div class="mt-4">
   <Label class="mb-2 text-gray-900 dark:text-white">

--- a/src/lib/components/Settings/Reader/ScheduledFilterCard.svelte
+++ b/src/lib/components/Settings/Reader/ScheduledFilterCard.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  import {
+    settings,
+    updateSetting,
+    updateScheduleSetting,
+    type ScheduleSettingKey
+  } from '$lib/settings';
+  import { Toggle, Label } from 'flowbite-svelte';
+  import TimePicker from '../TimePicker.svelte';
+
+  let {
+    title,
+    enableLabel,
+    hotkeyHint,
+    settingKey,
+    scheduleKey,
+    active
+  }: {
+    title: string;
+    enableLabel: string;
+    hotkeyHint: string;
+    settingKey: 'nightMode' | 'invertColors' | 'grayscale';
+    scheduleKey: ScheduleSettingKey;
+    active: boolean;
+  } = $props();
+
+  let mode = $derived($settings[scheduleKey].enabled ? 'scheduled' : 'manual');
+  // Unique radio-group name so multiple cards on the page stay independent.
+  let groupName = $derived(`${scheduleKey}-mode`);
+
+  function setMode(next: 'manual' | 'scheduled') {
+    if (next === 'manual') {
+      updateScheduleSetting(scheduleKey, 'enabled', false);
+    } else {
+      updateScheduleSetting(scheduleKey, 'enabled', true);
+      // Turn off the manual toggle when switching to scheduled
+      if ($settings[settingKey]) {
+        updateSetting(settingKey, false);
+      }
+    }
+  }
+</script>
+
+<div class="mt-2 rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+  <div class="mb-2 flex items-center justify-between">
+    <span class="text-sm font-medium text-gray-900 dark:text-white">
+      {title}
+      {#if active}
+        <span class="ml-1 text-xs text-green-600 dark:text-green-400">(active)</span>
+      {/if}
+    </span>
+  </div>
+
+  <div class="mb-3 flex gap-4">
+    <label class="flex cursor-pointer items-center gap-2">
+      <input
+        type="radio"
+        name={groupName}
+        checked={mode === 'manual'}
+        onchange={() => setMode('manual')}
+        class="h-4 w-4 text-primary-600"
+      />
+      <span class="text-sm text-gray-700 dark:text-gray-300">Manual ({hotkeyHint})</span>
+    </label>
+    <label class="flex cursor-pointer items-center gap-2">
+      <input
+        type="radio"
+        name={groupName}
+        checked={mode === 'scheduled'}
+        onchange={() => setMode('scheduled')}
+        class="h-4 w-4 text-primary-600"
+      />
+      <span class="text-sm text-gray-700 dark:text-gray-300">Scheduled</span>
+    </label>
+  </div>
+
+  {#if mode === 'manual'}
+    <Toggle
+      size="small"
+      checked={$settings[settingKey]}
+      onchange={() => updateSetting(settingKey, !$settings[settingKey])}
+    >
+      {enableLabel}
+    </Toggle>
+  {:else}
+    <div class="space-y-2">
+      <div class="flex items-center gap-2">
+        <Label class="w-12 text-xs text-gray-700 dark:text-gray-300">Start:</Label>
+        <TimePicker
+          value={$settings[scheduleKey].startTime}
+          onchange={(val) => updateScheduleSetting(scheduleKey, 'startTime', val)}
+        />
+      </div>
+      <div class="flex items-center gap-2">
+        <Label class="w-12 text-xs text-gray-700 dark:text-gray-300">End:</Label>
+        <TimePicker
+          value={$settings[scheduleKey].endTime}
+          onchange={(val) => updateScheduleSetting(scheduleKey, 'endTime', val)}
+        />
+      </div>
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/Settings/Reader/__tests__/ScheduledFilterCard.test.ts
+++ b/src/lib/components/Settings/Reader/__tests__/ScheduledFilterCard.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import ScheduledFilterCard from '../ScheduledFilterCard.svelte';
+
+const baseProps = {
+  title: 'Black & white',
+  enableLabel: 'Enable black & white',
+  hotkeyHint: 'G',
+  settingKey: 'grayscale',
+  scheduleKey: 'grayscaleSchedule'
+} as const;
+
+describe('ScheduledFilterCard', () => {
+  it('renders the title and the manual hotkey hint', () => {
+    const { getByText } = render(ScheduledFilterCard, {
+      props: { ...baseProps, active: false }
+    });
+    expect(getByText('Black & white')).toBeTruthy();
+    expect(getByText('Manual (G)')).toBeTruthy();
+  });
+
+  it('shows the active indicator when active', () => {
+    const { getByText } = render(ScheduledFilterCard, {
+      props: { ...baseProps, active: true }
+    });
+    expect(getByText('(active)')).toBeTruthy();
+  });
+});

--- a/src/lib/settings/settings.test.ts
+++ b/src/lib/settings/settings.test.ts
@@ -1,6 +1,7 @@
 // src/lib/settings/settings.test.ts
-import { describe, expect, it } from 'vitest';
-import { migrateProfiles } from './settings';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { migrateProfiles, grayscaleActive, updateSetting, updateScheduleSetting } from './settings';
 
 describe('theme migration', () => {
   it('defaults a profile with no theme to the Dark preset', () => {
@@ -30,5 +31,46 @@ describe('theme migration', () => {
     });
     expect(out.Test.customTheme.accent).toBe('#abcdef');
     expect(out.Test.customTheme.background).toBeDefined();
+  });
+});
+
+describe('grayscaleActive', () => {
+  beforeEach(() => {
+    // Known baseline: manual mode, filter off
+    updateScheduleSetting('grayscaleSchedule', 'enabled', false);
+    updateSetting('grayscale', false);
+  });
+
+  it('reflects the manual toggle when the schedule is disabled', () => {
+    updateSetting('grayscale', true);
+    expect(get(grayscaleActive)).toBe(true);
+
+    updateSetting('grayscale', false);
+    expect(get(grayscaleActive)).toBe(false);
+  });
+
+  describe('scheduled mode', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('is active when the current time is within a crossing-midnight schedule', () => {
+      vi.setSystemTime(new Date(2026, 0, 1, 22, 0, 0)); // 22:00
+      updateScheduleSetting('grayscaleSchedule', 'startTime', '21:00');
+      updateScheduleSetting('grayscaleSchedule', 'endTime', '06:00');
+      updateScheduleSetting('grayscaleSchedule', 'enabled', true);
+      expect(get(grayscaleActive)).toBe(true);
+    });
+
+    it('is inactive when the current time is outside the schedule', () => {
+      vi.setSystemTime(new Date(2026, 0, 1, 12, 0, 0)); // 12:00
+      updateScheduleSetting('grayscaleSchedule', 'startTime', '21:00');
+      updateScheduleSetting('grayscaleSchedule', 'endTime', '06:00');
+      updateScheduleSetting('grayscaleSchedule', 'enabled', true);
+      expect(get(grayscaleActive)).toBe(false);
+    });
   });
 });

--- a/src/lib/settings/settings.test.ts
+++ b/src/lib/settings/settings.test.ts
@@ -1,7 +1,13 @@
 // src/lib/settings/settings.test.ts
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { get } from 'svelte/store';
-import { migrateProfiles, grayscaleActive, updateSetting, updateScheduleSetting } from './settings';
+import {
+  migrateProfiles,
+  grayscaleActive,
+  imageFilter,
+  updateSetting,
+  updateScheduleSetting
+} from './settings';
 
 describe('theme migration', () => {
   it('defaults a profile with no theme to the Dark preset', () => {
@@ -72,5 +78,35 @@ describe('grayscaleActive', () => {
       updateScheduleSetting('grayscaleSchedule', 'enabled', true);
       expect(get(grayscaleActive)).toBe(false);
     });
+  });
+});
+
+describe('imageFilter', () => {
+  beforeEach(() => {
+    // Manual mode for both filters, both off
+    updateScheduleSetting('invertColorsSchedule', 'enabled', false);
+    updateScheduleSetting('grayscaleSchedule', 'enabled', false);
+    updateSetting('invertColors', false);
+    updateSetting('grayscale', false);
+  });
+
+  it('is both-off by default', () => {
+    expect(get(imageFilter)).toBe('invert(0) grayscale(0)');
+  });
+
+  it('reflects invert only', () => {
+    updateSetting('invertColors', true);
+    expect(get(imageFilter)).toBe('invert(1) grayscale(0)');
+  });
+
+  it('reflects grayscale only', () => {
+    updateSetting('grayscale', true);
+    expect(get(imageFilter)).toBe('invert(0) grayscale(1)');
+  });
+
+  it('reflects both on', () => {
+    updateSetting('invertColors', true);
+    updateSetting('grayscale', true);
+    expect(get(imageFilter)).toBe('invert(1) grayscale(1)');
   });
 });

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -145,6 +145,8 @@ export type Settings = {
   nightModeSchedule: TimeSchedule;
   invertColors: boolean;
   invertColorsSchedule: TimeSchedule;
+  grayscale: boolean;
+  grayscaleSchedule: TimeSchedule;
   inactivityTimeoutMinutes: number;
   swapWheelBehavior: boolean;
   textBoxContextMenu: boolean;
@@ -174,7 +176,7 @@ export type CatalogSettingsKey = keyof CatalogSettings;
 
 export type TimeScheduleKey = keyof TimeSchedule;
 
-export type ScheduleSettingKey = 'nightModeSchedule' | 'invertColorsSchedule';
+export type ScheduleSettingKey = 'nightModeSchedule' | 'invertColorsSchedule' | 'grayscaleSchedule';
 
 // Helper to migrate old AnkiConnect settings to new modelConfigs format
 function migrateOldAnkiModelConfig(oldSettings: Record<string, any>): Record<string, ModelConfig> {
@@ -280,6 +282,12 @@ const defaultSettings: Settings = {
   },
   invertColors: false,
   invertColorsSchedule: {
+    enabled: false,
+    startTime: '21:00',
+    endTime: '06:00'
+  },
+  grayscale: false,
+  grayscaleSchedule: {
     enabled: false,
     startTime: '21:00',
     endTime: '06:00'
@@ -441,6 +449,11 @@ export function migrateProfiles(profiles: Profiles): Profiles {
     migratedProfile.invertColorsSchedule = {
       ...defaultSettings.invertColorsSchedule,
       ...(profile.invertColorsSchedule || {})
+    };
+
+    migratedProfile.grayscaleSchedule = {
+      ...defaultSettings.grayscaleSchedule,
+      ...(profile.grayscaleSchedule || {})
     };
 
     migratedProfile.catalogSettings = {
@@ -611,6 +624,14 @@ export const invertColorsActive = derived([settings, currentMinute], ([$settings
     return isWithinSchedule($settings.invertColorsSchedule);
   }
   return $settings.invertColors ?? false;
+});
+
+export const grayscaleActive = derived([settings, currentMinute], ([$settings, _]) => {
+  if (!$settings) return false;
+  if ($settings.grayscaleSchedule?.enabled) {
+    return isWithinSchedule($settings.grayscaleSchedule);
+  }
+  return $settings.grayscale ?? false;
 });
 
 /**

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -635,6 +635,17 @@ export const grayscaleActive = derived([settings, currentMinute], ([$settings, _
 });
 
 /**
+ * Combined CSS filter string for the manga image layer. invert() and
+ * grayscale() commute, so order is irrelevant. Night mode is applied
+ * separately via NightModeFilter.svelte and is intentionally not included.
+ */
+export const imageFilter = derived(
+  [invertColorsActive, grayscaleActive],
+  ([$invertColorsActive, $grayscaleActive]) =>
+    `invert(${$invertColorsActive ? 1 : 0}) grayscale(${$grayscaleActive ? 1 : 0})`
+);
+
+/**
  * Helper function to update a profile's timestamp
  */
 function touchProfile(profile: Settings): Settings {


### PR DESCRIPTION
## Summary

Adds a black-and-white (grayscale) reader filter (issue #221), built as a faithful mirror of the existing **invert colors** filter, and refactors the shared machinery so the three display filters no longer duplicate code.

- **New B&W filter:** `grayscale` + `grayscaleSchedule` settings (with migration), a `grayscaleActive` derived store, and a **`G`** hotkey — Manual toggle *and* time-based Scheduled mode, just like invert.
- **Reusable control:** extracted the duplicated night/invert settings card into one `ScheduledFilterCard.svelte`, now used for night mode, invert, and B&W (net −124 lines in `ReaderToggles.svelte`).
- **Centralized filter:** a single `imageFilter` derived store (`invert(x) grayscale(y)`) replaces the three inline `invert(...)` strings across the paged, horizontal-scroll, and vertical-scroll readers. `invert()` and `grayscale()` commute, so combining them is order-independent.
- **DRY'd hotkeys:** `KeyN` / `KeyI` / `KeyG` now route through one `toggleScheduledFilter` helper.
- Night mode's application path (`NightModeFilter.svelte`) is unchanged — only its settings card is unified.

## Implementation notes

- One intentional cosmetic change: the night-mode *scheduled* toast normalizes to "Night Mode is on automatic schedule" (capital M) so all three filters share one label.
- Design + plan committed under `docs/superpowers/`.

## Automated verification

- `npm run lint` — 0 errors
- `npm run check` — 0 errors, 0 warnings
- `npm test` — 459 passing (incl. new `grayscaleActive`, `imageFilter`, and `ScheduledFilterCard` tests)
- `npm run build` — succeeds

## Test Plan (manual QA)

- [ ] Settings → Reader shows three matching cards: Night mode / Invert colors / Black & white
- [ ] Enabling "Black & white" greys the page; card shows "(active)"
- [ ] **G** toggles B&W and shows a `B&W On` / `B&W Off` toast (correct wording)
- [ ] Works in paged, horizontal-scroll, and vertical-scroll modes
- [ ] B&W + Invert together = inverted grayscale; **N** / **I** unchanged
- [ ] Scheduled mode activates by time; **G** then shows "B&W is on automatic schedule"
- [ ] Setting persists across reload (and exports/syncs like other settings)

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)