### PR TITLE
fix: request persistent storage from import user gestures for Firefox

### DIFF
--- a/src/lib/import/import-service.ts
+++ b/src/lib/import/import-service.ts
@@ -33,6 +33,7 @@ import {
 import { getImportUiBridge, type MissingFilesInfo } from './import-ui';
 import { extractSeriesName } from '$lib/upload/image-only-fallback';
 import { generateUUID } from '$lib/util/uuid';
+import { requestPersistentStorage } from '$lib/util/upload';
 import {
   extractArchiveByVolumes,
   decompressArchive,
@@ -1007,6 +1008,10 @@ export async function importArchiveWithOptionalMokuro(
     errors: []
   };
 
+  // Request persistent storage within the originating user gesture (see the
+  // note in importFiles) before we await any decompression/processing work.
+  void requestPersistentStorage();
+
   const pairedSource = createArchiveSource(archiveFile, mokuroFile);
   const queueItem = createLocalQueueItem(pairedSource);
   addToProgressTracker(queueItem);
@@ -1056,6 +1061,13 @@ export async function importFiles(files: File[], options?: ImportOptions): Promi
   if (files.length === 0) {
     return result;
   }
+
+  // Request persistent storage now, while we still hold the user gesture that
+  // triggered this import. Firefox only surfaces its persistent-storage prompt
+  // for a gesture-initiated request; once we await pairing/decompression below,
+  // the user activation is gone and the prompt never appears. Fire-and-forget —
+  // the prompt is non-blocking and resolves independently of the import.
+  void requestPersistentStorage();
 
   try {
     // Convert to FileEntry format

--- a/src/lib/util/download-queue.ts
+++ b/src/lib/util/download-queue.ts
@@ -20,6 +20,7 @@ import {
   decrementPoolUsers
 } from './file-processing-pool';
 import { normalizeFilename } from './misc';
+import { requestPersistentStorage } from './upload';
 import {
   getImageMimeType,
   isImageExtension,
@@ -107,6 +108,14 @@ queueStore.subscribe((queue) => {
  * Add a single volume to the download queue
  */
 export function queueVolume(volume: VolumeMetadata): void {
+  // Request persistent storage from within the click that queued this download.
+  // Cloud volumes are saved off the main gesture in the background worker, so
+  // this synchronous enqueue is the only point in the cloud path that still
+  // holds user activation — which Firefox needs to show its prompt. All cloud
+  // entry points (queueSeriesVolumes, queueVolumesFromCloudFiles) funnel here.
+  // Idempotent, so the per-volume repeat during a series queue is harmless.
+  void requestPersistentStorage();
+
   const cloudFileId = getCloudFileId(volume);
   const cloudProvider = getCloudProvider(volume);
 

--- a/src/lib/util/upload.ts
+++ b/src/lib/util/upload.ts
@@ -1,7 +1,23 @@
-export async function requestPersistentStorage() {
-  if (navigator.storage && navigator.storage.persist) {
-    await navigator.storage.persist();
+/**
+ * Ask the browser to mark our storage as persistent so IndexedDB isn't evicted.
+ *
+ * Firefox shows a permission prompt for this (Chromium decides silently), and
+ * both MDN and web.dev are explicit that the request should be made from a user
+ * gesture at the moment important data is saved — NOT on page load. Call this
+ * synchronously from the gesture that starts an import so the prompt actually
+ * appears; calling it deep in async work or at startup means Firefox won't.
+ *
+ * @returns true if storage is now persistent, false otherwise (incl. unsupported)
+ */
+export async function requestPersistentStorage(): Promise<boolean> {
+  if (navigator.storage?.persist) {
+    try {
+      return await navigator.storage.persist();
+    } catch {
+      return false;
+    }
   }
+  return false;
 }
 
 export function formatBytes(bytes: number, decimals = 2) {

--- a/src/lib/views/UploadView.svelte
+++ b/src/lib/views/UploadView.svelte
@@ -9,6 +9,7 @@
   import { db } from '$lib/catalog/db';
   import { thumbnailCache } from '$lib/catalog/thumbnail-cache';
   import { normalizeFilename, promptConfirmation, showSnackbar } from '$lib/util';
+  import { requestPersistentStorage } from '$lib/util/upload';
   import { nav } from '$lib/util/hash-router';
   import { progressTrackerStore } from '$lib/util/progress-tracker';
   import { onMount } from 'svelte';
@@ -92,6 +93,11 @@
 
   async function onImport() {
     if (!request) return;
+
+    // Request persistent storage now, within the confirmation click. The actual
+    // import below runs only after an async network download, by which point the
+    // user activation Firefox needs for its prompt is gone.
+    void requestPersistentStorage();
 
     const normalizedVolume = normalizeFilename(request.volume);
     const processId = `cross-site-import-${Date.now()}`;


### PR DESCRIPTION
## Problem

Firefox (unlike Chromium) shows a user-facing permission prompt for persistent storage, and only surfaces it for a **gesture-initiated** request. The request was buried in `saveVolume` (the background DB write) — reached only after pairing, worker decompression, and network downloads, long after the originating click. (A prior attempt also requested it on page load, which MDN/web.dev explicitly warn against.) Result: the prompt never reliably appeared, so Firefox could evict the IndexedDB-backed library.

## Fix

Request persistence synchronously from the actual import **user gestures**, across every import path:

| Import path | Where it's now requested |
| --- | --- |
| Regular upload (drag-drop, file picker) | `importFiles` / `importArchiveWithOptionalMokuro`, before the first `await` |
| Cloud provider download (Drive / MEGA / WebDAV) | `queueVolume` — the chokepoint all cloud queueing funnels through, inside the download click |
| Cross-site deep-link import | `UploadView.onImport`, before the network download |

- The buried `saveVolume` call is kept as an idempotent safety net.
- `requestPersistentStorage()` now returns the grant result and no longer throws.

### Known gap
PWA file-association launches (`launchQueue`) carry no user activation, so the prompt may not appear there. Low impact: persistent storage is **per-origin and permanent once granted** via any other path.

## Verification
- `npm run check`: 0 errors
- ESLint (changed files): 0 new warnings
- 450/450 tests pass

⚠️ The actual Firefox prompt behavior still needs manual confirmation in Firefox (drag-drop a file, click download on a cloud placeholder, open a cross-site import link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
