### PR TITLE
feat(reader): targeted zoom in continuous reading modes (#195)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ vite.config.ts.timestamp-*
 *.swp
 *.swo
 *~
+
+# Playwright artifacts
+test-results/
+playwright-report/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Mokuro Reader is a web-based manga reader for [mokuro](https://github.com/kha-wh
 - `npm run preview` - Preview production build
 - `npm test` - Run tests with Vitest
 - `npm run test:coverage` - Run tests with coverage
+- `npm run test:e2e` - Run Playwright e2e tests (see Testing for port caveats)
 - `npm run check` - Type-check with svelte-check
 - `npm run check:watch` - Type-check in watch mode
 - `npm run lint` - Lint code (Prettier + ESLint)
@@ -262,6 +263,13 @@ These are only required for Google Drive sync. MEGA and WebDAV don't require env
 - Component tests use @testing-library/svelte
 - Run tests with `npm test`
 - Example test files: `src/lib/util/count-chars.test.ts`, `src/lib/components/Settings/__tests__/QuickAccess.test.ts`
+
+### E2E (Playwright)
+
+- `npm run test:e2e` runs `e2e/*.spec.ts`. The config starts (or **silently reuses**) a dev server on port 5173.
+- **Multi-worktree caveat**: if another worktree's dev server already owns 5173, the suite would run against that worktree's code. Set `E2E_PORT=<free port>` to start a dedicated server for the current worktree.
+- `E2E_CHROMIUM=/path/to/chrome` points Playwright at an existing browser binary instead of downloading one (e.g. a build under `~/.cache/ms-playwright/`).
+- The zoom specs import production modules (`zoom-controller.ts`, `zoom-layout.ts`, `page-detection.ts`) through the Vite dev server and drive them against synthetic page strips.
 
 ## Common Development Tasks
 

--- a/docs/superpowers/specs/2026-06-09-continuous-targeted-zoom-design.md
+++ b/docs/superpowers/specs/2026-06-09-continuous-targeted-zoom-design.md
@@ -56,6 +56,8 @@ Both readers duplicate ~150 lines of zoom/pinch state. Extract one tested implem
   - `onZoomedChange(zoomed)` — drives `userZoom`-gated layout/drag state in the component
   - `onSettled(zoom)` — cleanup + page re-detection hook
   - API: `wheelZoom(e)`, `pinchStart/Move/End(points)`, `toggleZoom(x, y)` (double-tap), `cycleZoom(dir, x?, y?)`, `reset()` (instant 1×), `finishNow()` (snap to target + settle), `isActive`, `currentZoom`, `zoomTarget`, `destroy()`.
+- **`src/lib/reader/zoom-layout.ts`** (new): the reader-specific layout appliers (`applyVerticalZoomLayout`, `applyHorizontalZoomLayout` + alignment) — element-parametrized and Svelte-free so the components and the e2e suite drive the **same** code; the wrapper width pin and RTL transform-origin rules live only here.
+- **`src/lib/reader/page-detection.ts`** (new): pure rect-based current-page detection (`closestPageToCenter`, `detectHorizontalPage`, `horizontalVisibilityRatio`), unit-tested with zoomed-rect fixtures so the "aberrant paging" regression class stays pinned by tests.
 
 ### Frame step (the core fix)
 
@@ -79,8 +81,9 @@ Anchor capture (gesture start): pick the page element containing/nearest the ges
 
 ### Settle, interruption, and exclusivity rules
 
-- **Pinch must settle explicitly.** `Animator.snapTo` never fires `onSettle`, so `pinchEnd` runs the same settle routine as animated zoom: snap `zoomTarget` to the nearest level (bookkeeping; the visual zoom stays where the user left it), run 1× cleanup when `currentZoom ≤ 1 + ε`, re-run page detection + `reportProgress()`.
-- **`finishNow()`:** any competing scroll intent — keyboard nav, the external `currentPage` effect, scroll-intent wheel, a new drag — arriving while `controller.isActive` first snaps the zoom to its target and runs the settle routine synchronously, then proceeds against settled geometry. This prevents two rAF loops (zoom correction vs `ScrollAnimator`) from fighting and prevents user input from being silently reverted by the correction loop.
+- **Pinch must settle explicitly.** `Animator.snapTo` never fires `onSettle`, so `pinchEnd` runs the same settle routine as animated zoom: snap `zoomTarget` to the nearest level (bookkeeping; the visual zoom stays where the user left it — except releases between 1 and 1.05, which animate back to exactly 1× so a near-unzoomed view doesn't linger with zoomed layout), run 1× cleanup when `currentZoom ≤ 1 + ε`, re-run page detection + `reportProgress()`.
+- **`finishNow()`:** any competing scroll intent — keyboard nav, the external `currentPage` effect, scroll-intent wheel, a new drag — arriving while `controller.isActive` first snaps the zoom to its target and runs the settle routine synchronously, then proceeds against settled geometry. This prevents two rAF loops (zoom correction vs `ScrollAnimator`) from fighting and prevents user input from being silently reverted by the correction loop. After an interrupt the component re-syncs the `ScrollAnimator` to the container (`sync()`): scroll events from the correction frames arrive asynchronously, so without it the next `scrollBy` would animate from a stale position and undo the final correction. Wheel zoom also cancels a held-button drag for the same reason.
+- **Component resets are silent.** `reset()` (zoom-mode change, layout-setting change, resize) skips the anchor correction, leaving the scroll offset in stale zoomed-space coordinates — so the components suppress the settle report around it, capture the page to restore **before** resetting, and re-anchor afterward. Reporting there would detect a page roughly zoom× past the real one and corrupt progress/stats.
 - **Settle cleanup is conditional:** the cross-axis scroll reset at 1× only applies when no cross-axis scroll range remains after cleanup (`scrollWidth/Height ≤ client + 1`) — `zoomOriginal`/`fitToWidth` content legitimately scrolls on that axis at 1×.
 - **Pinch re-baselines on pointer-set changes:** if a third finger lands or one of three lifts while two remain, re-baseline `startDist`/`startZoom` and re-capture the anchor at the new midpoint — otherwise the pair-distance ratio jumps discontinuously.
 - **In horizontal, `onSettled` overrides `navTarget`** (and clears `navIsKeyboard`): an interrupted keyboard nav refers to a destination never reached.
@@ -118,7 +121,7 @@ Alignment is no longer driven by Svelte state (`userZoom > 1`) with its async fl
 
 ## Error handling
 
-- Anchor element missing (shouldn't happen — all page divs stay mounted): fall back to wrapper-relative anchoring for that gesture.
+- Anchor element missing (shouldn't happen — all page divs stay mounted): the gesture is ignored. Zooming with no measurable anchor has no meaningful target.
 - Zoom gesture with no scroll container / before mount: ignore.
 - Pinch with <2 pointers, zero start distance: ignore (existing guards).
 

--- a/docs/superpowers/specs/2026-06-09-continuous-targeted-zoom-design.md
+++ b/docs/superpowers/specs/2026-06-09-continuous-targeted-zoom-design.md
@@ -1,0 +1,135 @@
+# Targeted Zoom in Continuous Reading Modes (Issue #195)
+
+**Date:** 2026-06-09
+**Issue:** [#195](https://github.com/Gnathonic/mokuro-reader/issues/195) — Double tap zoom, pinch zoom, and wheel zoom all need to be implemented in both continuous modes. Current attempts result in issues with aberrant paging and are unusable and thus disabled.
+
+## Background
+
+Both continuous readers (`VerticalScrollReader.svelte`, `HorizontalScrollReader.svelte`) already contain a zoom architecture introduced in `74db024` and disabled in `d7f4e55` ("zoom targeting math causes position loss and page jumps"):
+
+- A wrapper element gets `transform: scale(zoom)` with `transform-origin: top left` (GPU-composited, no reflow of the page strip).
+- A spacer element gets explicit dimensions so the scroll container's scroll range covers the visually scaled content.
+- An `Animator` interpolates zoom per frame; each frame recomputes an absolute scroll position from a captured anchor via `computeScrollPosition()` (`zoom-math.ts`).
+- Wheel / pinch / double-tap handlers exist but are commented out.
+
+## Root causes of "position loss and page jumps"
+
+The original targeting failed for identifiable, fixable reasons — all stemming from computing **absolute** scroll positions from a **stale model** of the layout:
+
+1. **Wrapper offset assumed to be (0,0).** `computeScrollPosition()` takes a fixed wrapper offset of 0, but:
+   - Horizontal: the wrapper is vertically positioned by `align-items: center` / `flex-start` (flips on `userZoom > 1`, which only updates on animation settle → guaranteed jump at settle).
+   - Vertical: pages are centered with `mx-auto` inside a wrapper whose layout width tracks the spacer width (`viewportWidth * zoom`) — pages **re-center themselves horizontally every frame** as the spacer grows, invalidating the captured anchor.
+2. **RTL scroll coordinates.** The horizontal reader sets `direction: rtl` on the scroll container. In RTL, `scrollLeft` is `0` at the right edge and goes **negative** leftward. The math produces positive LTR values which the browser clamps to `0` → instant jump to the first page. This alone makes horizontal zoom unusable for RTL manga (the default).
+3. **Page detection in the wrong coordinate space.** Vertical `detectCurrentPage()` compares `el.offsetTop` (unscaled layout space) against `scrollTop` (scaled visual space). At 2× zoom on page 10 it detects ~page 20. The reported page drives progress/stat tracking and the base for keyboard navigation, so misdetection corrupts read stats and makes paging jump wildly ("aberrant paging").
+4. **Page detection runs mid-gesture.** The scroll-settle handler (150 ms) fires during zoom animation while layout is in flux; the horizontal reader syncs `navTarget` from it, so subsequent keyboard nav starts from a garbage page.
+5. **Browser scroll anchoring.** Spacer dimension changes are layout mutations; the browser's native scroll anchoring can adjust scroll positions behind our back (no `overflow-anchor: none` is set).
+6. **RTL overflow reachability.** Per CSS Overflow, content overflowing past the _inline-start_ edge of a scroller is unreachable (the same rule that makes left-overflow unreachable in LTR). In the RTL horizontal reader, inline-start is the **right** edge — and the wrapper scales from `transform-origin: top left`, pushing `(zoom−1)·stripWidth` of content rightward past the scroll origin. At 2×, roughly the first half of an RTL volume is physically unscrollable; no scroll math can reach it. The origin side must match the scroll-origin side: `transform-origin: top right` under RTL.
+7. **Layout-dependent page boxes (vertical fit-to-width).** Pages use `width: 100%` of a wrapper whose layout width tracks the spacer (`viewportWidth · zoom`), so the page _layout boxes themselves_ resize every frame while the inner image stays fixed — content scales as zoom² with growing gaps, and no anchor in page-box space stays glued to image content. The wrapper's layout width must be pinned to `viewportWidth` while zoomed so child layout is zoom-invariant and only the transform scales it.
+
+## Approaches considered
+
+**A. Measurement-based per-frame anchor correction (chosen).** Keep the transform+spacer architecture. Stop predicting absolute scroll positions; instead, every frame: apply zoom, force layout, _measure_ where the anchor actually is (`getBoundingClientRect`, which reflects transforms, alignment, centering, and RTL), and apply a **relative** scroll correction (`scrollLeft += actual − desired`). Relative deltas have identical semantics in LTR and RTL. The anchor is captured as a **fractional position inside a page element** (not the wrapper), so layout shifts (e.g. `mx-auto` re-centering) cannot invalidate it. Self-healing: any frame's error is corrected the next frame.
+
+**B. CSS `zoom` property instead of `transform: scale`.** `zoom` affects layout, so scroll geometry follows automatically and most of the math disappears. Rejected: it reflows the entire page strip (potentially hundreds of pages) every animation frame; the project already abandoned a PixiJS reader (`d080d36`) because plain DOM + native scroll outperformed cleverness, and the transform approach was deliberately chosen for GPU compositing (`fd0baff`).
+
+**C. Virtual viewport (transform-only pan+zoom, no native scroll).** Rejected: large rearchitecture, loses native scroll/inertia and the scroll-based progress tracking; the PixiJS history shows this path was already explored and abandoned.
+
+## Design
+
+### Shared controller
+
+Both readers duplicate ~150 lines of zoom/pinch state. Extract one tested implementation:
+
+- **`src/lib/reader/zoom-math.ts`** (extended; pure, unit-tested):
+  - `anchorFraction(rect, x, y)` → fractional anchor within a rect (can be <0/>1; linear extrapolation is fine).
+  - `anchorScreenPosition(rect, fx, fy)` → where that anchor currently is on screen.
+  - `zoomProgress(current, start, target)` → clamped 0–1.
+  - `lerp2(from, to, t)` → interpolated screen target.
+  - `nearestZoomLevel(levels, z)` / `nextZoomLevel(levels, target, dir)`.
+  - `wheelIntentIsZoom(ctrlOrMeta, swapWheelBehavior)`.
+  - `normalizeWheelDelta(deltaY, deltaMode)` + accumulator step logic (pure; timestamps passed in).
+  - `pinchDistance(points)` / `pinchMidpoint(points)`.
+  - The existing `computeScrollPosition`/`screenToContent`/`contentToScreen` are superseded; verified consumers are only the two readers and `zoom-math.test.ts` — remove all three and their tests.
+- **`src/lib/reader/zoom-controller.ts`** (new): `ContinuousZoomController` owning zoom state, the `Animator`, anchor state, pinch state, and wheel accumulation. The component supplies a config:
+  - `getScrollContainer()`, `getPageElements()`, `getViewport()`
+  - `applyZoomLayout(zoom)` — reader-specific spacer dims + wrapper transform
+  - `onZoomedChange(zoomed)` — drives `userZoom`-gated layout/drag state in the component
+  - `onSettled(zoom)` — cleanup + page re-detection hook
+  - API: `wheelZoom(e)`, `pinchStart/Move/End(points)`, `toggleZoom(x, y)` (double-tap), `cycleZoom(dir, x?, y?)`, `reset()` (instant 1×), `finishNow()` (snap to target + settle), `isActive`, `currentZoom`, `zoomTarget`, `destroy()`.
+
+### Frame step (the core fix)
+
+Per animator frame (and per pinch move, via `snapTo` for 1:1 tracking):
+
+1. `applyZoomLayout(zoom)` — spacer dims + `transform: scale(zoom)` + alignment (all imperative, same task, before any measurement).
+2. Force layout (`void container.scrollWidth`).
+3. Measure the anchored page element's rect; `actual = anchorScreenPosition(rect, fx, fy)`.
+4. `desired = lerp2(fromScreen, toScreen, zoomProgress(zoom, startZoom, targetZoom))`.
+5. `container.scrollLeft += actual.x − desired.x; container.scrollTop += actual.y − desired.y` (relative → identical semantics in LTR and RTL; browser clamping at reachable edges degrades gracefully).
+
+**Degenerate-case guards (NaN landmine):** `zoomProgress(current, start, target)` returns **1 when `start === target`** — otherwise pinch (driven via `snapTo`, where start == target on every move, e.g. pinching inward at min zoom) computes 0/0 = NaN, which survives `Math.min/max` clamping _and_ `lerp2` even when `from === to` (`0·NaN = NaN`), and a NaN scroll write coerces to 0 — a teleport to the scroll origin. Belt-and-braces: the controller skips the scroll write unless both deltas are finite.
+
+**Reader-specific `applyZoomLayout`:**
+
+- _Both:_ spacer dimensions derive from **measured wrapper layout size × zoom** (not viewport size) so all three `continuousZoomDefault` modes get a correct scroll range; cleared at 1×.
+- _Vertical:_ pin `wrapper.style.width = viewportWidth px` while zoomed (root cause 7); spacer `width = viewportWidth·zoom`, `minHeight = wrapperHeight·zoom + viewportHeight` (wrapper height is zoom-invariant once the width is pinned).
+- _Horizontal:_ `transform-origin: top right` when RTL, `top left` when LTR (root cause 6); spacer `width = wrapperWidth·zoom`, `height = wrapperHeight·zoom`. Cross-axis alignment of the spacer/wrapper is computed per frame as a pure function of measured geometry — `flex-start` when the wrapper's visual height (`offsetHeight·zoom`) exceeds the container height, `center` otherwise — applied imperatively in the same task as the transform so the measurement step sees post-alignment layout. (This replaces the `userZoom > 1` Svelte-state flip, whose async flush caused the settle jump, and incidentally fixes the pre-existing unreachable-top bug for taller-than-viewport pages at 1×.) The wrapper's _cell_ alignment (between pages of different heights) stays `center` always — it never affects reachability and flipping it reflows the strip mid-gesture.
+
+Anchor capture (gesture start): pick the page element containing/nearest the gesture point, store fractional coords. Re-capture whenever a new gesture or wheel step begins — continuity holds because the previous frames kept that content pinned.
+
+### Settle, interruption, and exclusivity rules
+
+- **Pinch must settle explicitly.** `Animator.snapTo` never fires `onSettle`, so `pinchEnd` runs the same settle routine as animated zoom: snap `zoomTarget` to the nearest level (bookkeeping; the visual zoom stays where the user left it), run 1× cleanup when `currentZoom ≤ 1 + ε`, re-run page detection + `reportProgress()`.
+- **`finishNow()`:** any competing scroll intent — keyboard nav, the external `currentPage` effect, scroll-intent wheel, a new drag — arriving while `controller.isActive` first snaps the zoom to its target and runs the settle routine synchronously, then proceeds against settled geometry. This prevents two rAF loops (zoom correction vs `ScrollAnimator`) from fighting and prevents user input from being silently reverted by the correction loop.
+- **Settle cleanup is conditional:** the cross-axis scroll reset at 1× only applies when no cross-axis scroll range remains after cleanup (`scrollWidth/Height ≤ client + 1`) — `zoomOriginal`/`fitToWidth` content legitimately scrolls on that axis at 1×.
+- **Pinch re-baselines on pointer-set changes:** if a third finger lands or one of three lifts while two remain, re-baseline `startDist`/`startZoom` and re-capture the anchor at the new midpoint — otherwise the pair-distance ratio jumps discontinuously.
+- **In horizontal, `onSettled` overrides `navTarget`** (and clears `navIsKeyboard`): an interrupted keyboard nav refers to a destination never reached.
+
+### Gesture semantics
+
+- **Wheel zoom** (`Ctrl`/`Meta` + wheel, or bare wheel when `swapWheelBehavior`, matching paged mode): steps through `ZOOM_LEVELS = [1, 1.5, 2, 3]`, anchored at the cursor (`from = to = cursor`), animated. Deltas normalized by `deltaMode` (lines ×40, pages ×800) and accumulated with a 100 px step size + idle/direction reset, so one mouse notch = one level step and trackpad streams don't fly through all levels at once.
+- **Wheel scroll under `swapWheelBehavior`**: when swap is on, the _modifier_+wheel combination is the scroll intent and **must actually scroll** — the vertical reader gains an explicit `preventDefault` + `scrollTop += normalizedDelta` branch (today its non-zoom path is a no-op, which under swap would leave the user with no wheel scrolling at all and ctrl+wheel falling through to browser page zoom); the horizontal reader applies its existing deltaY→scrollLeft conversion in that branch. Parity note (same as paged mode): trackpad pinch arrives as ctrl+wheel, so under swap it is classified as scroll.
+- **Double-tap / double-click**: toggle — when `currentZoom ≤ 1 + ε`, zoom to 2× sampling the tap point and animating it toward the viewport center (`from = tap`, `to = center`, interpolated so it pans while zooming, no first-frame jump); otherwise reset to 1× (`from = to = tap`). The predicate is the **animator's current value** (user-visible state), not `zoomTarget` — after a pinch to 1.2× whose target snapped to 1, a double-tap must reset, not zoom in. Matches paged-mode "zoom in / reset" semantics; replaces the old 4-level cycle, which made getting back out tedious. Existing single-tap-vs-double-tap timing and text-box guards stay in the components.
+- **Pinch (pointer events)**: continuous (not level-stepped), clamped to [1, 3]. Anchor = content under the **initial** midpoint, pinned to the **live** midpoint (`from = to = current midpoint`) → combined pan+zoom in one gesture. Applied via `snapTo` (no easing lag). Release runs the settle routine (above). Pinch start cancels drag (existing behavior) and `finishNow()`s any active animation.
+- **Safari desktop trackpad pinch**: Safari never synthesizes ctrl+wheel; it fires proprietary `gesturestart/gesturechange/gestureend` events and browser-zooms the page unless they're `preventDefault`ed. The readers listen for these and feed `baseZoom · e.scale` anchored at `(e.clientX, e.clientY)` through the same pinch path. (Untestable in this environment; isolated to three listeners.)
+- **Level-step guard**: a wheel/cycle step is a no-op only when `next === zoomTarget && |currentZoom − next| < ε` — after a pinch ends at 2.6 (target snapped to 3), a further zoom-in wheel must still animate 2.6 → 3 rather than dead-zone.
+
+### Aberrant paging fixes
+
+- Vertical `detectCurrentPage()` switches to visual space: compare `getBoundingClientRect()` centers against the container rect center (how the horizontal reader already does it) — correct at any zoom.
+- The scroll-settle handler skips detection while `controller.isActive` (animating or pinching); the settle routine re-runs detection + `reportProgress()` so progress updates exactly once, with correct geometry.
+- `ScrollAnimator` gets a `stop()`; any zoom gesture stops in-flight keyboard scroll animations, and conversely any scroll intent `finishNow()`s the zoom (see exclusivity rules).
+- `overflow-anchor: none` on both scroll containers (spacer resizes are real scroll-anchoring triggers in Chrome/Firefox).
+- Vertical `pageFitsVertically()` uses the element's _visual_ rect height instead of `offsetHeight · userZoom` — correct for any zoom value including non-level pinch results.
+
+### Layout-state changes (no more settle jump)
+
+Alignment is no longer driven by Svelte state (`userZoom > 1`) with its async flush; it is computed and applied imperatively inside `applyZoomLayout` (see above), so every frame's measurement sees the real layout and there is no settle flip left to jump. The component keeps a boolean `isZoomed` state (updated via `onZoomedChange`) solely for cross-axis drag gating, which additionally allows cross-axis drag whenever cross-axis scroll range exists at 1×.
+
+### Interaction hygiene
+
+- Zoom resets to 1× (instant, via the settle routine) on `continuousZoomDefault` mode change (Z key) and on viewport resize/orientation change — both already re-anchor to the current page; layering user zoom on top of those transitions is undefined territory.
+- Drag panning, keyboard nav, volume-boundary nav: unchanged semantics; they operate on visual rects and remain correct under zoom.
+
+### Peripheral fixes (flagged during review, same area)
+
+- Reader.svelte's paged-mode image-cache `$effect` is gated off in continuous mode (continuous readers create their own per-page blob URLs and never consume the cache; the effect just wastes a ±5-page decode window keyed off the reported page).
+- `continuousVisibleCount` resets to 1 when the effective scroll mode is vertical (only the horizontal reader reports visible counts; switching horizontal→vertical previously left a stale "n,n+1" page display).
+
+## Error handling
+
+- Anchor element missing (shouldn't happen — all page divs stay mounted): fall back to wrapper-relative anchoring for that gesture.
+- Zoom gesture with no scroll container / before mount: ignore.
+- Pinch with <2 pointers, zero start distance: ignore (existing guards).
+
+## Testing
+
+1. **Unit (vitest/jsdom):** all new pure functions in `zoom-math.ts` (including the `zoomProgress` start==target degenerate case); controller logic with stubbed elements (fake rects/scroll offsets), including: RTL relative-correction equivalence, anchor stability across frames, "pinch clamped at min zoom leaves scroll untouched" (the NaN case), wheel accumulation thresholds, post-pinch wheel step out of the dead zone, pinch pan+zoom pinning, pinch-end settle bookkeeping, pinch pointer-set re-baselining, `finishNow` semantics.
+2. **E2E (Playwright):** `e2e/zoom.spec.ts` is rewritten as a hard gate of this work — the current file re-implements the _old_ absolute-scroll math inline and would silently keep passing. The new spec dynamically imports the **real** `zoom-controller`/`zoom-math` modules through the Vite dev server and drives a synthetic strip DOM (LTR and RTL, including a fit-to-width-like layout) through wheel/double-tap/pinch scenarios, asserting anchor pinning and reachability (page-1 content reachable while zoomed in RTL). Add a `test:e2e` npm script — the Playwright dependency exists but nothing wires it.
+3. **Manual browser verification:** dev server + real volume; wheel zoom (both swap settings), double-tap in/out, page detection correctness while zoomed (page counter), keyboard nav while zoomed, RTL horizontal mode, vertical mode in all three `continuousZoomDefault` modes.
+
+## Out of scope
+
+- Continuous (non-stepped) wheel zoom and zoom ranges beyond 3× (parity with the existing level design).
+- Paged-mode behavior (untouched).
+- Migaku/extension DOM-mutation interactions beyond existing keying patterns.

--- a/e2e/zoom.spec.ts
+++ b/e2e/zoom.spec.ts
@@ -1,262 +1,340 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 /**
- * E2E zoom tests with multi-page volume.
- * Tests zoom at various positions throughout the volume to catch
- * issues that only appear on non-first pages.
+ * E2E tests for the continuous-mode targeted zoom (#195).
+ *
+ * Unlike the previous version of this file — which re-implemented the old
+ * absolute-scroll math inline — these tests import the REAL
+ * ContinuousZoomController through the Vite dev server and drive it against
+ * synthetic page strips that mirror the readers' layout (including the
+ * fit-to-width page boxes, mx-auto centering, RTL direction, and the
+ * transform-origin rules), asserting in a real browser that anchors stay
+ * pinned and content stays reachable.
  */
 
-test.describe('Multi-page vertical scroll zoom', () => {
-  test.beforeEach(async ({ page }) => {
-    // Create a 10-page test volume with distinct colored pages
-    await page.setContent(`
-			<style>
-				* { margin: 0; padding: 0; box-sizing: border-box; }
-				body { overflow: hidden; background: #000; }
-				#outer { position: fixed; inset: 0; }
-				#scroll { width: 100%; height: 100%; overflow: auto; }
-				.spacer-top, .spacer-bottom { height: 50vh; }
-				#wrapper { transform-origin: top left; }
-				.page {
-					width: 400px; height: 600px; margin: 0 auto;
-					position: relative; overflow: hidden;
-					display: flex; align-items: center; justify-content: center;
-					font-size: 48px; color: white; font-family: monospace;
-				}
-			</style>
-			<div id="outer">
-				<div id="scroll">
-					<div id="spacer">
-						<div class="spacer-top"></div>
-						<div id="wrapper">
-							${Array.from(
-                { length: 10 },
-                (_, i) => `
-								<div class="page" id="page${i}" style="background: hsl(${i * 36}, 70%, 40%)">
-									Page ${i}
-								</div>
-							`
-              ).join('')}
-						</div>
-						<div class="spacer-bottom"></div>
-					</div>
-				</div>
-			</div>
-			<div id="debug" style="position:fixed;bottom:0;left:0;color:white;font-size:11px;z-index:9999;background:rgba(0,0,0,0.8);padding:4px;max-width:100%;white-space:pre-wrap;"></div>
-		`);
-  });
+type WorldOpts = { mode: 'vertical' | 'horizontal'; rtl?: boolean };
 
-  /**
-   * Scroll to a specific page, then zoom at a given screen position.
-   * Returns the actual vs expected screen position of the content point.
-   */
-  async function zoomAtPage(
-    page: any,
-    pageIndex: number,
-    fromScreenX: number,
-    fromScreenY: number,
-    toScreenX: number,
-    toScreenY: number,
-    zoom: number
-  ) {
-    return await page.evaluate(
-      ({ pageIndex, fromScreenX, fromScreenY, toScreenX, toScreenY, zoom }) => {
-        const scroll = document.getElementById('scroll')!;
-        const wrapper = document.getElementById('wrapper')!;
-        const spacer = document.getElementById('spacer')!;
-        const targetPage = document.getElementById(`page${pageIndex}`)!;
-        const vh = window.innerHeight;
-        const vw = window.innerWidth;
+async function setupWorld(page: Page, opts: WorldOpts) {
+  await page.goto('/');
+  // Let the app finish booting before we take over the document.
+  await page.waitForTimeout(500);
 
-        // First, scroll to the target page (center it vertically)
-        targetPage.scrollIntoView({ block: 'center' });
+  await page.evaluate(async ({ mode, rtl }) => {
+    const w = window as any;
+    document.body.innerHTML = '';
+    Object.assign(document.body.style, { margin: '0', overflow: 'hidden', background: '#000' });
 
-        // Read wrapper rect AFTER scroll
-        const wrapperRect = wrapper.getBoundingClientRect();
-        const currentZoom = 1;
+    const outer = document.createElement('div');
+    Object.assign(outer.style, { position: 'fixed', inset: '0' });
+    const scroll = document.createElement('div');
+    const spacer = document.createElement('div');
+    const wrapper = document.createElement('div');
+    const pages: HTMLDivElement[] = [];
 
-        // Convert screen position to content space
-        const contentX = (fromScreenX - wrapperRect.left) / currentZoom;
-        const contentY = (fromScreenY - wrapperRect.top) / currentZoom;
-
-        // Set spacer dimensions
-        spacer.style.width = `${wrapper.offsetWidth * zoom}px`;
-        spacer.style.minHeight = `${wrapper.offsetHeight * zoom + vh}px`;
-
-        // Apply transform
-        wrapper.style.transform = `scale(${zoom})`;
-
-        // Force layout
-        void scroll.scrollWidth;
-
-        // Compute scroll position
-        const WRAPPER_OFFSET_X = 0;
-        const WRAPPER_OFFSET_Y = vh / 2;
-        const computedScrollLeft = WRAPPER_OFFSET_X + contentX * zoom - toScreenX;
-        const computedScrollTop = WRAPPER_OFFSET_Y + contentY * zoom - toScreenY;
-
-        scroll.scrollLeft = computedScrollLeft;
-        scroll.scrollTop = computedScrollTop;
-
-        // Verify: where did the content point actually end up?
-        const newWrapperRect = wrapper.getBoundingClientRect();
-        const actualScreenX = newWrapperRect.left + contentX * zoom;
-        const actualScreenY = newWrapperRect.top + contentY * zoom;
-
-        // Also check what the page element looks like
-        const pageRect = targetPage.getBoundingClientRect();
-
-        const debug = document.getElementById('debug')!;
-        debug.textContent = [
-          `Page ${pageIndex} zoom=${zoom}`,
-          `content=(${contentX.toFixed(0)}, ${contentY.toFixed(0)})`,
-          `target=(${toScreenX}, ${toScreenY})`,
-          `actual=(${actualScreenX.toFixed(0)}, ${actualScreenY.toFixed(0)})`,
-          `scroll: computed=(${computedScrollLeft.toFixed(0)}, ${computedScrollTop.toFixed(0)}) actual=(${scroll.scrollLeft}, ${scroll.scrollTop})`,
-          `scrollW=${scroll.scrollWidth} scrollH=${scroll.scrollHeight}`,
-          `wrapperRect=(${newWrapperRect.left.toFixed(0)}, ${newWrapperRect.top.toFixed(0)})`,
-          `pageRect=(${pageRect.left.toFixed(0)}, ${pageRect.top.toFixed(0)}, ${pageRect.width.toFixed(0)}x${pageRect.height.toFixed(0)})`,
-          `scrollClamped: L=${computedScrollLeft !== scroll.scrollLeft} T=${computedScrollTop !== scroll.scrollTop}`
-        ].join('\n');
-
-        return {
-          pageIndex,
-          contentX,
-          contentY,
-          computedScrollLeft,
-          computedScrollTop,
-          actualScrollLeft: scroll.scrollLeft,
-          actualScrollTop: scroll.scrollTop,
-          actualScreenX,
-          actualScreenY,
-          targetScreenX: toScreenX,
-          targetScreenY: toScreenY,
-          scrollWidth: scroll.scrollWidth,
-          scrollHeight: scroll.scrollHeight,
-          errorX: Math.abs(actualScreenX - toScreenX),
-          errorY: Math.abs(actualScreenY - toScreenY),
-          scrollClampedLeft: computedScrollLeft !== scroll.scrollLeft,
-          scrollClampedTop: computedScrollTop !== scroll.scrollTop
-        };
-      },
-      { pageIndex, fromScreenX, fromScreenY, toScreenX, toScreenY, zoom }
-    );
-  }
-
-  // Test zoom at page 0 (first page — known to work)
-  test('page 0: double-tap center zooms correctly', async ({ page }) => {
-    const vp = page.viewportSize()!;
-    const r = await zoomAtPage(
-      page,
-      0,
-      vp.width / 2,
-      vp.height / 2,
-      vp.width / 2,
-      vp.height / 2,
-      2
-    );
-    console.log(
-      `Page 0 center: error=(${r.errorX.toFixed(1)}, ${r.errorY.toFixed(1)}) clamped=(${r.scrollClampedLeft}, ${r.scrollClampedTop})`
-    );
-    expect(r.errorX).toBeLessThan(2);
-    expect(r.errorY).toBeLessThan(2);
-  });
-
-  // Test zoom at page 4 (middle of volume — likely to fail)
-  test('page 4: double-tap center zooms correctly', async ({ page }) => {
-    const vp = page.viewportSize()!;
-    const r = await zoomAtPage(
-      page,
-      4,
-      vp.width / 2,
-      vp.height / 2,
-      vp.width / 2,
-      vp.height / 2,
-      2
-    );
-    console.log(
-      `Page 4 center: error=(${r.errorX.toFixed(1)}, ${r.errorY.toFixed(1)}) clamped=(${r.scrollClampedLeft}, ${r.scrollClampedTop})`
-    );
-    expect(r.errorX).toBeLessThan(2);
-    expect(r.errorY).toBeLessThan(2);
-  });
-
-  // Test zoom at page 9 (last page)
-  test('page 9: double-tap center zooms correctly', async ({ page }) => {
-    const vp = page.viewportSize()!;
-    const r = await zoomAtPage(
-      page,
-      9,
-      vp.width / 2,
-      vp.height / 2,
-      vp.width / 2,
-      vp.height / 2,
-      2
-    );
-    console.log(
-      `Page 9 center: error=(${r.errorX.toFixed(1)}, ${r.errorY.toFixed(1)}) clamped=(${r.scrollClampedLeft}, ${r.scrollClampedTop})`
-    );
-    expect(r.errorX).toBeLessThan(2);
-    expect(r.errorY).toBeLessThan(2);
-  });
-
-  // Test zoom at page 4 — click on RIGHT side, target CENTER
-  test('page 4: right-side click zooms to center', async ({ page }) => {
-    const vp = page.viewportSize()!;
-    const r = await zoomAtPage(
-      page,
-      4,
-      vp.width / 2 + 150,
-      vp.height / 2,
-      vp.width / 2,
-      vp.height / 2,
-      2
-    );
-    console.log(
-      `Page 4 right: error=(${r.errorX.toFixed(1)}, ${r.errorY.toFixed(1)}) clamped=(${r.scrollClampedLeft}, ${r.scrollClampedTop})`
-    );
-    expect(r.errorX).toBeLessThan(2);
-    expect(r.errorY).toBeLessThan(2);
-  });
-
-  // Test zoom at page 4 — click on LEFT side, target CENTER
-  test('page 4: left-side click zooms to center', async ({ page }) => {
-    const vp = page.viewportSize()!;
-    const r = await zoomAtPage(
-      page,
-      4,
-      vp.width / 2 - 150,
-      vp.height / 2,
-      vp.width / 2,
-      vp.height / 2,
-      2
-    );
-    console.log(
-      `Page 4 left: error=(${r.errorX.toFixed(1)}, ${r.errorY.toFixed(1)}) clamped=(${r.scrollClampedLeft}, ${r.scrollClampedTop})`
-    );
-    // Left side might get clamped if scrollLeft would be negative
-    if (!r.scrollClampedLeft) {
-      expect(r.errorX).toBeLessThan(2);
+    if (mode === 'vertical') {
+      Object.assign(scroll.style, {
+        width: '100%',
+        height: '100%',
+        overflow: 'auto',
+        overscrollBehavior: 'none',
+        overflowAnchor: 'none'
+      });
+      wrapper.style.transformOrigin = 'top left';
+      const lead = document.createElement('div');
+      lead.style.height = '50vh';
+      const tail = document.createElement('div');
+      tail.style.height = '50vh';
+      wrapper.appendChild(lead);
+      for (let i = 0; i < 10; i++) {
+        const p = document.createElement('div');
+        // fit-to-width: the page layout box derives from the wrapper width —
+        // the exact geometry that broke the old absolute-scroll targeting.
+        Object.assign(p.style, {
+          width: '100%',
+          aspectRatio: '1400 / 2000',
+          margin: '0 auto -1px',
+          position: 'relative',
+          overflow: 'hidden',
+          background: `hsl(${i * 36}, 70%, 40%)`
+        });
+        wrapper.appendChild(p);
+        pages.push(p);
+      }
+      wrapper.appendChild(tail);
+    } else {
+      const dir = rtl ? 'rtl' : 'ltr';
+      Object.assign(scroll.style, {
+        display: 'flex',
+        height: '100%',
+        alignItems: 'center',
+        overflow: 'auto',
+        overscrollBehavior: 'none',
+        overflowAnchor: 'none',
+        direction: dir
+      });
+      Object.assign(spacer.style, { display: 'flex', alignItems: 'center', direction: dir });
+      Object.assign(wrapper.style, {
+        display: 'flex',
+        alignItems: 'center',
+        direction: dir,
+        transformOrigin: rtl ? 'top right' : 'top left'
+      });
+      const lead = document.createElement('div');
+      Object.assign(lead.style, { flexShrink: '0', width: '50vw' });
+      const tail = document.createElement('div');
+      Object.assign(tail.style, { flexShrink: '0', width: '50vw' });
+      wrapper.appendChild(lead);
+      const pageWidth = Math.round((1400 / 2000) * innerHeight); // fit-to-height
+      for (let i = 0; i < 10; i++) {
+        const p = document.createElement('div');
+        Object.assign(p.style, {
+          width: `${pageWidth}px`,
+          height: `${innerHeight}px`,
+          flexShrink: '0',
+          position: 'relative',
+          overflow: 'hidden',
+          marginRight: '-1px',
+          direction: 'ltr',
+          background: `hsl(${i * 36}, 70%, 40%)`
+        });
+        wrapper.appendChild(p);
+        pages.push(p);
+      }
+      wrapper.appendChild(tail);
     }
-    expect(r.errorY).toBeLessThan(2);
-  });
 
-  // Test zoom at page 7 with zoom level 3
-  test('page 7: zoom 3x center', async ({ page }) => {
-    const vp = page.viewportSize()!;
-    const r = await zoomAtPage(
-      page,
-      7,
-      vp.width / 2,
-      vp.height / 2,
-      vp.width / 2,
-      vp.height / 2,
-      3
-    );
-    console.log(
-      `Page 7 z3: error=(${r.errorX.toFixed(1)}, ${r.errorY.toFixed(1)}) clamped=(${r.scrollClampedLeft}, ${r.scrollClampedTop})`
-    );
-    expect(r.errorX).toBeLessThan(2);
-    expect(r.errorY).toBeLessThan(2);
+    spacer.appendChild(wrapper);
+    scroll.appendChild(spacer);
+    outer.appendChild(scroll);
+    document.body.appendChild(outer);
+
+    // Layout appliers mirroring the readers' applyZoomLayout
+    function applyVertical(zoom: number) {
+      if (zoom > 1) {
+        wrapper.style.width = `${innerWidth}px`;
+        spacer.style.width = `${innerWidth * zoom}px`;
+        spacer.style.minHeight = `${wrapper.offsetHeight * zoom + innerHeight}px`;
+        wrapper.style.transform = `scale(${zoom})`;
+      } else {
+        wrapper.style.transform = '';
+        wrapper.style.width = '';
+        spacer.style.width = '';
+        spacer.style.minHeight = '';
+      }
+    }
+
+    function applyHorizontal(zoom: number) {
+      if (zoom > 1) {
+        spacer.style.width = `${wrapper.offsetWidth * zoom}px`;
+        spacer.style.height = `${wrapper.offsetHeight * zoom}px`;
+        wrapper.style.transform = `scale(${zoom})`;
+      } else {
+        wrapper.style.transform = '';
+        spacer.style.width = '';
+        spacer.style.height = '';
+      }
+      const visualHeight = wrapper.offsetHeight * zoom;
+      const align = visualHeight > scroll.clientHeight + 1 ? 'flex-start' : 'center';
+      scroll.style.alignItems = align;
+      spacer.style.alignItems = align;
+    }
+
+    const mod = await import('/src/lib/reader/zoom-controller.ts');
+    const controller = new mod.ContinuousZoomController({
+      getScrollContainer: () => scroll,
+      getPageElements: () => pages,
+      getViewport: () => ({ width: innerWidth, height: innerHeight }),
+      applyZoomLayout: mode === 'vertical' ? applyVertical : applyHorizontal
+    });
+
+    w.__zoom = {
+      controller,
+      scroll,
+      spacer,
+      wrapper,
+      pages,
+      settle: () =>
+        new Promise<void>((resolve, reject) => {
+          const t0 = performance.now();
+          const check = () => {
+            if (!controller.isActive) return resolve();
+            if (performance.now() - t0 > 10000) return reject(new Error('zoom never settled'));
+            requestAnimationFrame(check);
+          };
+          check();
+        }),
+      frac(i: number, x: number, y: number) {
+        const r = pages[i].getBoundingClientRect();
+        return { fx: (x - r.left) / r.width, fy: (y - r.top) / r.height };
+      },
+      pos(i: number, fx: number, fy: number) {
+        const r = pages[i].getBoundingClientRect();
+        return { x: r.left + fx * r.width, y: r.top + fy * r.height };
+      }
+    };
+  }, opts);
+}
+
+test('vertical fit-to-width: double-tap centers the tapped content on a middle page', async ({
+  page
+}) => {
+  await setupWorld(page, { mode: 'vertical' });
+  const r = await page.evaluate(async () => {
+    const z = (window as any).__zoom;
+    z.pages[5].scrollIntoView({ block: 'center' });
+    const tap = { x: innerWidth / 2 + 300, y: innerHeight / 2 };
+    const frac = z.frac(5, tap.x, tap.y);
+    z.controller.toggleZoom(tap.x, tap.y);
+    await z.settle();
+    return {
+      zoom: z.controller.currentZoom,
+      pos: z.pos(5, frac.fx, frac.fy),
+      vw: innerWidth,
+      vh: innerHeight
+    };
   });
+  expect(r.zoom).toBe(2);
+  expect(Math.abs(r.pos.x - r.vw / 2)).toBeLessThan(2);
+  expect(Math.abs(r.pos.y - r.vh / 2)).toBeLessThan(2);
+});
+
+test('vertical fit-to-width: wheel zoom pins the cursor point and page boxes stay zoom-invariant', async ({
+  page
+}) => {
+  await setupWorld(page, { mode: 'vertical' });
+  const r = await page.evaluate(async () => {
+    const z = (window as any).__zoom;
+    z.pages[3].scrollIntoView({ block: 'center' });
+    const cursor = { x: 700, y: 600 };
+    const frac = z.frac(3, cursor.x, cursor.y);
+
+    z.controller.wheelZoom({
+      deltaY: -120,
+      deltaMode: 0,
+      clientX: cursor.x,
+      clientY: cursor.y,
+      timeStamp: performance.now()
+    });
+    await z.settle();
+    const pos1 = z.pos(3, frac.fx, frac.fy);
+    const zoom1 = z.controller.currentZoom;
+
+    z.controller.wheelZoom({
+      deltaY: -120,
+      deltaMode: 0,
+      clientX: cursor.x,
+      clientY: cursor.y,
+      timeStamp: performance.now()
+    });
+    await z.settle();
+    const pos2 = z.pos(3, frac.fx, frac.fy);
+    const zoom2 = z.controller.currentZoom;
+
+    // Page layout boxes must scale once (transform), not twice (layout × transform)
+    const pageRectWidth = z.pages[3].getBoundingClientRect().width;
+    return { cursor, pos1, zoom1, pos2, zoom2, pageRectWidth, vw: innerWidth };
+  });
+  expect(r.zoom1).toBe(1.5);
+  expect(r.zoom2).toBe(2);
+  expect(Math.abs(r.pos1.x - r.cursor.x)).toBeLessThan(2);
+  expect(Math.abs(r.pos1.y - r.cursor.y)).toBeLessThan(2);
+  expect(Math.abs(r.pos2.x - r.cursor.x)).toBeLessThan(2);
+  expect(Math.abs(r.pos2.y - r.cursor.y)).toBeLessThan(2);
+  expect(Math.abs(r.pageRectWidth - r.vw * 2)).toBeLessThan(2);
+});
+
+test('vertical: pinching inward at min zoom leaves the position untouched', async ({ page }) => {
+  await setupWorld(page, { mode: 'vertical' });
+  const r = await page.evaluate(async () => {
+    const z = (window as any).__zoom;
+    z.pages[2].scrollIntoView({ block: 'center' });
+    const before = { left: z.scroll.scrollLeft, top: z.scroll.scrollTop };
+    z.controller.pinchStart([
+      { x: 860, y: 540 },
+      { x: 1060, y: 540 }
+    ]);
+    z.controller.pinchMove([
+      { x: 910, y: 540 },
+      { x: 1010, y: 540 }
+    ]);
+    z.controller.pinchEnd();
+    await z.settle();
+    return {
+      before,
+      after: { left: z.scroll.scrollLeft, top: z.scroll.scrollTop },
+      zoom: z.controller.currentZoom
+    };
+  });
+  expect(r.zoom).toBe(1);
+  expect(r.after.left).toBe(r.before.left);
+  expect(r.after.top).toBe(r.before.top);
+});
+
+test('horizontal RTL: zoom pins the anchor and the volume start stays reachable', async ({
+  page
+}) => {
+  await setupWorld(page, { mode: 'horizontal', rtl: true });
+  const r = await page.evaluate(async () => {
+    const z = (window as any).__zoom;
+    z.pages[0].scrollIntoView({ inline: 'center' });
+    const rect = z.pages[0].getBoundingClientRect();
+    const anchor = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    const frac = z.frac(0, anchor.x, anchor.y);
+
+    z.controller.cycleZoom(1, anchor.x, anchor.y);
+    await z.settle();
+    z.controller.cycleZoom(1, anchor.x, anchor.y);
+    await z.settle();
+    const pos = z.pos(0, frac.fx, frac.fy);
+
+    // Reachability: at the RTL scroll origin (scrollLeft = 0, its maximum)
+    // the strip's right edge must sit at the viewport edge — with the old
+    // top-left transform-origin the scaled strip extended unreachably past it.
+    z.scroll.scrollLeft = 1e9; // clamps to 0 in RTL
+    const wrapRight = z.wrapper.getBoundingClientRect().right;
+
+    return { anchor, pos, zoom: z.controller.currentZoom, wrapRight, vw: innerWidth };
+  });
+  expect(r.zoom).toBe(2);
+  expect(Math.abs(r.pos.x - r.anchor.x)).toBeLessThan(2);
+  expect(Math.abs(r.pos.y - r.anchor.y)).toBeLessThan(2);
+  expect(r.wrapRight).toBeLessThanOrEqual(r.vw + 1);
+  expect(r.wrapRight).toBeGreaterThan(r.vw - 2);
+});
+
+test('horizontal LTR: double-tap zooms in and a second double-tap restores 1×', async ({
+  page
+}) => {
+  await setupWorld(page, { mode: 'horizontal', rtl: false });
+  const r = await page.evaluate(async () => {
+    const z = (window as any).__zoom;
+    z.pages[2].scrollIntoView({ inline: 'center' });
+    const rect = z.pages[2].getBoundingClientRect();
+    const tap = { x: rect.left + rect.width * 0.75, y: rect.top + rect.height * 0.25 };
+    const frac = z.frac(2, tap.x, tap.y);
+
+    z.controller.toggleZoom(tap.x, tap.y);
+    await z.settle();
+    const zoomedPos = z.pos(2, frac.fx, frac.fy);
+    const zoomedZoom = z.controller.currentZoom;
+
+    z.controller.toggleZoom(innerWidth / 2, innerHeight / 2);
+    await z.settle();
+
+    return {
+      zoomedZoom,
+      zoomedPos,
+      finalZoom: z.controller.currentZoom,
+      transform: z.wrapper.style.transform,
+      spacerWidth: z.spacer.style.width,
+      vw: innerWidth,
+      vh: innerHeight
+    };
+  });
+  expect(r.zoomedZoom).toBe(2);
+  expect(Math.abs(r.zoomedPos.x - r.vw / 2)).toBeLessThan(2);
+  expect(Math.abs(r.zoomedPos.y - r.vh / 2)).toBeLessThan(2);
+  expect(r.finalZoom).toBe(1);
+  expect(r.transform).toBe('');
+  expect(r.spacerWidth).toBe('');
 });

--- a/e2e/zoom.spec.ts
+++ b/e2e/zoom.spec.ts
@@ -39,7 +39,6 @@ async function setupWorld(page: Page, opts: WorldOpts) {
         overscrollBehavior: 'none',
         overflowAnchor: 'none'
       });
-      wrapper.style.transformOrigin = 'top left';
       const lead = document.createElement('div');
       lead.style.height = '50vh';
       const tail = document.createElement('div');
@@ -76,8 +75,7 @@ async function setupWorld(page: Page, opts: WorldOpts) {
       Object.assign(wrapper.style, {
         display: 'flex',
         alignItems: 'center',
-        direction: dir,
-        transformOrigin: rtl ? 'top right' : 'top left'
+        direction: dir
       });
       const lead = document.createElement('div');
       Object.assign(lead.style, { flexShrink: '0', width: '50vw' });
@@ -108,43 +106,27 @@ async function setupWorld(page: Page, opts: WorldOpts) {
     outer.appendChild(scroll);
     document.body.appendChild(outer);
 
-    // Layout appliers mirroring the readers' applyZoomLayout
-    function applyVertical(zoom: number) {
-      if (zoom > 1) {
-        wrapper.style.width = `${innerWidth}px`;
-        spacer.style.width = `${innerWidth * zoom}px`;
-        spacer.style.minHeight = `${wrapper.offsetHeight * zoom + innerHeight}px`;
-        wrapper.style.transform = `scale(${zoom})`;
-      } else {
-        wrapper.style.transform = '';
-        wrapper.style.width = '';
-        spacer.style.width = '';
-        spacer.style.minHeight = '';
-      }
-    }
-
-    function applyHorizontal(zoom: number) {
-      if (zoom > 1) {
-        spacer.style.width = `${wrapper.offsetWidth * zoom}px`;
-        spacer.style.height = `${wrapper.offsetHeight * zoom}px`;
-        wrapper.style.transform = `scale(${zoom})`;
-      } else {
-        wrapper.style.transform = '';
-        spacer.style.width = '';
-        spacer.style.height = '';
-      }
-      const visualHeight = wrapper.offsetHeight * zoom;
-      const align = visualHeight > scroll.clientHeight + 1 ? 'flex-start' : 'center';
-      scroll.style.alignItems = align;
-      spacer.style.alignItems = align;
-    }
+    // Drive the REAL production layout appliers (incl. the wrapper width pin
+    // and the RTL transform-origin rule) — not inline mirrors that would
+    // silently keep passing if the production rules regressed.
+    const layout = await import('/src/lib/reader/zoom-layout.ts');
+    const applyZoomLayout =
+      mode === 'vertical'
+        ? (zoom: number) =>
+            layout.applyVerticalZoomLayout(
+              { wrapper, spacer },
+              { width: innerWidth, height: innerHeight },
+              zoom
+            )
+        : (zoom: number) =>
+            layout.applyHorizontalZoomLayout({ wrapper, spacer, container: scroll }, !!rtl, zoom);
 
     const mod = await import('/src/lib/reader/zoom-controller.ts');
     const controller = new mod.ContinuousZoomController({
       getScrollContainer: () => scroll,
       getPageElements: () => pages,
       getViewport: () => ({ width: innerWidth, height: innerHeight }),
-      applyZoomLayout: mode === 'vertical' ? applyVertical : applyHorizontal
+      applyZoomLayout
     });
 
     w.__zoom = {
@@ -232,7 +214,20 @@ test('vertical fit-to-width: wheel zoom pins the cursor point and page boxes sta
 
     // Page layout boxes must scale once (transform), not twice (layout × transform)
     const pageRectWidth = z.pages[3].getBoundingClientRect().width;
-    return { cursor, pos1, zoom1, pos2, zoom2, pageRectWidth, vw: innerWidth };
+
+    // Page detection (issue #195's "aberrant paging"): with page 6's center
+    // scrolled to the viewport center at 2×, the real detection module must
+    // report 6 — the old offsetTop-based detection drifted by the zoom factor.
+    const det = await import('/src/lib/reader/page-detection.ts');
+    const r6 = z.pages[6].getBoundingClientRect();
+    z.scroll.scrollTop += r6.top + r6.height / 2 - innerHeight / 2;
+    const detected = det.closestPageToCenter(
+      z.scroll.getBoundingClientRect(),
+      z.pages.map((p: Element) => p.getBoundingClientRect()),
+      'y'
+    );
+
+    return { cursor, pos1, zoom1, pos2, zoom2, pageRectWidth, detected, vw: innerWidth };
   });
   expect(r.zoom1).toBe(1.5);
   expect(r.zoom2).toBe(2);
@@ -241,6 +236,7 @@ test('vertical fit-to-width: wheel zoom pins the cursor point and page boxes sta
   expect(Math.abs(r.pos2.x - r.cursor.x)).toBeLessThan(2);
   expect(Math.abs(r.pos2.y - r.cursor.y)).toBeLessThan(2);
   expect(Math.abs(r.pageRectWidth - r.vw * 2)).toBeLessThan(2);
+  expect(r.detected).toBe(6);
 });
 
 test('vertical: pinching inward at min zoom leaves the position untouched', async ({ page }) => {

--- a/e2e/zoom.spec.ts
+++ b/e2e/zoom.spec.ts
@@ -12,14 +12,14 @@ import { test, expect, type Page } from '@playwright/test';
  * pinned and content stays reachable.
  */
 
-type WorldOpts = { mode: 'vertical' | 'horizontal'; rtl?: boolean };
+type WorldOpts = { mode: 'vertical' | 'horizontal'; rtl?: boolean; pageWidth?: number };
 
 async function setupWorld(page: Page, opts: WorldOpts) {
   await page.goto('/');
   // Let the app finish booting before we take over the document.
   await page.waitForTimeout(500);
 
-  await page.evaluate(async ({ mode, rtl }) => {
+  await page.evaluate(async ({ mode, rtl, pageWidth }) => {
     const w = window as any;
     document.body.innerHTML = '';
     Object.assign(document.body.style, { margin: '0', overflow: 'hidden', background: '#000' });
@@ -46,16 +46,30 @@ async function setupWorld(page: Page, opts: WorldOpts) {
       wrapper.appendChild(lead);
       for (let i = 0; i < 10; i++) {
         const p = document.createElement('div');
-        // fit-to-width: the page layout box derives from the wrapper width —
-        // the exact geometry that broke the old absolute-scroll targeting.
-        Object.assign(p.style, {
-          width: '100%',
-          aspectRatio: '1400 / 2000',
-          margin: '0 auto -1px',
-          position: 'relative',
-          overflow: 'hidden',
-          background: `hsl(${i * 36}, 70%, 40%)`
-        });
+        // Default: fit-to-width — the page layout box derives from the
+        // wrapper width, the exact geometry that broke the old absolute-
+        // scroll targeting. With pageWidth: fixed-size fit-to-screen-like
+        // pages narrower than the viewport (side margins).
+        Object.assign(
+          p.style,
+          pageWidth
+            ? {
+                width: `${pageWidth}px`,
+                height: `${Math.round((pageWidth * 2000) / 1400)}px`,
+                margin: '0 auto -1px',
+                position: 'relative',
+                overflow: 'hidden',
+                background: `hsl(${i * 36}, 70%, 40%)`
+              }
+            : {
+                width: '100%',
+                aspectRatio: '1400 / 2000',
+                margin: '0 auto -1px',
+                position: 'relative',
+                overflow: 'hidden',
+                background: `hsl(${i * 36}, 70%, 40%)`
+              }
+        );
         wrapper.appendChild(p);
         pages.push(p);
       }
@@ -116,6 +130,7 @@ async function setupWorld(page: Page, opts: WorldOpts) {
             layout.applyVerticalZoomLayout(
               { wrapper, spacer },
               { width: innerWidth, height: innerHeight },
+              pageWidth ?? innerWidth,
               zoom
             )
         : (zoom: number) =>
@@ -333,4 +348,69 @@ test('horizontal LTR: double-tap zooms in and a second double-tap restores 1×',
   expect(r.finalZoom).toBe(1);
   expect(r.transform).toBe('');
   expect(r.spacerWidth).toBe('');
+});
+
+test('vertical fit-to-screen: side margins are not pannable while zoomed', async ({ page }) => {
+  // Narrow fixed-size pages (560px in a 1920px viewport): at 2x the scaled
+  // content (1120px) still fits, so there must be NO horizontal scroll range
+  // — previously the spacer spanned viewport×zoom and the page could be
+  // panned fully off screen through its own empty margins.
+  await setupWorld(page, { mode: 'vertical', pageWidth: 560 });
+  const r = await page.evaluate(async () => {
+    const z = (window as any).__zoom;
+    z.pages[2].scrollIntoView({ block: 'center' });
+    z.controller.cycleZoom(1, innerWidth / 2, innerHeight / 2);
+    await z.settle();
+    z.controller.cycleZoom(1, innerWidth / 2, innerHeight / 2);
+    await z.settle();
+
+    z.scroll.scrollLeft = 99999; // try to pan the page away
+    const afterRight = z.pages[2].getBoundingClientRect();
+    z.scroll.scrollLeft = -99999;
+    const afterLeft = z.pages[2].getBoundingClientRect();
+
+    return {
+      zoom: z.controller.currentZoom,
+      scrollWidth: z.scroll.scrollWidth,
+      clientWidth: z.scroll.clientWidth,
+      centeredLeft: afterRight.left,
+      expectedLeft: (innerWidth - afterRight.width) / 2,
+      sameAfterPanAttempts: Math.abs(afterRight.left - afterLeft.left) < 1
+    };
+  });
+  expect(r.zoom).toBe(2);
+  expect(r.scrollWidth).toBeLessThanOrEqual(r.clientWidth + 1); // no margin pan range
+  expect(r.sameAfterPanAttempts).toBe(true);
+  expect(Math.abs(r.centeredLeft - r.expectedLeft)).toBeLessThan(2); // stays centered
+});
+
+test('vertical fit-to-screen: overflow pan range hugs the content edges exactly', async ({
+  page
+}) => {
+  // 700px pages at 3x = 2100px > 1920px viewport: a 180px range must exist,
+  // with the content edges flush to the viewport at both extremes.
+  await setupWorld(page, { mode: 'vertical', pageWidth: 700 });
+  const r = await page.evaluate(async () => {
+    const z = (window as any).__zoom;
+    z.pages[2].scrollIntoView({ block: 'center' });
+    for (let i = 0; i < 3; i++) {
+      z.controller.cycleZoom(1, innerWidth / 2, innerHeight / 2);
+      await z.settle();
+    }
+    z.scroll.scrollLeft = 0;
+    const atStart = z.pages[2].getBoundingClientRect();
+    z.scroll.scrollLeft = 99999;
+    const atEnd = z.pages[2].getBoundingClientRect();
+    return {
+      zoom: z.controller.currentZoom,
+      range: z.scroll.scrollWidth - z.scroll.clientWidth,
+      startLeft: atStart.left,
+      endRight: atEnd.left + atEnd.width,
+      vw: innerWidth
+    };
+  });
+  expect(r.zoom).toBe(3);
+  expect(Math.abs(r.range - (700 * 3 - r.vw))).toBeLessThan(2);
+  expect(Math.abs(r.startLeft - 0)).toBeLessThan(2); // left edge flush at start
+  expect(Math.abs(r.endRight - r.vw)).toBeLessThan(2); // right edge flush at end
 });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --plugin-search-dir . --write .",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:publish": "changeset tag",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,15 +1,22 @@
 import { defineConfig } from '@playwright/test';
 
+// Override with E2E_PORT when 5173 is taken (e.g. another worktree's dev server).
+const port = Number(process.env.E2E_PORT ?? 5173);
+
 export default defineConfig({
   testDir: 'e2e',
   timeout: 30000,
   use: {
-    baseURL: 'http://localhost:5173',
-    viewport: { width: 1920, height: 1080 }
+    baseURL: `http://localhost:${port}`,
+    viewport: { width: 1920, height: 1080 },
+    // Point at an existing Chromium build instead of downloading one.
+    ...(process.env.E2E_CHROMIUM
+      ? { launchOptions: { executablePath: process.env.E2E_CHROMIUM } }
+      : {})
   },
   webServer: {
-    command: 'npm run dev -- --port 5173',
-    port: 5173,
+    command: `npm run dev -- --port ${port}`,
+    port,
     reuseExistingServer: true
   }
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
   webServer: {
     command: `npm run dev -- --port ${port}`,
     port,
-    reuseExistingServer: true
+    // Reusing a server that another worktree owns would silently test that
+    // worktree's code — only reuse outside CI, and prefer E2E_PORT locally.
+    reuseExistingServer: !process.env.CI
   }
 });

--- a/src/lib/components/Reader/HorizontalScrollReader.svelte
+++ b/src/lib/components/Reader/HorizontalScrollReader.svelte
@@ -8,6 +8,8 @@
   import MangaPage from './MangaPage.svelte';
   import { ScrollAnimator } from '$lib/reader/scroll-animator';
   import { ContinuousZoomController } from '$lib/reader/zoom-controller';
+  import { applyHorizontalAlignment, applyHorizontalZoomLayout } from '$lib/reader/zoom-layout';
+  import { detectHorizontalPage, horizontalVisibilityRatio } from '$lib/reader/page-detection';
   import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
   import { onMount, onDestroy, tick } from 'svelte';
 
@@ -70,37 +72,24 @@
   let isZoomed = $state(false);
   let suppressSettleReport = false;
 
-  /**
-   * Cross-axis alignment as a pure function of measured geometry: top-align
-   * whenever the strip's visual height exceeds the container (otherwise the
-   * top edge overflows past the unreachable block-start edge), center it
-   * otherwise. Applied imperatively so the zoom frame step measures
-   * post-alignment layout in the same task — Svelte-state flips flush
-   * asynchronously and caused the old settle jump.
-   */
-  function applyAlignment(zoom: number) {
-    if (!scrollContainer || !zoomSpacerEl || !zoomWrapperEl) return;
-    const visualHeight = zoomWrapperEl.offsetHeight * zoom;
-    const align = visualHeight > scrollContainer.clientHeight + 1 ? 'flex-start' : 'center';
-    scrollContainer.style.alignItems = align;
-    zoomSpacerEl.style.alignItems = align;
+  // Reader-specific zoomed layout (transform origin per direction, spacer
+  // dims, measured cross-axis alignment) — shared with the e2e suite, see
+  // zoom-layout.ts
+  function applyZoomLayout(zoom: number) {
+    if (!zoomWrapperEl || !zoomSpacerEl || !scrollContainer) return;
+    applyHorizontalZoomLayout(
+      { wrapper: zoomWrapperEl, spacer: zoomSpacerEl, container: scrollContainer },
+      rtl,
+      zoom
+    );
   }
 
-  function applyZoomLayout(zoom: number) {
-    if (!zoomWrapperEl || !zoomSpacerEl) return;
-    if (zoom > 1) {
-      // Spacer covers the strip's visual extent so the scroll range never
-      // depends on transformed-overflow contribution. The wrapper is a
-      // content-sized flex item, so its layout dims are zoom-invariant.
-      zoomSpacerEl.style.width = `${zoomWrapperEl.offsetWidth * zoom}px`;
-      zoomSpacerEl.style.height = `${zoomWrapperEl.offsetHeight * zoom}px`;
-      zoomWrapperEl.style.transform = `scale(${zoom})`;
-    } else {
-      zoomWrapperEl.style.transform = '';
-      zoomSpacerEl.style.width = '';
-      zoomSpacerEl.style.height = '';
-    }
-    applyAlignment(zoom);
+  function applyAlignment(zoom: number) {
+    if (!zoomWrapperEl || !zoomSpacerEl || !scrollContainer) return;
+    applyHorizontalAlignment(
+      { wrapper: zoomWrapperEl, spacer: zoomSpacerEl, container: scrollContainer },
+      zoom
+    );
   }
 
   function handleZoomSettled(zoom: number) {
@@ -111,11 +100,14 @@
         scrollContainer.scrollTop = 0;
       }
     }
-    // An interrupted keyboard nav refers to a destination never reached —
-    // re-detect from real geometry.
-    navTarget = detectCurrentPage();
-    navIsKeyboard = false;
-    if (!suppressSettleReport) reportProgress();
+    // Suppressed settles (nav interrupts, resets) are followed by their own
+    // navTarget update against restored geometry — detection here would read
+    // the shifted layout and land on a garbage page.
+    if (!suppressSettleReport) {
+      navTarget = detectCurrentPage();
+      navIsKeyboard = false;
+      reportProgress();
+    }
   }
 
   const zoomController = new ContinuousZoomController({
@@ -132,23 +124,43 @@
   /**
    * Finish an in-flight zoom before a competing scroll intent (keyboard nav,
    * external page change) so it acts on settled geometry. The settle report
-   * is suppressed — the navigation is about to change the page anyway.
+   * is suppressed — the navigation is about to change the page anyway —
+   * and the scroller adopts the corrected position (its state only syncs
+   * via async scroll events; without this the next scrollBy would animate
+   * from a stale position and undo the zoom's final correction).
    */
   function interruptZoomForNav() {
     if (!zoomController.isActive) return;
     suppressSettleReport = true;
     zoomController.finishNow();
     suppressSettleReport = false;
+    scroller?.sync();
+    navIsKeyboard = false;
   }
 
-  // When zoom mode changes (Z key), stay on the current page
-  let prevZoomMode = $settings.continuousZoomDefault;
-  $effect(() => {
-    if (zoomMode === prevZoomMode) return;
-    prevZoomMode = zoomMode;
-
+  /**
+   * Instant zoom reset with the settle report suppressed: reset() skips the
+   * anchor correction, so the scroll offset is stale zoomed-space garbage —
+   * detection would land pages ahead and corrupt progress before the caller
+   * re-anchors to the page it captured.
+   */
+  function resetZoom() {
+    suppressSettleReport = true;
     zoomController.reset();
+    suppressSettleReport = false;
+  }
+
+  // When the zoom mode (Z key) or a layout-affecting setting changes, reset
+  // any user zoom (its measured spacer/transform are stale against the new
+  // layout) and stay on the current page.
+  let prevLayoutKey = `${$settings.continuousZoomDefault}|${$settings.pageDividers}|${$settings.scrollGap}|${volumeSettings.rightToLeft ?? true}`;
+  $effect(() => {
+    const layoutKey = `${zoomMode}|${$settings.pageDividers}|${$settings.scrollGap}|${rtl}`;
+    if (layoutKey === prevLayoutKey) return;
+    prevLayoutKey = layoutKey;
+
     const pageIdx = lastReportedPage - 1;
+    resetZoom();
     tick().then(() => {
       applyAlignment(1);
       const el = pageElements[pageIdx];
@@ -167,59 +179,17 @@
   let pageElements: HTMLDivElement[] = [];
 
   /**
-   * Check how much of a page is visible in the viewport (0-1 ratio).
-   */
-  function visibilityRatio(el: HTMLElement, containerRect: DOMRect): number {
-    const rect = el.getBoundingClientRect();
-    if (rect.width <= 0) return 0;
-    const visibleLeft = Math.max(rect.left, containerRect.left);
-    const visibleRight = Math.min(rect.right, containerRect.right);
-    return Math.max(0, visibleRight - visibleLeft) / rect.width;
-  }
-
-  /**
    * Detect current page: the >95% visible page whose center is closest
    * to the viewport center. Falls back to any page with center in viewport.
+   * Pure rect math in visual space — correct at any zoom (page-detection.ts).
    */
   function detectCurrentPage(): number {
     if (!scrollContainer) return navTarget;
-    const containerRect = scrollContainer.getBoundingClientRect();
-    const viewportCenter = containerRect.left + containerRect.width / 2;
-
-    // Primary: among >95% visible pages, pick the one closest to viewport center
-    let bestIdx = -1;
-    let bestDist = Infinity;
-    for (let i = 0; i < pageElements.length; i++) {
-      const el = pageElements[i];
-      if (!el) continue;
-      if (visibilityRatio(el, containerRect) > 0.95) {
-        const rect = el.getBoundingClientRect();
-        const centerX = rect.left + rect.width / 2;
-        const dist = Math.abs(centerX - viewportCenter);
-        if (dist < bestDist) {
-          bestDist = dist;
-          bestIdx = i;
-        }
-      }
-    }
-    if (bestIdx >= 0) return bestIdx;
-
-    // Fallback: page with center closest to viewport center
-    for (let i = 0; i < pageElements.length; i++) {
-      const el = pageElements[i];
-      if (!el) continue;
-      const rect = el.getBoundingClientRect();
-      const centerX = rect.left + rect.width / 2;
-      if (centerX >= containerRect.left && centerX <= containerRect.right) {
-        const dist = Math.abs(centerX - viewportCenter);
-        if (dist < bestDist) {
-          bestDist = dist;
-          bestIdx = i;
-        }
-      }
-    }
-
-    return bestIdx >= 0 ? bestIdx : navTarget;
+    return detectHorizontalPage(
+      scrollContainer.getBoundingClientRect(),
+      pageElements.map((el) => el?.getBoundingClientRect()),
+      navTarget
+    );
   }
 
   function reportProgress() {
@@ -239,7 +209,7 @@
       for (let i = 0; i < pageElements.length; i++) {
         const el = pageElements[i];
         if (!el) continue;
-        if (visibilityRatio(el, containerRect) > 0.95) count++;
+        if (horizontalVisibilityRatio(el.getBoundingClientRect(), containerRect) > 0.95) count++;
       }
       onVisibleCountChange(Math.max(count, 1));
     }
@@ -395,6 +365,9 @@
     if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {
       e.preventDefault();
       scroller?.stop();
+      // A held-button drag would keep writing absolute positions from its
+      // pre-zoom baseline, fighting the correction frames.
+      isDragging = false;
       zoomController.wheelZoom(e);
       return;
     }
@@ -572,9 +545,9 @@
   // ============================================================
 
   function handleResize() {
-    zoomController.reset();
     const wasLandscape = viewportWidth > viewportHeight;
     const pageIdx = lastReportedPage - 1;
+    resetZoom();
     viewportWidth = window.innerWidth;
     viewportHeight = window.innerHeight;
     const isLandscape = viewportWidth > viewportHeight;
@@ -655,12 +628,12 @@
       style:direction={rtl ? 'rtl' : 'ltr'}
       style:filter={$imageFilter}
     >
+      <!-- transform-origin is set by applyHorizontalZoomLayout (top right in RTL) -->
       <div
         bind:this={zoomWrapperEl}
         class="flex"
         style:align-items="center"
         style:direction={rtl ? 'rtl' : 'ltr'}
-        style:transform-origin={rtl ? 'top right' : 'top left'}
       >
         <!-- Centering spacer: allows first page to be centered -->
         <div class="flex-shrink-0" style:width="50vw"></div>

--- a/src/lib/components/Reader/HorizontalScrollReader.svelte
+++ b/src/lib/components/Reader/HorizontalScrollReader.svelte
@@ -7,8 +7,8 @@
   import { activityTracker } from '$lib/util/activity-tracker';
   import MangaPage from './MangaPage.svelte';
   import { ScrollAnimator } from '$lib/reader/scroll-animator';
-  import { Animator } from '$lib/reader/animator';
-  import { computeScrollPosition } from '$lib/reader/zoom-math';
+  import { ContinuousZoomController } from '$lib/reader/zoom-controller';
+  import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
   import { onMount, onDestroy, tick } from 'svelte';
 
   interface Props {
@@ -61,105 +61,84 @@
     return { width: page.img_width * scale, height: viewportHeight };
   }
 
-  function scaledWidth(page: Page): number {
-    return pageSize(page).width;
-  }
-
   // ============================================================
-  // Zoom — CSS zoom on scroll content
+  // Zoom — transform scale + measurement-based scroll correction
   // ============================================================
 
-  let userZoom = $state(1);
-  let zoomTarget = 1;
-  const ZOOM_LEVELS = [1, 1.5, 2, 3];
-
-  let zoomAnchorContentX = 0;
-  let zoomAnchorContentY = 0;
-  let zoomAnchorScreenX = 0;
-  let zoomAnchorScreenY = 0;
   let zoomWrapperEl: HTMLDivElement | undefined = $state();
   let zoomSpacerEl: HTMLDivElement | undefined = $state();
-
-  // Wrapper offset is 0,0 — centering spacers are INSIDE the wrapper
-  const WRAPPER_OFFSET_X = 0;
-  const WRAPPER_OFFSET_Y = 0;
-
-  const zoomAnimator = new Animator(
-    1,
-    (currentZoom) => {
-      if (!zoomWrapperEl || !scrollContainer || !zoomSpacerEl) return;
-
-      // Set spacer dimensions (use viewportHeight as base, not offsetHeight which feeds back)
-      zoomSpacerEl.style.height = currentZoom > 1 ? `${viewportHeight * currentZoom}px` : '';
-      zoomSpacerEl.style.width = currentZoom > 1 ? `${viewportWidth * currentZoom}px` : '';
-
-      // Apply transform
-      zoomWrapperEl.style.transform = currentZoom !== 1 ? `scale(${currentZoom})` : '';
-
-      // Force layout
-      void scrollContainer.scrollWidth;
-
-      // Set scroll using tested math
-      const { scrollLeft, scrollTop } = computeScrollPosition(
-        zoomAnchorContentX,
-        zoomAnchorContentY,
-        zoomAnchorScreenX,
-        zoomAnchorScreenY,
-        currentZoom,
-        WRAPPER_OFFSET_X,
-        WRAPPER_OFFSET_Y
-      );
-      scrollContainer.scrollLeft = scrollLeft;
-      scrollContainer.scrollTop = scrollTop;
-    },
-    {
-      factor: 0.25,
-      epsilon: 0.005,
-      onSettle: () => {
-        userZoom = zoomTarget;
-        if (zoomTarget <= 1 && scrollContainer && zoomSpacerEl) {
-          zoomSpacerEl.style.width = '';
-          zoomSpacerEl.style.height = '';
-          scrollContainer.scrollTop = 0;
-        }
-      }
-    }
-  );
+  let isZoomed = $state(false);
+  let suppressSettleReport = false;
 
   /**
-   * Animate zoom: sample content at fromScreen, place at toScreen.
+   * Cross-axis alignment as a pure function of measured geometry: top-align
+   * whenever the strip's visual height exceeds the container (otherwise the
+   * top edge overflows past the unreachable block-start edge), center it
+   * otherwise. Applied imperatively so the zoom frame step measures
+   * post-alignment layout in the same task — Svelte-state flips flush
+   * asynchronously and caused the old settle jump.
    */
-  function animateZoom(
-    newZoom: number,
-    fromScreenX: number,
-    fromScreenY: number,
-    toScreenX: number,
-    toScreenY: number
-  ) {
-    if (!scrollContainer || !zoomWrapperEl) return;
-    const currentZoom = zoomAnimator.current || 1;
-
-    const wrapperRect = zoomWrapperEl.getBoundingClientRect();
-
-    zoomAnchorContentX = (fromScreenX - wrapperRect.left) / currentZoom;
-    zoomAnchorContentY = (fromScreenY - wrapperRect.top) / currentZoom;
-    zoomAnchorScreenX = toScreenX;
-    zoomAnchorScreenY = toScreenY;
-
-    zoomTarget = newZoom;
-    zoomAnimator.setTarget(newZoom);
+  function applyAlignment(zoom: number) {
+    if (!scrollContainer || !zoomSpacerEl || !zoomWrapperEl) return;
+    const visualHeight = zoomWrapperEl.offsetHeight * zoom;
+    const align = visualHeight > scrollContainer.clientHeight + 1 ? 'flex-start' : 'center';
+    scrollContainer.style.alignItems = align;
+    zoomSpacerEl.style.alignItems = align;
   }
 
-  function cycleZoom(direction: number, anchorX?: number, anchorY?: number) {
-    const curIdx = ZOOM_LEVELS.indexOf(zoomTarget);
-    let nextIdx = curIdx < 0 ? (direction > 0 ? 1 : 0) : curIdx + direction;
-    nextIdx = Math.max(0, Math.min(ZOOM_LEVELS.length - 1, nextIdx));
-    const newZoom = ZOOM_LEVELS[nextIdx];
-    if (newZoom === zoomTarget) return;
+  function applyZoomLayout(zoom: number) {
+    if (!zoomWrapperEl || !zoomSpacerEl) return;
+    if (zoom > 1) {
+      // Spacer covers the strip's visual extent so the scroll range never
+      // depends on transformed-overflow contribution. The wrapper is a
+      // content-sized flex item, so its layout dims are zoom-invariant.
+      zoomSpacerEl.style.width = `${zoomWrapperEl.offsetWidth * zoom}px`;
+      zoomSpacerEl.style.height = `${zoomWrapperEl.offsetHeight * zoom}px`;
+      zoomWrapperEl.style.transform = `scale(${zoom})`;
+    } else {
+      zoomWrapperEl.style.transform = '';
+      zoomSpacerEl.style.width = '';
+      zoomSpacerEl.style.height = '';
+    }
+    applyAlignment(zoom);
+  }
 
-    const ax = anchorX ?? viewportWidth / 2;
-    const ay = anchorY ?? viewportHeight / 2;
-    animateZoom(newZoom, ax, ay, ax, ay);
+  function handleZoomSettled(zoom: number) {
+    if (zoom <= 1 && scrollContainer) {
+      // Reset the cross axis only when no scroll range legitimately remains
+      // at 1× (fit-to-width/original pages taller than the viewport keep it).
+      if (scrollContainer.scrollHeight <= scrollContainer.clientHeight + 1) {
+        scrollContainer.scrollTop = 0;
+      }
+    }
+    // An interrupted keyboard nav refers to a destination never reached —
+    // re-detect from real geometry.
+    navTarget = detectCurrentPage();
+    navIsKeyboard = false;
+    if (!suppressSettleReport) reportProgress();
+  }
+
+  const zoomController = new ContinuousZoomController({
+    getScrollContainer: () => scrollContainer,
+    getPageElements: () => pageElements,
+    getViewport: () => ({ width: viewportWidth, height: viewportHeight }),
+    applyZoomLayout,
+    onZoomedChange: (zoomed) => {
+      isZoomed = zoomed;
+    },
+    onSettled: handleZoomSettled
+  });
+
+  /**
+   * Finish an in-flight zoom before a competing scroll intent (keyboard nav,
+   * external page change) so it acts on settled geometry. The settle report
+   * is suppressed — the navigation is about to change the page anyway.
+   */
+  function interruptZoomForNav() {
+    if (!zoomController.isActive) return;
+    suppressSettleReport = true;
+    zoomController.finishNow();
+    suppressSettleReport = false;
   }
 
   // When zoom mode changes (Z key), stay on the current page
@@ -168,8 +147,10 @@
     if (zoomMode === prevZoomMode) return;
     prevZoomMode = zoomMode;
 
+    zoomController.reset();
     const pageIdx = lastReportedPage - 1;
     tick().then(() => {
+      applyAlignment(1);
       const el = pageElements[pageIdx];
       if (el) el.scrollIntoView({ behavior: 'instant', inline: 'center' });
     });
@@ -271,6 +252,8 @@
 
     if (settleTimer) clearTimeout(settleTimer);
     settleTimer = setTimeout(() => {
+      // Mid-zoom layout is in flux; the zoom settle hook reports instead.
+      if (zoomController.isActive) return;
       // On settle, sync navTarget from DOM only if it wasn't set by keyboard
       if (!navIsKeyboard) {
         navTarget = detectCurrentPage();
@@ -293,13 +276,8 @@
   // ============================================================
 
   /**
-   * Count how many pages are currently fully visible in the viewport.
-   */
-
-  /**
    * Navigate to a page. If the target is past the boundaries,
-   * exit to the series page instead. Home/End use clamp=true
-   * to stay at the boundary without exiting.
+   * exit to the series page instead.
    */
   function navigateToPage(pageIdx: number) {
     if (!scroller || !scrollContainer) return;
@@ -316,6 +294,7 @@
       onVolumeNav('prev');
       return;
     }
+    interruptZoomForNav();
     navTarget = pageIdx;
     navIsKeyboard = true;
     const el = pageElements[pageIdx];
@@ -371,10 +350,12 @@
         break;
       case 'ArrowUp':
         e.preventDefault();
+        interruptZoomForNav();
         scroller?.scrollBy(0, -viewportHeight * 0.5);
         break;
       case 'ArrowDown':
         e.preventDefault();
+        interruptZoomForNav();
         scroller?.scrollBy(0, viewportHeight * 0.5);
         break;
       case 'PageDown':
@@ -409,18 +390,20 @@
 
   function handleWheel(e: WheelEvent) {
     if (!scrollContainer) return;
-    // TODO: Wheel zoom disabled — targeting causes position loss
-    // const swap = $settings.swapWheelBehavior;
-    // const isZoom = swap ? !(e.ctrlKey || e.metaKey) : e.ctrlKey || e.metaKey;
-    // if (isZoom) {
-    //   e.preventDefault();
-    //   cycleZoom(e.deltaY < 0 ? 1 : -1, e.clientX, e.clientY);
-    // } else {
-    // Convert vertical wheel to horizontal scroll
+    const modifier = e.ctrlKey || e.metaKey;
+
+    if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {
+      e.preventDefault();
+      scroller?.stop();
+      zoomController.wheelZoom(e);
+      return;
+    }
+
+    // Scroll intent: convert vertical wheel to horizontal strip scroll.
     e.preventDefault();
-    const delta = rtl ? -e.deltaY : e.deltaY;
-    scrollContainer.scrollLeft += delta;
-    // }
+    if (zoomController.isActive) zoomController.finishNow();
+    const delta = normalizeWheelDelta(e.deltaY, e.deltaMode);
+    scrollContainer.scrollLeft += rtl ? -delta : delta;
   }
 
   // ============================================================
@@ -436,25 +419,7 @@
   let dragScrollTop = 0;
   const DRAG_THRESHOLD = 5;
 
-  // Pinch zoom state
   let activePointers = new Map<number, { x: number; y: number }>();
-  let isPinching = false;
-  let pinchStartDist = 0;
-  let pinchStartZoom = 1;
-
-  function pinchDistance(): number {
-    const pts = [...activePointers.values()];
-    if (pts.length < 2) return 0;
-    const dx = pts[1].x - pts[0].x;
-    const dy = pts[1].y - pts[0].y;
-    return Math.sqrt(dx * dx + dy * dy);
-  }
-
-  function pinchMidpoint(): { x: number; y: number } {
-    const pts = [...activePointers.values()];
-    if (pts.length < 2) return { x: 0, y: 0 };
-    return { x: (pts[0].x + pts[1].x) / 2, y: (pts[0].y + pts[1].y) / 2 };
-  }
 
   function handlePointerDown(e: PointerEvent) {
     activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
@@ -464,18 +429,19 @@
       return;
     }
 
-    // TODO: Pinch zoom disabled — targeting causes position loss
-    // if (activePointers.size === 2) {
-    // 	isDragging = false;
-    // 	wasDrag = true;
-    // 	isPinching = true;
-    // 	pinchStartDist = pinchDistance();
-    // 	pinchStartZoom = zoomAnimator.current || 1;
-    // 	return;
-    // }
+    if (activePointers.size >= 2) {
+      // Pinch start — also re-baselines when the pointer set changes
+      // (third finger down) so the gesture stays continuous.
+      isDragging = false;
+      wasDrag = true;
+      scroller?.stop();
+      zoomController.pinchStart([...activePointers.values()]);
+      return;
+    }
 
     if (e.button !== 0) return;
 
+    if (zoomController.isActive) zoomController.finishNow();
     isDragging = true;
     wasDrag = false;
     dragStartX = e.clientX;
@@ -486,19 +452,12 @@
   }
 
   function handlePointerMove(e: PointerEvent) {
-    activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (activePointers.has(e.pointerId)) {
+      activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    }
 
-    if (isPinching && activePointers.size >= 2) {
-      const dist = pinchDistance();
-      if (pinchStartDist > 0) {
-        const newZoom = pinchStartZoom * (dist / pinchStartDist);
-        const mid = pinchMidpoint();
-        const clamped = Math.max(
-          ZOOM_LEVELS[0],
-          Math.min(ZOOM_LEVELS[ZOOM_LEVELS.length - 1], newZoom)
-        );
-        animateZoom(clamped, mid.x, mid.y, mid.x, mid.y);
-      }
+    if (activePointers.size >= 2) {
+      zoomController.pinchMove([...activePointers.values()]);
       return;
     }
 
@@ -514,25 +473,26 @@
     if (wasDrag) {
       e.preventDefault();
       scrollContainer.scrollLeft = dragScrollLeft - dx;
-      if (userZoom > 1) {
+      if (isZoomed || scrollContainer.scrollHeight > scrollContainer.clientHeight + 1) {
         scrollContainer.scrollTop = dragScrollTop - dy;
       }
     }
   }
 
   function handlePointerUp(e: PointerEvent) {
+    const hadPointer = activePointers.has(e.pointerId);
     activePointers.delete(e.pointerId);
 
-    if (isPinching) {
-      if (activePointers.size < 2) {
-        isPinching = false;
-        const currentZoom = zoomAnimator.current || 1;
-        zoomTarget = ZOOM_LEVELS.reduce((prev, curr) =>
-          Math.abs(curr - currentZoom) < Math.abs(prev - currentZoom) ? curr : prev
-        );
+    if (hadPointer && activePointers.size >= 1 && zoomController.isActive) {
+      if (activePointers.size >= 2) {
+        // A pinch finger lifted but two remain — re-baseline on the new pair.
+        zoomController.pinchStart([...activePointers.values()]);
+      } else {
+        zoomController.pinchEnd();
       }
       return;
     }
+    if (activePointers.size === 0) zoomController.pinchEnd();
 
     if (isDragging) {
       try {
@@ -562,17 +522,12 @@
     }
 
     const now = Date.now();
-    // TODO: Double-tap zoom disabled — targeting causes position loss
-    // if (now - lastTapTime < DOUBLE_TAP_DELAY) {
-    //   lastTapTime = 0;
-    //   const curIdx = ZOOM_LEVELS.indexOf(zoomTarget);
-    //   const nextIdx = (curIdx + 1) % ZOOM_LEVELS.length;
-    //   const newZoom = ZOOM_LEVELS[nextIdx];
-    //   if (newZoom !== zoomTarget) {
-    //     animateZoom(newZoom, e.clientX, e.clientY, viewportWidth / 2, viewportHeight / 2);
-    //   }
-    //   return;
-    // }
+    if (now - lastTapTime < DOUBLE_TAP_DELAY) {
+      lastTapTime = 0;
+      scroller?.stop();
+      zoomController.toggleZoom(e.clientX, e.clientY);
+      return;
+    }
     lastTapTime = now;
     const tapTime = now;
     setTimeout(() => {
@@ -581,10 +536,43 @@
   }
 
   // ============================================================
+  // Safari desktop trackpad pinch (proprietary gesture events)
+  // ============================================================
+
+  interface WebKitGestureEvent extends Event {
+    scale: number;
+    clientX: number;
+    clientY: number;
+  }
+
+  function handleGestureStart(e: Event) {
+    e.preventDefault();
+    const ge = e as WebKitGestureEvent;
+    scroller?.stop();
+    zoomController.gestureStart(ge.clientX ?? viewportWidth / 2, ge.clientY ?? viewportHeight / 2);
+  }
+
+  function handleGestureChange(e: Event) {
+    e.preventDefault();
+    const ge = e as WebKitGestureEvent;
+    zoomController.gestureChange(
+      ge.scale ?? 1,
+      ge.clientX ?? viewportWidth / 2,
+      ge.clientY ?? viewportHeight / 2
+    );
+  }
+
+  function handleGestureEnd(e: Event) {
+    e.preventDefault();
+    zoomController.gestureEnd();
+  }
+
+  // ============================================================
   // Resize
   // ============================================================
 
   function handleResize() {
+    zoomController.reset();
     const wasLandscape = viewportWidth > viewportHeight;
     const pageIdx = lastReportedPage - 1;
     viewportWidth = window.innerWidth;
@@ -592,6 +580,7 @@
     const isLandscape = viewportWidth > viewportHeight;
 
     tick().then(() => {
+      applyAlignment(1);
       if (isLandscape && !wasLandscape) {
         // Rotated to landscape — center pair if both fit
         navigateToPage(pageIdx);
@@ -608,7 +597,11 @@
       scroller = new ScrollAnimator(scrollContainer);
     }
     outerDiv?.addEventListener('wheel', handleWheel, { passive: false });
+    outerDiv?.addEventListener('gesturestart', handleGestureStart);
+    outerDiv?.addEventListener('gesturechange', handleGestureChange);
+    outerDiv?.addEventListener('gestureend', handleGestureEnd);
     requestAnimationFrame(() => {
+      applyAlignment(1);
       // Use navigateToPage for pair centering on landscape mount
       if (scroller) {
         navigateToPage(currentPage - 1);
@@ -621,8 +614,11 @@
 
   onDestroy(() => {
     scroller?.destroy();
-    zoomAnimator.destroy();
+    zoomController.destroy();
     outerDiv?.removeEventListener('wheel', handleWheel);
+    outerDiv?.removeEventListener('gesturestart', handleGestureStart);
+    outerDiv?.removeEventListener('gesturechange', handleGestureChange);
+    outerDiv?.removeEventListener('gestureend', handleGestureEnd);
     if (settleTimer) clearTimeout(settleTimer);
   });
 </script>
@@ -644,26 +640,27 @@
   <div
     bind:this={scrollContainer}
     class="scrollbar-hide flex h-full"
-    style:align-items={userZoom > 1 ? 'flex-start' : 'center'}
+    style:align-items="center"
     style:overflow-x="auto"
     style:overflow-y="auto"
     style:overscroll-behavior="none"
+    style:overflow-anchor="none"
     style:direction={rtl ? 'rtl' : 'ltr'}
     onscroll={handleScroll}
   >
     <div
       bind:this={zoomSpacerEl}
       class="flex"
-      style:align-items={userZoom > 1 ? 'flex-start' : 'center'}
+      style:align-items="center"
       style:direction={rtl ? 'rtl' : 'ltr'}
       style:filter={$imageFilter}
     >
       <div
         bind:this={zoomWrapperEl}
         class="flex"
-        style:align-items={userZoom > 1 ? 'flex-start' : 'center'}
+        style:align-items="center"
         style:direction={rtl ? 'rtl' : 'ltr'}
-        style:transform-origin="top left"
+        style:transform-origin={rtl ? 'top right' : 'top left'}
       >
         <!-- Centering spacer: allows first page to be centered -->
         <div class="flex-shrink-0" style:width="50vw"></div>

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -783,13 +783,15 @@
   let cachedImageUrl1 = $state<string | null>(null);
   let cachedImageUrl2 = $state<string | null>(null);
 
-  // Update cache when page or volume data changes
+  // Update cache when page or volume data changes. Continuous readers render
+  // every page with their own blob URLs and never consume this cache — skip
+  // the decode window there.
   $effect(() => {
     const currentIndex = index;
     const files = volumeData?.files;
     const pgs = pages;
 
-    if (files && pgs.length > 0 && currentIndex >= 0) {
+    if (files && pgs.length > 0 && currentIndex >= 0 && !$settings.continuousScroll) {
       // Update cache first (non-blocking - preloads in background)
       imageCache.updateCache(files, pgs, currentIndex);
 
@@ -832,6 +834,14 @@
   // Window size state for reactive auto-detection
   let windowWidth = $state(typeof window !== 'undefined' ? window.innerWidth : 0);
   let windowHeight = $state(typeof window !== 'undefined' ? window.innerHeight : 0);
+
+  let effectiveScrollMode = $derived(
+    $settings.scrollMode === 'auto'
+      ? windowWidth > windowHeight
+        ? 'horizontal'
+        : 'vertical'
+      : $settings.scrollMode
+  );
 
   // Determine if we should show single page based on mode, pages, and screen
   // Force calculation to wait for all data by using a single derived with explicit dependencies
@@ -894,8 +904,14 @@
   let continuousVisibleCount = $state(1);
   let pageDisplay = $derived.by(() => {
     if ($settings.continuousScroll) {
-      // Continuous mode: use actual visible count from the scroll reader
-      if (continuousVisibleCount > 1 && page + 1 <= (pages?.length ?? 0)) {
+      // Continuous mode: use actual visible count from the scroll reader.
+      // Only the horizontal reader reports counts — ignore a stale value
+      // after switching to vertical.
+      if (
+        effectiveScrollMode === 'horizontal' &&
+        continuousVisibleCount > 1 &&
+        page + 1 <= (pages?.length ?? 0)
+      ) {
         return `${page},${page + 1} / ${pages?.length}`;
       }
       return `${page} / ${pages?.length}`;
@@ -1369,12 +1385,6 @@
     {/key}
   {/if}
   {#if $settings.continuousScroll && volumeData?.files}
-    {@const effectiveScrollMode =
-      $settings.scrollMode === 'auto'
-        ? windowWidth > windowHeight
-          ? 'horizontal'
-          : 'vertical'
-        : $settings.scrollMode}
     {#if effectiveScrollMode === 'vertical'}
       <VerticalScrollReader
         {pages}

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -784,14 +784,14 @@
   let cachedImageUrl2 = $state<string | null>(null);
 
   // Update cache when page or volume data changes. Continuous readers render
-  // every page with their own blob URLs and never consume this cache — skip
-  // the decode window there.
+  // their own blob URLs, but QuickActions reads imageCache.getFile() for Anki
+  // image actions in BOTH modes — the cache must stay warm here.
   $effect(() => {
     const currentIndex = index;
     const files = volumeData?.files;
     const pgs = pages;
 
-    if (files && pgs.length > 0 && currentIndex >= 0 && !$settings.continuousScroll) {
+    if (files && pgs.length > 0 && currentIndex >= 0) {
       // Update cache first (non-blocking - preloads in background)
       imageCache.updateCache(files, pgs, currentIndex);
 

--- a/src/lib/components/Reader/VerticalScrollReader.svelte
+++ b/src/lib/components/Reader/VerticalScrollReader.svelte
@@ -7,8 +7,8 @@
   import { activityTracker } from '$lib/util/activity-tracker';
   import MangaPage from './MangaPage.svelte';
   import { ScrollAnimator } from '$lib/reader/scroll-animator';
-  import { Animator } from '$lib/reader/animator';
-  import { screenToContent, computeScrollPosition } from '$lib/reader/zoom-math';
+  import { ContinuousZoomController } from '$lib/reader/zoom-controller';
+  import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
   import { onMount, onDestroy, tick } from 'svelte';
 
   interface Props {
@@ -73,114 +73,71 @@
   }
 
   // ============================================================
-  // Zoom — CSS zoom on the scroll content
+  // Zoom — transform scale + measurement-based scroll correction
   // ============================================================
 
-  let userZoom = $state(1);
-  let zoomTarget = 1;
-  const ZOOM_LEVELS = [1, 1.5, 2, 3];
-
-  // Zoom anchor — content-space point to keep fixed on screen during zoom
-  let zoomAnchorContentX = 0;
-  let zoomAnchorContentY = 0;
-  let zoomAnchorScreenX = 0;
-  let zoomAnchorScreenY = 0;
   let zoomWrapperEl: HTMLDivElement | undefined = $state();
   let zoomSpacerEl: HTMLDivElement | undefined = $state();
-
-  // Zoom animator — GPU-composited via transform: scale()
-  // Updates transform + spacer dimensions + scroll position directly (no Svelte re-render)
-  // Wrapper offset is 0,0 — centering spacers are INSIDE the wrapper,
-  // so contentY from getBoundingClientRect already includes the spacer offset.
-  const WRAPPER_OFFSET_X = 0;
-  const WRAPPER_OFFSET_Y = 0;
-
-  const zoomAnimator = new Animator(
-    1,
-    (currentZoom) => {
-      if (!zoomWrapperEl || !scrollContainer || !zoomSpacerEl) return;
-
-      // 1. Set spacer dimensions for scroll bounds.
-      // Use viewportWidth as base (not wrapper.offsetWidth which stretches to fill spacer
-      // and creates an exponential feedback loop).
-      // Height uses wrapper.offsetHeight which is stable (determined by stacked content, not parent).
-      zoomSpacerEl.style.width = currentZoom > 1 ? `${viewportWidth * currentZoom}px` : '';
-      zoomSpacerEl.style.minHeight = `${zoomWrapperEl.offsetHeight * currentZoom + viewportHeight}px`;
-
-      // 2. Apply transform
-      zoomWrapperEl.style.transform = currentZoom !== 1 ? `scale(${currentZoom})` : '';
-
-      // 3. Force layout
-      void scrollContainer.scrollWidth;
-
-      // 4. Set scroll using tested math
-      const { scrollLeft, scrollTop } = computeScrollPosition(
-        zoomAnchorContentX,
-        zoomAnchorContentY,
-        zoomAnchorScreenX,
-        zoomAnchorScreenY,
-        currentZoom,
-        WRAPPER_OFFSET_X,
-        WRAPPER_OFFSET_Y
-      );
-      scrollContainer.scrollLeft = scrollLeft;
-      scrollContainer.scrollTop = scrollTop;
-    },
-    {
-      factor: 0.25,
-      epsilon: 0.005,
-      onSettle: () => {
-        userZoom = zoomTarget;
-        // At zoom 1, clear spacer dimensions and reset horizontal scroll
-        if (zoomTarget <= 1 && scrollContainer && zoomSpacerEl) {
-          zoomSpacerEl.style.width = '';
-          zoomSpacerEl.style.minHeight = '';
-          scrollContainer.scrollLeft = 0;
-        }
-      }
-    }
-  );
+  let isZoomed = $state(false);
+  let suppressSettleReport = false;
 
   /**
-   * Animate zoom, sampling content at fromScreen and placing it at toScreen.
-   * - Wheel zoom: from=cursor, to=cursor (keep cursor point fixed)
-   * - Double-tap: from=click, to=center (zoom clicked area to center)
+   * Reader-specific zoomed layout, applied imperatively inside the
+   * controller's frame step (before it measures and corrects scroll).
+   *
+   * The wrapper's layout width is pinned to the viewport width while zoomed:
+   * the spacer grows to provide scroll range, and an unpinned block wrapper
+   * would track it, resizing fit-to-width pages every frame (and re-centering
+   * mx-auto pages), so page layout must stay zoom-invariant with only the
+   * transform scaling it.
    */
-  function animateZoom(
-    newZoom: number,
-    fromScreenX: number,
-    fromScreenY: number,
-    toScreenX: number,
-    toScreenY: number
-  ) {
-    if (!scrollContainer || !zoomWrapperEl) return;
-    const currentZoom = zoomAnimator.current || 1;
-
-    const wrapperRect = zoomWrapperEl.getBoundingClientRect();
-
-    // Content-space point under the "from" screen position
-    zoomAnchorContentX = (fromScreenX - wrapperRect.left) / currentZoom;
-    zoomAnchorContentY = (fromScreenY - wrapperRect.top) / currentZoom;
-
-    // Where that content should end up on screen
-    zoomAnchorScreenX = toScreenX;
-    zoomAnchorScreenY = toScreenY;
-
-    zoomTarget = newZoom;
-    zoomAnimator.setTarget(newZoom);
+  function applyZoomLayout(zoom: number) {
+    if (!zoomWrapperEl || !zoomSpacerEl) return;
+    if (zoom > 1) {
+      zoomWrapperEl.style.width = `${viewportWidth}px`;
+      zoomSpacerEl.style.width = `${viewportWidth * zoom}px`;
+      zoomSpacerEl.style.minHeight = `${zoomWrapperEl.offsetHeight * zoom + viewportHeight}px`;
+      zoomWrapperEl.style.transform = `scale(${zoom})`;
+    } else {
+      zoomWrapperEl.style.transform = '';
+      zoomWrapperEl.style.width = '';
+      zoomSpacerEl.style.width = '';
+      zoomSpacerEl.style.minHeight = '';
+    }
   }
 
-  function cycleZoom(direction: number, anchorX?: number, anchorY?: number) {
-    const curIdx = ZOOM_LEVELS.indexOf(zoomTarget);
-    let nextIdx = curIdx < 0 ? (direction > 0 ? 1 : 0) : curIdx + direction;
-    nextIdx = Math.max(0, Math.min(ZOOM_LEVELS.length - 1, nextIdx));
-    const newZoom = ZOOM_LEVELS[nextIdx];
-    if (newZoom === zoomTarget) return;
+  function handleZoomSettled(zoom: number) {
+    if (zoom <= 1 && scrollContainer) {
+      // Reset the cross axis only when no scroll range legitimately remains
+      // at 1× (zoomOriginal pages wider than the viewport keep theirs).
+      if (scrollContainer.scrollWidth <= scrollContainer.clientWidth + 1) {
+        scrollContainer.scrollLeft = 0;
+      }
+    }
+    if (!suppressSettleReport) reportProgress();
+  }
 
-    // Wheel: keep the cursor point fixed on screen
-    const ax = anchorX ?? viewportWidth / 2;
-    const ay = anchorY ?? viewportHeight / 2;
-    animateZoom(newZoom, ax, ay, ax, ay);
+  const zoomController = new ContinuousZoomController({
+    getScrollContainer: () => scrollContainer,
+    getPageElements: () => pageElements,
+    getViewport: () => ({ width: viewportWidth, height: viewportHeight }),
+    applyZoomLayout,
+    onZoomedChange: (zoomed) => {
+      isZoomed = zoomed;
+    },
+    onSettled: handleZoomSettled
+  });
+
+  /**
+   * Finish an in-flight zoom before a competing scroll intent (keyboard nav,
+   * external page change) so it acts on settled geometry. The settle report
+   * is suppressed — the navigation is about to change the page anyway.
+   */
+  function interruptZoomForNav() {
+    if (!zoomController.isActive) return;
+    suppressSettleReport = true;
+    zoomController.finishNow();
+    suppressSettleReport = false;
   }
 
   // When zoom mode changes (Z key), stay on the current page.
@@ -191,6 +148,7 @@
     if (zoomMode === prevZoomMode) return;
     prevZoomMode = zoomMode;
 
+    zoomController.reset();
     const pageIdx = lastReportedPage - 1;
     tick().then(() => {
       const el = pageElements[pageIdx];
@@ -210,16 +168,24 @@
   let settleTimer: ReturnType<typeof setTimeout> | undefined;
   let pageElements: HTMLDivElement[] = [];
 
+  /**
+   * Current page = element whose visual center is closest to the viewport
+   * center. Uses getBoundingClientRect (visual space) so it stays correct
+   * under the zoom transform — offsetTop is unscaled layout space and
+   * diverges from scroll coordinates as soon as zoom != 1.
+   */
   function detectCurrentPage(): number {
     if (!scrollContainer) return 0;
-    const centerY = scrollContainer.scrollTop + scrollContainer.clientHeight / 2;
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const centerY = containerRect.top + containerRect.height / 2;
     let closest = 0;
     let closestDist = Infinity;
 
     for (let i = 0; i < pageElements.length; i++) {
       const el = pageElements[i];
       if (!el) continue;
-      const elCenter = el.offsetTop + el.offsetHeight / 2;
+      const rect = el.getBoundingClientRect();
+      const elCenter = rect.top + rect.height / 2;
       const dist = Math.abs(elCenter - centerY);
       if (dist < closestDist) {
         closestDist = dist;
@@ -245,7 +211,11 @@
     activityTracker.recordActivity();
 
     if (settleTimer) clearTimeout(settleTimer);
-    settleTimer = setTimeout(reportProgress, 150);
+    settleTimer = setTimeout(() => {
+      // Mid-zoom layout is in flux; the zoom settle hook reports instead.
+      if (zoomController.isActive) return;
+      reportProgress();
+    }, 150);
   }
 
   // External page change
@@ -261,15 +231,14 @@
   // ============================================================
 
   /**
-   * Check if a page fits vertically in the viewport at current zoom.
+   * Check if a page fits vertically in the viewport at the current zoom.
+   * Visual rect height is transform-aware for any zoom value.
    */
   function pageFitsVertically(pageIdx: number): boolean {
     const el = pageElements[pageIdx];
     if (!el) return false;
-    return el.offsetHeight * userZoom <= viewportHeight * 1.05;
+    return el.getBoundingClientRect().height <= viewportHeight * 1.05;
   }
-
-  let lastNavPage = currentPage - 1;
 
   function scrollToPageVertical(pageIdx: number) {
     if (!scroller) return;
@@ -287,7 +256,7 @@
       return;
     }
 
-    lastNavPage = pageIdx;
+    interruptZoomForNav();
     const el = pageElements[pageIdx];
     if (!el) return;
 
@@ -313,6 +282,7 @@
       case 'ArrowDown':
         e.preventDefault();
         if (shouldPanVertically) {
+          interruptZoomForNav();
           scroller?.scrollBy(0, viewportHeight * 0.5);
         } else {
           scrollToPageVertical(detectCurrentPage() + 1);
@@ -321,6 +291,7 @@
       case 'ArrowUp':
         e.preventDefault();
         if (shouldPanVertically) {
+          interruptZoomForNav();
           scroller?.scrollBy(0, -viewportHeight * 0.5);
         } else {
           scrollToPageVertical(detectCurrentPage() - 1);
@@ -328,10 +299,12 @@
         break;
       case 'ArrowLeft':
         e.preventDefault();
+        interruptZoomForNav();
         scroller?.scrollBy(-viewportWidth * 0.5, 0);
         break;
       case 'ArrowRight':
         e.preventDefault();
+        interruptZoomForNav();
         scroller?.scrollBy(viewportWidth * 0.5, 0);
         break;
       case 'PageDown':
@@ -360,13 +333,26 @@
 
   function handleWheel(e: WheelEvent) {
     if (!scrollContainer) return;
-    // TODO: Wheel zoom disabled — targeting causes position loss
-    // const swap = $settings.swapWheelBehavior;
-    // const isZoom = swap ? !(e.ctrlKey || e.metaKey) : e.ctrlKey || e.metaKey;
-    // if (isZoom) {
-    // 	e.preventDefault();
-    // 	cycleZoom(e.deltaY < 0 ? 1 : -1, e.clientX, e.clientY);
-    // }
+    const modifier = e.ctrlKey || e.metaKey;
+
+    if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {
+      e.preventDefault();
+      scroller?.stop();
+      zoomController.wheelZoom(e);
+      return;
+    }
+
+    if (modifier) {
+      // Swap mode: modifier+wheel is the scroll intent. Scroll manually —
+      // letting it fall through would trigger browser page zoom instead.
+      e.preventDefault();
+      if (zoomController.isActive) zoomController.finishNow();
+      scrollContainer.scrollTop += normalizeWheelDelta(e.deltaY, e.deltaMode);
+      return;
+    }
+
+    // Bare wheel scrolls natively; don't let it fight an active zoom.
+    if (zoomController.isActive) zoomController.finishNow();
   }
 
   // ============================================================
@@ -382,25 +368,7 @@
   let dragScrollTop = 0;
   const DRAG_THRESHOLD = 5;
 
-  // Pinch zoom state
   let activePointers = new Map<number, { x: number; y: number }>();
-  let isPinching = false;
-  let pinchStartDist = 0;
-  let pinchStartZoom = 1;
-
-  function pinchDistance(): number {
-    const pts = [...activePointers.values()];
-    if (pts.length < 2) return 0;
-    const dx = pts[1].x - pts[0].x;
-    const dy = pts[1].y - pts[0].y;
-    return Math.sqrt(dx * dx + dy * dy);
-  }
-
-  function pinchMidpoint(): { x: number; y: number } {
-    const pts = [...activePointers.values()];
-    if (pts.length < 2) return { x: 0, y: 0 };
-    return { x: (pts[0].x + pts[1].x) / 2, y: (pts[0].y + pts[1].y) / 2 };
-  }
 
   function handlePointerDown(e: PointerEvent) {
     activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
@@ -410,18 +378,19 @@
       return;
     }
 
-    // TODO: Pinch zoom disabled — targeting causes position loss
-    // if (activePointers.size === 2) {
-    // 	isDragging = false;
-    // 	wasDrag = true;
-    // 	isPinching = true;
-    // 	pinchStartDist = pinchDistance();
-    // 	pinchStartZoom = zoomAnimator.current || 1;
-    // 	return;
-    // }
+    if (activePointers.size >= 2) {
+      // Pinch start — also re-baselines when the pointer set changes
+      // (third finger down) so the gesture stays continuous.
+      isDragging = false;
+      wasDrag = true;
+      scroller?.stop();
+      zoomController.pinchStart([...activePointers.values()]);
+      return;
+    }
 
     if (e.button !== 0) return;
 
+    if (zoomController.isActive) zoomController.finishNow();
     isDragging = true;
     wasDrag = false;
     dragStartX = e.clientX;
@@ -432,20 +401,12 @@
   }
 
   function handlePointerMove(e: PointerEvent) {
-    activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (activePointers.has(e.pointerId)) {
+      activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    }
 
-    if (isPinching && activePointers.size >= 2) {
-      const dist = pinchDistance();
-      if (pinchStartDist > 0) {
-        const newZoom = pinchStartZoom * (dist / pinchStartDist);
-        const mid = pinchMidpoint();
-        // Clamp to zoom level range
-        const clamped = Math.max(
-          ZOOM_LEVELS[0],
-          Math.min(ZOOM_LEVELS[ZOOM_LEVELS.length - 1], newZoom)
-        );
-        animateZoom(clamped, mid.x, mid.y, mid.x, mid.y);
-      }
+    if (activePointers.size >= 2) {
+      zoomController.pinchMove([...activePointers.values()]);
       return;
     }
 
@@ -461,26 +422,26 @@
     if (wasDrag) {
       e.preventDefault();
       scrollContainer.scrollTop = dragScrollTop - dy;
-      if (userZoom > 1) {
+      if (isZoomed || scrollContainer.scrollWidth > scrollContainer.clientWidth + 1) {
         scrollContainer.scrollLeft = dragScrollLeft - dx;
       }
     }
   }
 
   function handlePointerUp(e: PointerEvent) {
+    const hadPointer = activePointers.has(e.pointerId);
     activePointers.delete(e.pointerId);
 
-    if (isPinching) {
-      if (activePointers.size < 2) {
-        isPinching = false;
-        // Snap zoomTarget to nearest level for keyboard zoom to work from
-        const currentZoom = zoomAnimator.current || 1;
-        zoomTarget = ZOOM_LEVELS.reduce((prev, curr) =>
-          Math.abs(curr - currentZoom) < Math.abs(prev - currentZoom) ? curr : prev
-        );
+    if (hadPointer && activePointers.size >= 1 && zoomController.isActive) {
+      if (activePointers.size >= 2) {
+        // A pinch finger lifted but two remain — re-baseline on the new pair.
+        zoomController.pinchStart([...activePointers.values()]);
+      } else {
+        zoomController.pinchEnd();
       }
       return;
     }
+    if (activePointers.size === 0) zoomController.pinchEnd();
 
     if (isDragging) {
       try {
@@ -510,17 +471,12 @@
     }
 
     const now = Date.now();
-    // TODO: Double-tap zoom disabled — targeting causes position loss
-    // if (now - lastTapTime < DOUBLE_TAP_DELAY) {
-    //   lastTapTime = 0;
-    //   const curIdx = ZOOM_LEVELS.indexOf(zoomTarget);
-    //   const nextIdx = (curIdx + 1) % ZOOM_LEVELS.length;
-    //   const newZoom = ZOOM_LEVELS[nextIdx];
-    //   if (newZoom !== zoomTarget) {
-    //     animateZoom(newZoom, e.clientX, e.clientY, viewportWidth / 2, viewportHeight / 2);
-    //   }
-    //   return;
-    // }
+    if (now - lastTapTime < DOUBLE_TAP_DELAY) {
+      lastTapTime = 0;
+      scroller?.stop();
+      zoomController.toggleZoom(e.clientX, e.clientY);
+      return;
+    }
     lastTapTime = now;
     const tapTime = now;
     setTimeout(() => {
@@ -529,10 +485,43 @@
   }
 
   // ============================================================
+  // Safari desktop trackpad pinch (proprietary gesture events)
+  // ============================================================
+
+  interface WebKitGestureEvent extends Event {
+    scale: number;
+    clientX: number;
+    clientY: number;
+  }
+
+  function handleGestureStart(e: Event) {
+    e.preventDefault();
+    const ge = e as WebKitGestureEvent;
+    scroller?.stop();
+    zoomController.gestureStart(ge.clientX ?? viewportWidth / 2, ge.clientY ?? viewportHeight / 2);
+  }
+
+  function handleGestureChange(e: Event) {
+    e.preventDefault();
+    const ge = e as WebKitGestureEvent;
+    zoomController.gestureChange(
+      ge.scale ?? 1,
+      ge.clientX ?? viewportWidth / 2,
+      ge.clientY ?? viewportHeight / 2
+    );
+  }
+
+  function handleGestureEnd(e: Event) {
+    e.preventDefault();
+    zoomController.gestureEnd();
+  }
+
+  // ============================================================
   // Resize
   // ============================================================
 
   function handleResize() {
+    zoomController.reset();
     const pageIdx = lastReportedPage - 1;
     viewportWidth = window.innerWidth;
     viewportHeight = window.innerHeight;
@@ -551,6 +540,9 @@
       scroller = new ScrollAnimator(scrollContainer);
     }
     outerDiv?.addEventListener('wheel', handleWheel, { passive: false });
+    outerDiv?.addEventListener('gesturestart', handleGestureStart);
+    outerDiv?.addEventListener('gesturechange', handleGestureChange);
+    outerDiv?.addEventListener('gestureend', handleGestureEnd);
     requestAnimationFrame(() => {
       const el = pageElements[currentPage - 1];
       if (el) el.scrollIntoView({ behavior: 'instant', block: 'start' });
@@ -559,8 +551,11 @@
 
   onDestroy(() => {
     scroller?.destroy();
-    zoomAnimator.destroy();
+    zoomController.destroy();
     outerDiv?.removeEventListener('wheel', handleWheel);
+    outerDiv?.removeEventListener('gesturestart', handleGestureStart);
+    outerDiv?.removeEventListener('gesturechange', handleGestureChange);
+    outerDiv?.removeEventListener('gestureend', handleGestureEnd);
     if (settleTimer) clearTimeout(settleTimer);
   });
 </script>
@@ -585,6 +580,7 @@
     style:overflow-y="auto"
     style:overflow-x="auto"
     style:overscroll-behavior="none"
+    style:overflow-anchor="none"
     onscroll={handleScroll}
   >
     <div bind:this={zoomSpacerEl} style:filter={$imageFilter}>

--- a/src/lib/components/Reader/VerticalScrollReader.svelte
+++ b/src/lib/components/Reader/VerticalScrollReader.svelte
@@ -8,6 +8,8 @@
   import MangaPage from './MangaPage.svelte';
   import { ScrollAnimator } from '$lib/reader/scroll-animator';
   import { ContinuousZoomController } from '$lib/reader/zoom-controller';
+  import { applyVerticalZoomLayout } from '$lib/reader/zoom-layout';
+  import { closestPageToCenter } from '$lib/reader/page-detection';
   import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
   import { onMount, onDestroy, tick } from 'svelte';
 
@@ -81,29 +83,14 @@
   let isZoomed = $state(false);
   let suppressSettleReport = false;
 
-  /**
-   * Reader-specific zoomed layout, applied imperatively inside the
-   * controller's frame step (before it measures and corrects scroll).
-   *
-   * The wrapper's layout width is pinned to the viewport width while zoomed:
-   * the spacer grows to provide scroll range, and an unpinned block wrapper
-   * would track it, resizing fit-to-width pages every frame (and re-centering
-   * mx-auto pages), so page layout must stay zoom-invariant with only the
-   * transform scaling it.
-   */
+  // Reader-specific zoomed layout — shared with the e2e suite, see zoom-layout.ts
   function applyZoomLayout(zoom: number) {
     if (!zoomWrapperEl || !zoomSpacerEl) return;
-    if (zoom > 1) {
-      zoomWrapperEl.style.width = `${viewportWidth}px`;
-      zoomSpacerEl.style.width = `${viewportWidth * zoom}px`;
-      zoomSpacerEl.style.minHeight = `${zoomWrapperEl.offsetHeight * zoom + viewportHeight}px`;
-      zoomWrapperEl.style.transform = `scale(${zoom})`;
-    } else {
-      zoomWrapperEl.style.transform = '';
-      zoomWrapperEl.style.width = '';
-      zoomSpacerEl.style.width = '';
-      zoomSpacerEl.style.minHeight = '';
-    }
+    applyVerticalZoomLayout(
+      { wrapper: zoomWrapperEl, spacer: zoomSpacerEl },
+      { width: viewportWidth, height: viewportHeight },
+      zoom
+    );
   }
 
   function handleZoomSettled(zoom: number) {
@@ -131,25 +118,44 @@
   /**
    * Finish an in-flight zoom before a competing scroll intent (keyboard nav,
    * external page change) so it acts on settled geometry. The settle report
-   * is suppressed — the navigation is about to change the page anyway.
+   * is suppressed — the navigation is about to change the page anyway —
+   * and the scroller adopts the corrected position (its state only syncs
+   * via async scroll events; without this the next scrollBy would animate
+   * from a stale position and undo the zoom's final correction).
    */
   function interruptZoomForNav() {
     if (!zoomController.isActive) return;
     suppressSettleReport = true;
     zoomController.finishNow();
     suppressSettleReport = false;
+    scroller?.sync();
   }
 
-  // When zoom mode changes (Z key), stay on the current page.
-  // Use lastReportedPage (set by scroll progress tracking) since
-  // detectCurrentPage() would see the already-shifted layout.
-  let prevZoomMode = $settings.continuousZoomDefault;
-  $effect(() => {
-    if (zoomMode === prevZoomMode) return;
-    prevZoomMode = zoomMode;
-
+  /**
+   * Instant zoom reset with the settle report suppressed: reset() skips the
+   * anchor correction, so the scroll offset is stale zoomed-space garbage —
+   * detection would land pages ahead and corrupt progress before the caller
+   * re-anchors to the page it captured.
+   */
+  function resetZoom() {
+    suppressSettleReport = true;
     zoomController.reset();
+    suppressSettleReport = false;
+  }
+
+  // When the zoom mode (Z key) or a layout-affecting setting changes, reset
+  // any user zoom (its measured spacer/transform are stale against the new
+  // layout) and stay on the current page. Use lastReportedPage (set by
+  // scroll progress tracking) since detectCurrentPage() would see the
+  // already-shifted layout.
+  let prevLayoutKey = `${$settings.continuousZoomDefault}|${$settings.pageDividers}|${$settings.scrollGap}`;
+  $effect(() => {
+    const layoutKey = `${zoomMode}|${$settings.pageDividers}|${$settings.scrollGap}`;
+    if (layoutKey === prevLayoutKey) return;
+    prevLayoutKey = layoutKey;
+
     const pageIdx = lastReportedPage - 1;
+    resetZoom();
     tick().then(() => {
       const el = pageElements[pageIdx];
       if (el)
@@ -176,23 +182,11 @@
    */
   function detectCurrentPage(): number {
     if (!scrollContainer) return 0;
-    const containerRect = scrollContainer.getBoundingClientRect();
-    const centerY = containerRect.top + containerRect.height / 2;
-    let closest = 0;
-    let closestDist = Infinity;
-
-    for (let i = 0; i < pageElements.length; i++) {
-      const el = pageElements[i];
-      if (!el) continue;
-      const rect = el.getBoundingClientRect();
-      const elCenter = rect.top + rect.height / 2;
-      const dist = Math.abs(elCenter - centerY);
-      if (dist < closestDist) {
-        closestDist = dist;
-        closest = i;
-      }
-    }
-    return closest;
+    return closestPageToCenter(
+      scrollContainer.getBoundingClientRect(),
+      pageElements.map((el) => el?.getBoundingClientRect()),
+      'y'
+    );
   }
 
   function reportProgress() {
@@ -338,6 +332,9 @@
     if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {
       e.preventDefault();
       scroller?.stop();
+      // A held-button drag would keep writing absolute positions from its
+      // pre-zoom baseline, fighting the correction frames.
+      isDragging = false;
       zoomController.wheelZoom(e);
       return;
     }
@@ -521,8 +518,8 @@
   // ============================================================
 
   function handleResize() {
-    zoomController.reset();
     const pageIdx = lastReportedPage - 1;
+    resetZoom();
     viewportWidth = window.innerWidth;
     viewportHeight = window.innerHeight;
     tick().then(() => {
@@ -584,7 +581,8 @@
     onscroll={handleScroll}
   >
     <div bind:this={zoomSpacerEl} style:filter={$imageFilter}>
-      <div bind:this={zoomWrapperEl} style:transform-origin="top left">
+      <!-- transform-origin is set by applyVerticalZoomLayout -->
+      <div bind:this={zoomWrapperEl}>
         <!-- Centering spacer -->
         <div style:height="50vh"></div>
         {#each pages as page, i (i)}

--- a/src/lib/components/Reader/VerticalScrollReader.svelte
+++ b/src/lib/components/Reader/VerticalScrollReader.svelte
@@ -83,12 +83,35 @@
   let isZoomed = $state(false);
   let suppressSettleReport = false;
 
+  /**
+   * Widest page's scaled layout width at the current zoom mode — the zoomed
+   * wrapper pins to this (not the viewport width) so empty side margins
+   * never become pannable scroll range.
+   */
+  function maxContentWidth(): number {
+    let max = 0;
+    for (const page of pages) {
+      let width: number;
+      if (zoomMode === 'zoomOriginal') {
+        width = page.img_width;
+      } else if (zoomMode === 'zoomFitToScreen') {
+        const scale = Math.min(viewportWidth / page.img_width, viewportHeight / page.img_height);
+        width = page.img_width * scale;
+      } else {
+        width = viewportWidth; // zoomFitToWidth
+      }
+      if (width > max) max = width;
+    }
+    return max || viewportWidth;
+  }
+
   // Reader-specific zoomed layout — shared with the e2e suite, see zoom-layout.ts
   function applyZoomLayout(zoom: number) {
     if (!zoomWrapperEl || !zoomSpacerEl) return;
     applyVerticalZoomLayout(
       { wrapper: zoomWrapperEl, spacer: zoomSpacerEl },
       { width: viewportWidth, height: viewportHeight },
+      maxContentWidth(),
       zoom
     );
   }

--- a/src/lib/reader/page-detection.test.ts
+++ b/src/lib/reader/page-detection.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  closestPageToCenter,
+  detectHorizontalPage,
+  horizontalVisibilityRatio
+} from './page-detection';
+import type { RectLike } from './zoom-math';
+
+/** Build a vertical strip of page rects as the browser would measure them. */
+function verticalStrip(count: number, pageHeight: number, scrollTop: number, zoom = 1): RectLike[] {
+  return Array.from({ length: count }, (_, i) => ({
+    left: 0,
+    top: (i * pageHeight - scrollTop / zoom) * zoom,
+    width: 1000 * zoom,
+    height: pageHeight * zoom
+  }));
+}
+
+const container: RectLike = { left: 0, top: 0, width: 1000, height: 800 };
+
+describe('closestPageToCenter', () => {
+  it('picks the page under the viewport center', () => {
+    // Page 3 spans 3000–4000; scrolled so its middle is at the center.
+    const rects = verticalStrip(10, 1000, 3100);
+    expect(closestPageToCenter(container, rects, 'y')).toBe(3);
+  });
+
+  it('stays correct at 2x zoom (visual rects, not layout offsets)', () => {
+    // Same reading position as the previous test but measured under
+    // transform: scale(2) — page i spans top = i*2000 - 6200. The old
+    // offsetTop-based detection compared unscaled layout offsets against
+    // scaled scroll coordinates and reported ~page 7 here.
+    const rects = Array.from({ length: 10 }, (_, i) => ({
+      left: 0,
+      top: i * 2000 - 6200,
+      width: 2000,
+      height: 2000
+    }));
+    expect(closestPageToCenter(container, rects, 'y')).toBe(3);
+  });
+
+  it('skips missing entries', () => {
+    const rects: (RectLike | undefined)[] = verticalStrip(10, 1000, 3100);
+    rects[3] = undefined;
+    const got = closestPageToCenter(container, rects, 'y');
+    expect([2, 4]).toContain(got);
+  });
+
+  it('works on the x axis', () => {
+    const rects = Array.from({ length: 5 }, (_, i) => ({
+      left: i * 600 - 900,
+      top: 0,
+      width: 600,
+      height: 800
+    }));
+    // centers at -600, 0, 600, 1200, 1800; container center x = 500
+    expect(closestPageToCenter(container, rects, 'x')).toBe(2);
+  });
+
+  it('returns 0 when no rects are usable', () => {
+    expect(closestPageToCenter(container, [undefined, undefined], 'y')).toBe(0);
+  });
+});
+
+describe('horizontalVisibilityRatio', () => {
+  it('is 1 for a fully visible page and 0 for an offscreen one', () => {
+    expect(
+      horizontalVisibilityRatio({ left: 100, top: 0, width: 400, height: 800 }, container)
+    ).toBe(1);
+    expect(
+      horizontalVisibilityRatio({ left: 1200, top: 0, width: 400, height: 800 }, container)
+    ).toBe(0);
+  });
+
+  it('is fractional for a partially visible page', () => {
+    expect(
+      horizontalVisibilityRatio({ left: -200, top: 0, width: 400, height: 800 }, container)
+    ).toBe(0.5);
+  });
+
+  it('is 0 for a zero-width rect', () => {
+    expect(horizontalVisibilityRatio({ left: 0, top: 0, width: 0, height: 800 }, container)).toBe(
+      0
+    );
+  });
+});
+
+describe('detectHorizontalPage', () => {
+  it('prefers the >95%-visible page closest to the center', () => {
+    // Pages 1 and 2 fully visible, page 2 closer to center
+    const rects: RectLike[] = [
+      { left: -500, top: 0, width: 450, height: 800 },
+      { left: 0, top: 0, width: 450, height: 800 },
+      { left: 460, top: 0, width: 450, height: 800 },
+      { left: 950, top: 0, width: 450, height: 800 }
+    ];
+    expect(detectHorizontalPage(container, rects, 9)).toBe(2);
+  });
+
+  it('falls back to the center-containing page when none is fully visible', () => {
+    // One huge zoomed page covering the center
+    const rects: RectLike[] = [
+      { left: -2500, top: 0, width: 2000, height: 800 },
+      { left: -500, top: 0, width: 2000, height: 800 },
+      { left: 1500, top: 0, width: 2000, height: 800 }
+    ];
+    expect(detectHorizontalPage(container, rects, 9)).toBe(1);
+  });
+
+  it('stays correct under 2x zoom in RTL (negative lefts)', () => {
+    // RTL strip at 2x: page 0 far right offscreen, page 1 spans the viewport
+    const rects: RectLike[] = [
+      { left: 1100, top: 0, width: 1900, height: 1600 },
+      { left: -800, top: 0, width: 1900, height: 1600 },
+      { left: -2700, top: 0, width: 1900, height: 1600 }
+    ];
+    expect(detectHorizontalPage(container, rects, 9)).toBe(1);
+  });
+
+  it('returns the fallback when nothing covers the center', () => {
+    const rects: RectLike[] = [{ left: 2000, top: 0, width: 400, height: 800 }];
+    expect(detectHorizontalPage(container, rects, 7)).toBe(7);
+  });
+});

--- a/src/lib/reader/page-detection.ts
+++ b/src/lib/reader/page-detection.ts
@@ -1,0 +1,91 @@
+/**
+ * Current-page detection for the continuous scroll readers — pure rect math.
+ *
+ * Everything operates on getBoundingClientRect-style visual rects, which
+ * reflect the zoom transform. The bug class this guards against (issue #195
+ * "aberrant paging"): comparing unscaled layout offsets (offsetTop) against
+ * scaled scroll coordinates made detection drift by the zoom factor — at 2×
+ * on page 10 it reported ~page 20, corrupting read stats and keyboard nav.
+ */
+
+import type { RectLike } from './zoom-math';
+
+/**
+ * Index of the page whose visual center is closest to the container's center
+ * along the given axis. Returns 0 when no rects are usable.
+ */
+export function closestPageToCenter(
+  containerRect: RectLike,
+  pageRects: readonly (RectLike | undefined)[],
+  axis: 'x' | 'y'
+): number {
+  const center =
+    axis === 'y'
+      ? containerRect.top + containerRect.height / 2
+      : containerRect.left + containerRect.width / 2;
+  let closest = 0;
+  let closestDist = Infinity;
+  for (let i = 0; i < pageRects.length; i++) {
+    const rect = pageRects[i];
+    if (!rect) continue;
+    const rectCenter = axis === 'y' ? rect.top + rect.height / 2 : rect.left + rect.width / 2;
+    const dist = Math.abs(rectCenter - center);
+    if (dist < closestDist) {
+      closestDist = dist;
+      closest = i;
+    }
+  }
+  return closest;
+}
+
+/** Horizontally visible fraction (0–1) of a rect within the container. */
+export function horizontalVisibilityRatio(rect: RectLike, containerRect: RectLike): number {
+  if (rect.width <= 0) return 0;
+  const visibleLeft = Math.max(rect.left, containerRect.left);
+  const visibleRight = Math.min(rect.left + rect.width, containerRect.left + containerRect.width);
+  return Math.max(0, visibleRight - visibleLeft) / rect.width;
+}
+
+/**
+ * Horizontal-reader detection: among pages >95% visible, the one whose center
+ * is closest to the viewport center; otherwise any page whose center lies in
+ * the viewport, closest first; otherwise the fallback.
+ */
+export function detectHorizontalPage(
+  containerRect: RectLike,
+  pageRects: readonly (RectLike | undefined)[],
+  fallback: number
+): number {
+  const viewportCenter = containerRect.left + containerRect.width / 2;
+
+  let bestIdx = -1;
+  let bestDist = Infinity;
+  for (let i = 0; i < pageRects.length; i++) {
+    const rect = pageRects[i];
+    if (!rect) continue;
+    if (horizontalVisibilityRatio(rect, containerRect) > 0.95) {
+      const centerX = rect.left + rect.width / 2;
+      const dist = Math.abs(centerX - viewportCenter);
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestIdx = i;
+      }
+    }
+  }
+  if (bestIdx >= 0) return bestIdx;
+
+  for (let i = 0; i < pageRects.length; i++) {
+    const rect = pageRects[i];
+    if (!rect) continue;
+    const centerX = rect.left + rect.width / 2;
+    if (centerX >= containerRect.left && centerX <= containerRect.left + containerRect.width) {
+      const dist = Math.abs(centerX - viewportCenter);
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestIdx = i;
+      }
+    }
+  }
+
+  return bestIdx >= 0 ? bestIdx : fallback;
+}

--- a/src/lib/reader/scroll-animator.ts
+++ b/src/lib/reader/scroll-animator.ts
@@ -67,6 +67,16 @@ export class ScrollAnimator {
     this.yAnim.snapTo(y);
   }
 
+  /**
+   * Stop any in-flight animation, leaving the scroll position as-is.
+   * Used when a zoom gesture takes over scroll control — the next manual
+   * scroll resyncs the animators via onScroll().
+   */
+  stop(): void {
+    this.xAnim.stop();
+    this.yAnim.stop();
+  }
+
   /** Animate so that an element is centered in the viewport */
   scrollToElement(
     el: HTMLElement,

--- a/src/lib/reader/scroll-animator.ts
+++ b/src/lib/reader/scroll-animator.ts
@@ -77,6 +77,20 @@ export class ScrollAnimator {
     this.yAnim.stop();
   }
 
+  /**
+   * Stop and adopt the container's actual scroll position. Required after
+   * programmatic scroll writes (e.g. a zoom gesture's correction frames):
+   * their scroll events arrive asynchronously, so without this the next
+   * scrollBy() would animate from a stale position and undo those writes.
+   */
+  sync(): void {
+    this.stop();
+    this.xAnim.current = this.container.scrollLeft;
+    this.xAnim.target = this.container.scrollLeft;
+    this.yAnim.current = this.container.scrollTop;
+    this.yAnim.target = this.container.scrollTop;
+  }
+
   /** Animate so that an element is centered in the viewport */
   scrollToElement(
     el: HTMLElement,

--- a/src/lib/reader/zoom-controller.test.ts
+++ b/src/lib/reader/zoom-controller.test.ts
@@ -1,0 +1,501 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ContinuousZoomController } from './zoom-controller';
+import type { RectLike } from './zoom-math';
+
+/**
+ * Fake layout world simulating the browser geometry the controller corrects
+ * against: pages live at unscaled layout coordinates inside a wrapper that is
+ * visually scaled by `zoom`; rects are derived the way getBoundingClientRect
+ * would report them; scroll writes clamp to bounds (and coerce NaN to 0,
+ * like real CSSOM setters).
+ */
+interface FakePage {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+class FakeWorld {
+  zoom = 1;
+  scrollLeft = 0;
+  scrollTop = 0;
+  rtl = false;
+  viewport = { width: 1000, height: 800 };
+  pages: FakePage[] = [];
+  /** Wrapper layout origin in scroll-content space; may depend on zoom to simulate alignment/centering shifts. */
+  originX: (z: number) => number = () => 0;
+  originY: (z: number) => number = () => 0;
+  applyZoomLayoutCalls: number[] = [];
+
+  private contentWidth(z: number): number {
+    const right = Math.max(0, ...this.pages.map((p) => p.x + p.w));
+    return this.originX(z) + right * z;
+  }
+
+  private contentHeight(z: number): number {
+    const bottom = Math.max(0, ...this.pages.map((p) => p.y + p.h));
+    return this.originY(z) + bottom * z;
+  }
+
+  get scrollWidth(): number {
+    return Math.max(this.viewport.width, this.contentWidth(this.zoom));
+  }
+
+  get scrollHeight(): number {
+    return Math.max(this.viewport.height, this.contentHeight(this.zoom));
+  }
+
+  private clampScrollLeft(v: number): number {
+    if (Number.isNaN(v)) v = 0; // CSSOM coercion
+    const range = this.scrollWidth - this.viewport.width;
+    return this.rtl ? Math.max(-range, Math.min(0, v)) : Math.max(0, Math.min(range, v));
+  }
+
+  private clampScrollTop(v: number): number {
+    if (Number.isNaN(v)) v = 0;
+    const range = this.scrollHeight - this.viewport.height;
+    return Math.max(0, Math.min(range, v));
+  }
+
+  /** Visual offset of the scroll content's left edge at scrollLeft = 0. */
+  private get baseX(): number {
+    return this.rtl ? this.viewport.width - this.scrollWidth : 0;
+  }
+
+  pageRect(i: number): RectLike {
+    const p = this.pages[i];
+    const z = this.zoom;
+    return {
+      left: this.baseX + this.originX(z) + p.x * z - this.scrollLeft,
+      top: this.originY(z) + p.y * z - this.scrollTop,
+      width: p.w * z,
+      height: p.h * z
+    };
+  }
+
+  readonly container = {
+    world: this as FakeWorld,
+    get scrollLeft() {
+      return this.world.scrollLeft;
+    },
+    set scrollLeft(v: number) {
+      this.world.scrollLeft = this.world['clampScrollLeft'](v);
+    },
+    get scrollTop() {
+      return this.world.scrollTop;
+    },
+    set scrollTop(v: number) {
+      this.world.scrollTop = this.world['clampScrollTop'](v);
+    },
+    get scrollWidth() {
+      return this.world.scrollWidth;
+    }
+  };
+
+  readonly pageEls = {
+    world: this as FakeWorld,
+    list(): { getBoundingClientRect(): RectLike }[] {
+      return this.world.pages.map((_, i) => ({
+        getBoundingClientRect: () => this.world.pageRect(i)
+      }));
+    }
+  };
+}
+
+function makeController(
+  world: FakeWorld,
+  spies?: { settled?: (z: number) => void; zoomed?: (b: boolean) => void }
+) {
+  return new ContinuousZoomController({
+    getScrollContainer: () => world.container,
+    getPageElements: () => world.pageEls.list(),
+    getViewport: () => world.viewport,
+    applyZoomLayout: (z) => {
+      world.zoom = z;
+      world.applyZoomLayoutCalls.push(z);
+    },
+    onZoomedChange: spies?.zoomed,
+    onSettled: spies?.settled
+  });
+}
+
+/** Deterministic rAF pump for the Animator. */
+let rafQueue: FrameRequestCallback[] = [];
+let clock = 0;
+
+function pump(frames = 80, dt = 16.67) {
+  for (let i = 0; i < frames && rafQueue.length > 0; i++) {
+    clock += dt;
+    const cbs = rafQueue.splice(0);
+    for (const cb of cbs) cb(clock);
+  }
+}
+
+beforeEach(() => {
+  rafQueue = [];
+  clock = 0;
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    rafQueue.push(cb);
+    return rafQueue.length;
+  });
+  vi.stubGlobal('cancelAnimationFrame', () => {});
+  vi.spyOn(performance, 'now').mockImplementation(() => clock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/** A single tall page, like vertical fit-to-width. */
+function tallPageWorld(): FakeWorld {
+  const w = new FakeWorld();
+  w.pages = [{ x: 0, y: 0, w: 1000, h: 1500 }];
+  w.scrollTop = 300;
+  return w;
+}
+
+describe('ContinuousZoomController — pinch', () => {
+  it('zooms about the midpoint and pans with it', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.pinchStart([
+      { x: 400, y: 400 },
+      { x: 600, y: 400 }
+    ]);
+    c.pinchMove([
+      { x: 350, y: 380 },
+      { x: 750, y: 380 }
+    ]);
+
+    expect(world.zoom).toBe(2);
+    // Content under the initial midpoint (500, 400) → content (500, 700)
+    // must now sit at the live midpoint (550, 380).
+    expect(world.scrollLeft).toBeCloseTo(450, 4);
+    expect(world.scrollTop).toBeCloseTo(1020, 4);
+  });
+
+  it('pinching inward at min zoom leaves scroll untouched (NaN regression)', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.pinchStart([
+      { x: 400, y: 400 },
+      { x: 600, y: 400 }
+    ]);
+    c.pinchMove([
+      { x: 450, y: 400 },
+      { x: 550, y: 400 }
+    ]);
+
+    expect(world.zoom).toBe(1);
+    expect(world.scrollLeft).toBe(0);
+    expect(world.scrollTop).toBe(300);
+  });
+
+  it('end snaps bookkeeping target to nearest level, keeps the zoom, settles once', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const c = makeController(world, { settled });
+
+    c.pinchStart([
+      { x: 400, y: 400 },
+      { x: 600, y: 400 }
+    ]);
+    c.pinchMove([
+      { x: 240, y: 400 },
+      { x: 760, y: 400 }
+    ]); // dist 200 → 520 ⇒ zoom 2.6
+    c.pinchEnd();
+    pump();
+
+    expect(c.currentZoom).toBeCloseTo(2.6, 6);
+    expect(c.zoomTarget).toBe(3);
+    expect(settled).toHaveBeenCalledTimes(1);
+    expect(settled).toHaveBeenCalledWith(2.6);
+    expect(c.isActive).toBe(false);
+  });
+
+  it('ending near 1× animates to exactly 1 and reports unzoomed', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const zoomed = vi.fn();
+    const c = makeController(world, { settled, zoomed });
+
+    c.pinchStart([
+      { x: 400, y: 400 },
+      { x: 600, y: 400 }
+    ]);
+    c.pinchMove([
+      { x: 396, y: 400 },
+      { x: 604, y: 400 }
+    ]); // dist 200 → 208 ⇒ zoom 1.04
+    c.pinchEnd();
+    pump();
+
+    expect(c.currentZoom).toBe(1);
+    expect(c.zoomTarget).toBe(1);
+    expect(settled).toHaveBeenCalledTimes(1);
+    expect(settled).toHaveBeenCalledWith(1);
+    expect(zoomed).toHaveBeenLastCalledWith(false);
+  });
+
+  it('re-baselines when pinchStart is called again mid-gesture (pointer-set change)', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.pinchStart([
+      { x: 400, y: 400 },
+      { x: 600, y: 400 }
+    ]);
+    c.pinchMove([
+      { x: 300, y: 400 },
+      { x: 700, y: 400 }
+    ]); // zoom 2
+    // A different pair takes over (e.g. third finger landed / one lifted)
+    c.pinchStart([
+      { x: 100, y: 400 },
+      { x: 900, y: 400 }
+    ]);
+    c.pinchMove([
+      { x: 100, y: 400 },
+      { x: 900, y: 400 }
+    ]); // same distance ⇒ zoom must stay 2, not jump
+
+    expect(world.zoom).toBeCloseTo(2, 6);
+  });
+});
+
+describe('ContinuousZoomController — wheel', () => {
+  it('one notch zooms one level anchored at the cursor', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const c = makeController(world, { settled });
+
+    c.wheelZoom({ deltaY: -120, deltaMode: 0, clientX: 300, clientY: 500, timeStamp: 1000 });
+    pump();
+
+    expect(c.zoomTarget).toBe(1.5);
+    expect(c.currentZoom).toBe(1.5);
+    // Content under cursor (300, 500) → content (300, 800) stays under it.
+    expect(world.scrollLeft).toBeCloseTo(150, 3);
+    expect(world.scrollTop).toBeCloseTo(700, 3);
+    expect(settled).toHaveBeenCalledTimes(1);
+  });
+
+  it('accumulates trackpad deltas into a single step', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    for (let i = 0; i < 4; i++) {
+      c.wheelZoom({
+        deltaY: -20,
+        deltaMode: 0,
+        clientX: 500,
+        clientY: 400,
+        timeStamp: 1000 + i * 16
+      });
+    }
+    expect(c.zoomTarget).toBe(1);
+    c.wheelZoom({ deltaY: -20, deltaMode: 0, clientX: 500, clientY: 400, timeStamp: 1064 });
+    expect(c.zoomTarget).toBe(1.5);
+  });
+
+  it('steps onto the level after an off-level pinch instead of dead-zoning', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.pinchStart([
+      { x: 400, y: 400 },
+      { x: 600, y: 400 }
+    ]);
+    c.pinchMove([
+      { x: 240, y: 400 },
+      { x: 760, y: 400 }
+    ]); // zoom 2.6
+    c.pinchEnd(); // target → 3, zoom stays 2.6
+    pump();
+
+    c.wheelZoom({ deltaY: -120, deltaMode: 0, clientX: 500, clientY: 400, timeStamp: 2000 });
+    pump();
+    expect(c.currentZoom).toBe(3);
+  });
+});
+
+describe('ContinuousZoomController — double-tap', () => {
+  it('at 1× zooms to 2× moving the tap point toward the viewport center', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.toggleZoom(300, 500);
+    pump();
+
+    expect(c.currentZoom).toBe(2);
+    // Content under the tap (300, 500) → content (300, 800) ends at center (500, 400).
+    expect(world.scrollLeft).toBeCloseTo(100, 3);
+    expect(world.scrollTop).toBeCloseTo(1200, 3);
+  });
+
+  it('when zoomed resets to 1×', () => {
+    const world = tallPageWorld();
+    const zoomed = vi.fn();
+    const c = makeController(world, { zoomed });
+
+    c.toggleZoom(300, 500);
+    pump();
+    expect(c.currentZoom).toBe(2);
+
+    c.toggleZoom(700, 300);
+    pump();
+    expect(c.currentZoom).toBe(1);
+    expect(zoomed).toHaveBeenLastCalledWith(false);
+  });
+
+  it('resets even when the visible zoom is off-level after a pinch whose target snapped to 1', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    // Pinch to 1.2: stays (above the 1.05 snap threshold), target snaps to 1.
+    c.pinchStart([
+      { x: 400, y: 400 },
+      { x: 600, y: 400 }
+    ]);
+    c.pinchMove([
+      { x: 380, y: 400 },
+      { x: 620, y: 400 }
+    ]); // zoom 1.2
+    c.pinchEnd();
+    pump();
+    expect(c.currentZoom).toBeCloseTo(1.2, 6);
+    expect(c.zoomTarget).toBe(1);
+
+    c.toggleZoom(500, 400);
+    pump();
+    expect(c.currentZoom).toBe(1);
+  });
+});
+
+describe('ContinuousZoomController — interruption and lifecycle', () => {
+  it('finishNow snaps to the target and settles exactly once', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const c = makeController(world, { settled });
+
+    c.toggleZoom(300, 500);
+    pump(3);
+    expect(c.isActive).toBe(true);
+    expect(c.currentZoom).toBeLessThan(2);
+
+    c.finishNow();
+    expect(c.currentZoom).toBe(2);
+    expect(c.isActive).toBe(false);
+    expect(settled).toHaveBeenCalledTimes(1);
+
+    pump();
+    expect(settled).toHaveBeenCalledTimes(1);
+  });
+
+  it('pinch start during an animation finishes it first', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const c = makeController(world, { settled });
+
+    c.toggleZoom(300, 500);
+    pump(3);
+
+    c.pinchStart([
+      { x: 400, y: 400 },
+      { x: 600, y: 400 }
+    ]);
+    expect(settled).toHaveBeenCalledTimes(1); // finished before baselining
+    c.pinchMove([
+      { x: 425, y: 400 },
+      { x: 575, y: 400 }
+    ]); // dist 200 → 150 ⇒ ratio 0.75 from zoom 2
+    expect(world.zoom).toBeCloseTo(1.5, 6);
+  });
+
+  it('reset returns to 1× instantly and cleans up', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const zoomed = vi.fn();
+    const c = makeController(world, { settled, zoomed });
+
+    c.toggleZoom(300, 500);
+    pump();
+    settled.mockClear();
+
+    c.reset();
+    expect(c.currentZoom).toBe(1);
+    expect(world.zoom).toBe(1);
+    expect(settled).toHaveBeenCalledTimes(1);
+    expect(settled).toHaveBeenCalledWith(1);
+    expect(zoomed).toHaveBeenLastCalledWith(false);
+  });
+
+  it('gestures no-op safely when no pages exist', () => {
+    const world = new FakeWorld();
+    const c = makeController(world);
+
+    c.toggleZoom(300, 500);
+    c.wheelZoom({ deltaY: -120, deltaMode: 0, clientX: 300, clientY: 500, timeStamp: 0 });
+    pump();
+    expect(c.currentZoom).toBe(1);
+  });
+});
+
+describe('ContinuousZoomController — geometry robustness', () => {
+  it('keeps the anchor pinned when the wrapper origin shifts with zoom (alignment/centering)', () => {
+    const world = tallPageWorld();
+    world.originY = (z) => (z - 1) * 40; // simulated alignment shift
+    const c = makeController(world);
+
+    c.toggleZoom(300, 500);
+    pump();
+
+    // actual = originY(2) + contentY·2 − scrollTop must equal desired 400
+    const rect = world.pageRect(0);
+    const fy = 800 / 1500; // content (300, 800) inside the 1000x1500 page
+    const fx = 300 / 1000;
+    expect(rect.left + fx * rect.width).toBeCloseTo(500, 3);
+    expect(rect.top + fy * rect.height).toBeCloseTo(400, 3);
+  });
+
+  it('RTL: zoom pins the cursor anchor inside the negative scroll range', () => {
+    const world = new FakeWorld();
+    world.rtl = true;
+    world.pages = [
+      { x: 0, y: 0, w: 800, h: 800 },
+      { x: 800, y: 0, w: 800, h: 800 },
+      { x: 1600, y: 0, w: 800, h: 800 }
+    ];
+    // scrollLeft = 0 shows the right end (RTL start); range is [-1400, 0]
+    const c = makeController(world);
+
+    c.cycleZoom(1, 600, 400);
+    pump();
+
+    expect(c.currentZoom).toBe(1.5);
+    // Content under (600, 400) was content x = 2000; at 1.5× pinned at 600:
+    // base' = 1000 − 3600 = −2600 ⇒ −2600 + 3000 − scrollLeft = 600 ⇒ scrollLeft = −200
+    expect(world.scrollLeft).toBeCloseTo(-200, 3);
+  });
+
+  it('Safari gesture events drive the same pinch path', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const c = makeController(world, { settled });
+
+    c.gestureStart(500, 400);
+    c.gestureChange(2, 550, 380);
+    expect(world.zoom).toBe(2);
+    expect(world.scrollLeft).toBeCloseTo(450, 4);
+    expect(world.scrollTop).toBeCloseTo(1020, 4);
+
+    c.gestureEnd();
+    pump();
+    expect(settled).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/reader/zoom-controller.ts
+++ b/src/lib/reader/zoom-controller.ts
@@ -1,0 +1,365 @@
+/**
+ * Targeted zoom for the continuous scroll readers (issue #195).
+ *
+ * Owns the zoom state machine shared by both readers: discrete level zoom for
+ * wheel/double-tap (animated), continuous zoom for pinch (1:1 via snapTo),
+ * and the per-frame measurement-based scroll correction that keeps an anchor
+ * point pinned while the wrapper's transform scale changes.
+ *
+ * The correction never predicts absolute scroll positions. Each frame it
+ * applies the new zoom layout, forces layout, measures where the anchored
+ * page element actually is, and applies the difference to the desired anchor
+ * position as a *relative* scroll delta — which is exact under any wrapper
+ * offset, alignment, centering, or RTL scroll-coordinate scheme.
+ *
+ * See docs/superpowers/specs/2026-06-09-continuous-targeted-zoom-design.md.
+ */
+
+import { Animator } from './animator';
+import {
+  anchorFraction,
+  anchorScreenPosition,
+  lerp2,
+  nearestZoomLevel,
+  nextZoomLevel,
+  normalizeWheelDelta,
+  pinchDistance,
+  pinchMidpoint,
+  WheelAccumulator,
+  zoomProgress,
+  type Point,
+  type RectLike
+} from './zoom-math';
+
+/** Numeric tolerance for "is zoomed" / "is at this level" comparisons. */
+const ZOOM_EPS = 0.001;
+/** Pinches released below this zoom animate back to exactly 1×. */
+const SNAP_TO_ONE_BELOW = 1.05;
+/** Double-tap zoom-in target level. */
+const DOUBLE_TAP_ZOOM = 2;
+
+export const CONTINUOUS_ZOOM_LEVELS: readonly number[] = [1, 1.5, 2, 3];
+
+/** Structural subset of HTMLElement the controller scrolls. */
+export interface ZoomContainer {
+  scrollLeft: number;
+  scrollTop: number;
+  readonly scrollWidth: number;
+}
+
+/** Structural subset of HTMLElement the controller anchors to. */
+export interface ZoomAnchorTarget {
+  getBoundingClientRect(): RectLike;
+}
+
+export interface ZoomWheelEventLike {
+  deltaY: number;
+  deltaMode: number;
+  clientX: number;
+  clientY: number;
+  timeStamp: number;
+}
+
+export interface ZoomControllerConfig {
+  /** Discrete levels for wheel/double-tap stepping. First entry is min zoom, last is max. */
+  levels?: readonly number[];
+  getScrollContainer(): ZoomContainer | null | undefined;
+  getPageElements(): readonly (ZoomAnchorTarget | undefined)[];
+  getViewport(): { width: number; height: number };
+  /**
+   * Apply reader-specific zoomed layout: wrapper transform (+origin), spacer
+   * dimensions, alignment. Called inside the frame step BEFORE measurement,
+   * so it must be fully synchronous/imperative (no reactive state).
+   */
+  applyZoomLayout(zoom: number): void;
+  /** Gate for cross-axis drag panning and similar component state. */
+  onZoomedChange?(zoomed: boolean): void;
+  /**
+   * A gesture finished (animation settled, pinch released, finishNow, reset).
+   * Components re-run page detection and report progress here.
+   */
+  onSettled?(zoom: number): void;
+}
+
+export class ContinuousZoomController {
+  private config: ZoomControllerConfig;
+  private levels: readonly number[];
+  private animator: Animator;
+  private wheelAcc = new WheelAccumulator();
+
+  private target = 1;
+  private startZoom = 1;
+  private fromScreen: Point = { x: 0, y: 0 };
+  private toScreen: Point = { x: 0, y: 0 };
+
+  private anchorEl: ZoomAnchorTarget | null = null;
+  private anchorFx = 0;
+  private anchorFy = 0;
+
+  private pinching = false;
+  private pinchStartDist = 0;
+  private pinchStartZoom = 1;
+  private gestureBaseZoom = 1;
+
+  constructor(config: ZoomControllerConfig) {
+    this.config = config;
+    this.levels = config.levels ?? CONTINUOUS_ZOOM_LEVELS;
+    this.animator = new Animator(1, (zoom) => this.frameStep(zoom), {
+      factor: 0.25,
+      epsilon: 0.005,
+      onSettle: () => this.settle()
+    });
+  }
+
+  get currentZoom(): number {
+    return this.animator.current;
+  }
+
+  get zoomTarget(): number {
+    return this.target;
+  }
+
+  get isActive(): boolean {
+    return this.pinching || this.animator.isAnimating;
+  }
+
+  /** True when the view is visibly zoomed in. */
+  get isZoomed(): boolean {
+    return this.animator.current > 1 + ZOOM_EPS;
+  }
+
+  // ============================================================
+  // Gestures
+  // ============================================================
+
+  /** Wheel event already classified as zoom intent by the caller. */
+  wheelZoom(e: ZoomWheelEventLike): void {
+    const steps = this.wheelAcc.add(normalizeWheelDelta(e.deltaY, e.deltaMode), e.timeStamp);
+    if (steps === 0) return;
+    const direction = steps > 0 ? 1 : -1;
+    let next = this.target;
+    for (let i = 0; i < Math.abs(steps); i++) {
+      next = nextZoomLevel(this.levels, next, direction);
+    }
+    this.stepTo(next, { x: e.clientX, y: e.clientY });
+  }
+
+  /** Step one level in `direction`, anchored at (x, y) or the viewport center. */
+  cycleZoom(direction: 1 | -1, anchorX?: number, anchorY?: number): void {
+    const viewport = this.config.getViewport();
+    const anchor = {
+      x: anchorX ?? viewport.width / 2,
+      y: anchorY ?? viewport.height / 2
+    };
+    this.stepTo(nextZoomLevel(this.levels, this.target, direction), anchor);
+  }
+
+  private stepTo(next: number, anchor: Point): void {
+    // No-op only when we're already settled on that level — after an
+    // off-level pinch (e.g. 2.6 with target 3) a step must still animate.
+    if (next === this.target && Math.abs(this.animator.current - next) < ZOOM_EPS) return;
+    this.beginAnimatedGesture(next, anchor, anchor);
+  }
+
+  /** Double-tap: zoom in toward the viewport center, or reset when zoomed. */
+  toggleZoom(x: number, y: number): void {
+    if (this.isZoomed) {
+      this.beginAnimatedGesture(1, { x, y }, { x, y });
+    } else {
+      const viewport = this.config.getViewport();
+      this.beginAnimatedGesture(
+        DOUBLE_TAP_ZOOM,
+        { x, y },
+        { x: viewport.width / 2, y: viewport.height / 2 }
+      );
+    }
+  }
+
+  /**
+   * Begin (or re-baseline) a pinch. Callers invoke this whenever the active
+   * pointer pair changes — a third finger landing or one of three lifting
+   * re-baselines distance/zoom/anchor so the gesture stays continuous.
+   */
+  pinchStart(points: readonly Point[]): void {
+    if (!this.pinching && this.animator.isAnimating) this.finishNow();
+    const mid = pinchMidpoint(points);
+    if (!this.captureAnchor(mid.x, mid.y)) return;
+    this.pinching = true;
+    this.pinchStartDist = pinchDistance(points);
+    this.pinchStartZoom = this.animator.current;
+    this.fromScreen = mid;
+    this.toScreen = mid;
+    this.startZoom = this.animator.current;
+    this.target = this.animator.current;
+  }
+
+  pinchMove(points: readonly Point[]): void {
+    if (!this.pinching || this.pinchStartDist <= 0) return;
+    const ratio = pinchDistance(points) / this.pinchStartDist;
+    this.applyPinchZoom(this.pinchStartZoom * ratio, pinchMidpoint(points));
+  }
+
+  /** Pinch released (fewer than two pointers remain). */
+  pinchEnd(): void {
+    if (!this.pinching) return;
+    this.pinching = false;
+    const zoom = this.animator.current;
+    if (zoom < SNAP_TO_ONE_BELOW && zoom > 1) {
+      // Nearly unzoomed — animate the residue away; settle runs cleanup.
+      this.target = 1;
+      this.animator.setTarget(1);
+      return;
+    }
+    this.target = nearestZoomLevel(this.levels, zoom);
+    this.settle();
+  }
+
+  // Safari desktop trackpad pinch (proprietary gesture events).
+  gestureStart(x: number, y: number): void {
+    if (!this.pinching && this.animator.isAnimating) this.finishNow();
+    if (!this.captureAnchor(x, y)) return;
+    this.pinching = true;
+    this.pinchStartDist = 0; // pointer-pair distance unused for gesture events
+    this.gestureBaseZoom = this.animator.current;
+    this.pinchStartZoom = this.animator.current;
+    this.fromScreen = { x, y };
+    this.toScreen = { x, y };
+    this.startZoom = this.animator.current;
+    this.target = this.animator.current;
+  }
+
+  gestureChange(scale: number, x: number, y: number): void {
+    if (!this.pinching) return;
+    this.applyPinchZoom(this.gestureBaseZoom * scale, { x, y });
+  }
+
+  gestureEnd(): void {
+    this.pinchEnd();
+  }
+
+  private applyPinchZoom(rawZoom: number, mid: Point): void {
+    const min = this.levels[0];
+    const max = this.levels[this.levels.length - 1];
+    const zoom = Math.max(min, Math.min(max, rawZoom));
+    this.fromScreen = mid;
+    this.toScreen = mid;
+    this.target = zoom;
+    this.config.onZoomedChange?.(zoom > 1 + ZOOM_EPS);
+    this.animator.snapTo(zoom);
+  }
+
+  // ============================================================
+  // Lifecycle
+  // ============================================================
+
+  /**
+   * Finish any in-flight gesture instantly against its target and settle.
+   * Call before competing scroll intents (keyboard nav, manual page change,
+   * scroll-intent wheel, new drag) so they act on settled geometry.
+   */
+  finishNow(): void {
+    if (this.pinching) {
+      this.pinching = false;
+      this.target = nearestZoomLevel(this.levels, this.animator.current);
+      this.settle();
+      return;
+    }
+    if (this.animator.isAnimating) {
+      this.animator.snapTo(this.target);
+      this.settle();
+    }
+  }
+
+  /** Instantly return to 1× (zoom-mode change, viewport resize). */
+  reset(): void {
+    this.pinching = false;
+    this.target = 1;
+    this.anchorEl = null; // skip anchor correction; layout cleanup only
+    if (this.animator.current !== 1 || this.animator.isAnimating) {
+      this.animator.snapTo(1);
+      this.settle();
+    }
+  }
+
+  destroy(): void {
+    this.animator.destroy();
+  }
+
+  // ============================================================
+  // Core frame step
+  // ============================================================
+
+  private frameStep(zoom: number): void {
+    const container = this.config.getScrollContainer();
+    if (!container) return;
+
+    this.config.applyZoomLayout(zoom);
+    void container.scrollWidth; // force layout before measuring
+
+    if (!this.anchorEl) return;
+    const actual = anchorScreenPosition(
+      this.anchorEl.getBoundingClientRect(),
+      this.anchorFx,
+      this.anchorFy
+    );
+    const desired = lerp2(
+      this.fromScreen,
+      this.toScreen,
+      zoomProgress(zoom, this.startZoom, this.target)
+    );
+    const dx = actual.x - desired.x;
+    const dy = actual.y - desired.y;
+    if (Number.isFinite(dx) && Number.isFinite(dy)) {
+      container.scrollLeft += dx;
+      container.scrollTop += dy;
+    }
+  }
+
+  private beginAnimatedGesture(target: number, from: Point, to: Point): void {
+    if (!this.captureAnchor(from.x, from.y)) return;
+    this.startZoom = this.animator.current;
+    this.fromScreen = from;
+    this.toScreen = to;
+    this.target = target;
+    this.config.onZoomedChange?.(Math.max(target, this.animator.current) > 1 + ZOOM_EPS);
+    this.animator.setTarget(target);
+  }
+
+  /**
+   * Anchor to the page element under (x, y), or the nearest one by center
+   * distance — fractions extrapolate linearly, so a near-miss anchor (gap,
+   * divider, centering spacer) still pins correctly.
+   */
+  private captureAnchor(x: number, y: number): boolean {
+    const pages = this.config.getPageElements();
+    let best: ZoomAnchorTarget | null = null;
+    let bestRect: RectLike | null = null;
+    let bestDist = Infinity;
+    for (const el of pages) {
+      if (!el) continue;
+      const rect = el.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) continue;
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
+      const dist = (cx - x) * (cx - x) + (cy - y) * (cy - y);
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = el;
+        bestRect = rect;
+      }
+    }
+    if (!best || !bestRect) return false;
+    const { fx, fy } = anchorFraction(bestRect, x, y);
+    this.anchorEl = best;
+    this.anchorFx = fx;
+    this.anchorFy = fy;
+    return true;
+  }
+
+  /** Shared settle: bookkeeping + component hooks. Runs exactly once per gesture. */
+  private settle(): void {
+    const zoom = this.animator.current;
+    this.config.onZoomedChange?.(zoom > 1 + ZOOM_EPS);
+    this.config.onSettled?.(zoom);
+  }
+}

--- a/src/lib/reader/zoom-layout.ts
+++ b/src/lib/reader/zoom-layout.ts
@@ -35,21 +35,40 @@ export interface HorizontalZoomElements {
   container: HTMLElement;
 }
 
+/**
+ * @param contentWidth Widest page's scaled layout width at the current zoom
+ * mode (computed from page data). The wrapper is pinned to the CONTENT width
+ * — not the viewport width — and centered, scaling from `top center`: the
+ * scroll range then hugs the content exactly. Pinning to the viewport width
+ * made the side margins of narrower-than-viewport content (fit-to-screen)
+ * part of the scaled wrapper, creating a pan range that let pages be pushed
+ * fully off screen.
+ *
+ * Geometry: spacer width = max(viewport, content×zoom); the centered wrapper's
+ * visual span is [spacer/2 − content×zoom/2, spacer/2 + content×zoom/2],
+ * which stays inside the spacer on both sides for any zoom — no unreachable
+ * inline-start overflow, no phantom margin panning.
+ */
 export function applyVerticalZoomLayout(
   els: VerticalZoomElements,
   viewport: { width: number; height: number },
+  contentWidth: number,
   zoom: number
 ): void {
   const { wrapper, spacer } = els;
-  wrapper.style.transformOrigin = 'top left';
+  wrapper.style.transformOrigin = 'top center';
   if (zoom > 1) {
-    wrapper.style.width = `${viewport.width}px`;
-    spacer.style.width = `${viewport.width * zoom}px`;
+    wrapper.style.width = `${contentWidth}px`;
+    wrapper.style.marginLeft = 'auto';
+    wrapper.style.marginRight = 'auto';
+    spacer.style.width = `${Math.max(viewport.width, contentWidth * zoom)}px`;
     spacer.style.minHeight = `${wrapper.offsetHeight * zoom + viewport.height}px`;
     wrapper.style.transform = `scale(${zoom})`;
   } else {
     wrapper.style.transform = '';
     wrapper.style.width = '';
+    wrapper.style.marginLeft = '';
+    wrapper.style.marginRight = '';
     spacer.style.width = '';
     spacer.style.minHeight = '';
   }

--- a/src/lib/reader/zoom-layout.ts
+++ b/src/lib/reader/zoom-layout.ts
@@ -1,0 +1,86 @@
+/**
+ * Reader-specific zoomed layout, applied imperatively from the zoom
+ * controller's frame step (before it measures and corrects scroll).
+ *
+ * This is the single source of truth for the layout rules behind issue #195:
+ *
+ * - The wrapper scales via transform with the origin on the scroll-origin
+ *   side: `top right` in RTL, `top left` otherwise. Per CSS Overflow,
+ *   content overflowing past the inline-start edge is unreachable by
+ *   scrolling, so the scaled strip must grow toward inline-end.
+ * - Spacers take the wrapper's measured layout size × zoom so the scroll
+ *   range covers the visual extent in every continuousZoomDefault mode.
+ * - Vertical: the wrapper's layout width is pinned to the viewport width
+ *   while zoomed — the spacer grows to provide scroll range, and an unpinned
+ *   block wrapper would track it, resizing fit-to-width pages every frame
+ *   (zoom² growth) and re-centering mx-auto pages.
+ * - Horizontal: cross-axis alignment is a pure function of measured geometry
+ *   (`flex-start` when the strip's visual height exceeds the container,
+ *   `center` otherwise), applied in the same task as the transform so the
+ *   controller's measurement sees post-alignment layout. Reactive-state
+ *   flips flush asynchronously and caused the old settle jump.
+ *
+ * The e2e suite imports this module through the Vite dev server and drives
+ * the real functions — keep it free of Svelte and component state.
+ */
+
+export interface VerticalZoomElements {
+  wrapper: HTMLElement;
+  spacer: HTMLElement;
+}
+
+export interface HorizontalZoomElements {
+  wrapper: HTMLElement;
+  spacer: HTMLElement;
+  container: HTMLElement;
+}
+
+export function applyVerticalZoomLayout(
+  els: VerticalZoomElements,
+  viewport: { width: number; height: number },
+  zoom: number
+): void {
+  const { wrapper, spacer } = els;
+  wrapper.style.transformOrigin = 'top left';
+  if (zoom > 1) {
+    wrapper.style.width = `${viewport.width}px`;
+    spacer.style.width = `${viewport.width * zoom}px`;
+    spacer.style.minHeight = `${wrapper.offsetHeight * zoom + viewport.height}px`;
+    wrapper.style.transform = `scale(${zoom})`;
+  } else {
+    wrapper.style.transform = '';
+    wrapper.style.width = '';
+    spacer.style.width = '';
+    spacer.style.minHeight = '';
+  }
+}
+
+/** `flex-start` when the strip's visual height exceeds the container, else `center`. */
+export function horizontalAlignment(visualHeight: number, containerHeight: number): string {
+  return visualHeight > containerHeight + 1 ? 'flex-start' : 'center';
+}
+
+export function applyHorizontalAlignment(els: HorizontalZoomElements, zoom: number): void {
+  const align = horizontalAlignment(els.wrapper.offsetHeight * zoom, els.container.clientHeight);
+  els.container.style.alignItems = align;
+  els.spacer.style.alignItems = align;
+}
+
+export function applyHorizontalZoomLayout(
+  els: HorizontalZoomElements,
+  rtl: boolean,
+  zoom: number
+): void {
+  const { wrapper, spacer } = els;
+  wrapper.style.transformOrigin = rtl ? 'top right' : 'top left';
+  if (zoom > 1) {
+    spacer.style.width = `${wrapper.offsetWidth * zoom}px`;
+    spacer.style.height = `${wrapper.offsetHeight * zoom}px`;
+    wrapper.style.transform = `scale(${zoom})`;
+  } else {
+    wrapper.style.transform = '';
+    spacer.style.width = '';
+    spacer.style.height = '';
+  }
+  applyHorizontalAlignment(els, zoom);
+}

--- a/src/lib/reader/zoom-math.test.ts
+++ b/src/lib/reader/zoom-math.test.ts
@@ -1,283 +1,229 @@
 import { describe, it, expect } from 'vitest';
-import { screenToContent, computeScrollPosition, contentToScreen } from './zoom-math';
+import {
+  anchorFraction,
+  anchorScreenPosition,
+  zoomProgress,
+  lerp2,
+  nearestZoomLevel,
+  nextZoomLevel,
+  wheelIntentIsZoom,
+  normalizeWheelDelta,
+  WheelAccumulator,
+  pinchDistance,
+  pinchMidpoint
+} from './zoom-math';
 
-/**
- * Test setup: vertical scroll mode
- * - Viewport: 1920x1080
- * - Page: 1500x2000 (narrower than viewport)
- * - Pages centered with mx-auto inside wrapper
- * - Wrapper fills scroll container width (1920px layout)
- * - Wrapper offset: X=0, Y=540 (50vh centering spacer = 1080/2)
- * - Page is centered at X=210 to X=1710 inside the wrapper
- */
-const VIEWPORT_W = 1920;
-const VIEWPORT_H = 1080;
-const PAGE_W = 1500;
-const PAGE_H = 2000;
-const WRAPPER_OFFSET_X = 0; // Wrapper starts at left edge
-const WRAPPER_OFFSET_Y = VIEWPORT_H / 2; // 50vh centering spacer
+describe('anchorFraction', () => {
+  const rect = { left: 100, top: 200, width: 400, height: 600 };
 
-// Page center X in the wrapper's content space
-const PAGE_LEFT_IN_WRAPPER = (VIEWPORT_W - PAGE_W) / 2; // 210px (mx-auto centering)
-
-describe('screenToContent', () => {
-  it('converts screen center to content space at zoom 1', () => {
-    // Wrapper visual left = -scrollLeft + wrapperOffset = 0
-    const { contentX, contentY } = screenToContent(
-      VIEWPORT_W / 2,
-      VIEWPORT_H / 2, // screen center
-      0,
-      -500 + WRAPPER_OFFSET_Y, // wrapper rect (scrolled down 500px)
-      1
-    );
-    // Content X should be 960 (center of 1920px wrapper)
-    expect(contentX).toBe(960);
-    // Content Y = (540 - (-500 + 540)) / 1 = (540 - 40) / 1 = 500
-    expect(contentY).toBe(500);
+  it('returns 0.5/0.5 for the rect center', () => {
+    expect(anchorFraction(rect, 300, 500)).toEqual({ fx: 0.5, fy: 0.5 });
   });
 
-  it('converts click on page center at zoom 1', () => {
-    // Click at center of the visible page
-    // Page is at x=210 to x=1710 in wrapper. Center = 960.
-    // Wrapper visual left = 0 (no horizontal scroll at zoom 1)
-    const { contentX } = screenToContent(960, 500, 0, 0, 1);
-    expect(contentX).toBe(960);
+  it('returns 0/0 for the top-left corner', () => {
+    expect(anchorFraction(rect, 100, 200)).toEqual({ fx: 0, fy: 0 });
   });
 
-  it('converts screen position at zoom 2', () => {
-    // At zoom 2, wrapper visual left might be offset by scroll
-    // If scrollLeft=960, wrapperRect.left = wrapperOffset - scrollLeft = 0 - 960 = -960
-    const { contentX, contentY } = screenToContent(
-      960,
-      540, // screen center
-      -960,
-      -500, // wrapper rect position
-      2
-    );
-    // contentX = (960 - (-960)) / 2 = 1920 / 2 = 960
-    expect(contentX).toBe(960);
-    // contentY = (540 - (-500)) / 2 = 1040 / 2 = 520
-    expect(contentY).toBe(520);
+  it('extrapolates outside the rect', () => {
+    const { fx, fy } = anchorFraction(rect, 0, 1100);
+    expect(fx).toBe(-0.25);
+    expect(fy).toBe(1.5);
+  });
+
+  it('guards against zero-size rects', () => {
+    const { fx, fy } = anchorFraction({ left: 100, top: 200, width: 0, height: 0 }, 300, 500);
+    expect(fx).toBe(0);
+    expect(fy).toBe(0);
   });
 });
 
-describe('computeScrollPosition', () => {
-  it('centers content point at viewport center when zooming from 1 to 2', () => {
-    // Content point at (960, 300) should end up at viewport center
-    const { scrollLeft, scrollTop } = computeScrollPosition(
-      960,
-      300, // content point
-      VIEWPORT_W / 2,
-      VIEWPORT_H / 2, // target screen position (center)
-      2, // zoom
-      WRAPPER_OFFSET_X,
-      WRAPPER_OFFSET_Y
-    );
-
-    // scrollLeft = 0 + 960*2 - 960 = 960
-    expect(scrollLeft).toBe(960);
-    // scrollTop = 540 + 300*2 - 540 = 600
-    expect(scrollTop).toBe(600);
+describe('anchorScreenPosition', () => {
+  it('is the inverse of anchorFraction', () => {
+    const rect = { left: 100, top: 200, width: 400, height: 600 };
+    const { fx, fy } = anchorFraction(rect, 250, 380);
+    expect(anchorScreenPosition(rect, fx, fy)).toEqual({ x: 250, y: 380 });
   });
 
-  it('keeps content point at cursor position for wheel zoom', () => {
-    // Cursor at (400, 300), content under cursor, keep it there
-    const contentX = 400; // At zoom 1, content at x=400 in wrapper
-    const { scrollLeft, scrollTop } = computeScrollPosition(
-      contentX,
-      200,
-      400,
-      300, // target = same as cursor (keep fixed)
-      2,
-      WRAPPER_OFFSET_X,
-      WRAPPER_OFFSET_Y
-    );
-
-    // scrollLeft = 0 + 400*2 - 400 = 400
-    expect(scrollLeft).toBe(400);
-    // scrollTop = 540 + 200*2 - 300 = 640
-    expect(scrollTop).toBe(640);
-  });
-
-  it('at zoom 1 with no offset, scroll is 0 when content center is at screen center', () => {
-    const { scrollLeft, scrollTop } = computeScrollPosition(
-      960,
-      0,
-      960,
-      WRAPPER_OFFSET_Y,
-      1,
-      WRAPPER_OFFSET_X,
-      WRAPPER_OFFSET_Y
-    );
-    expect(scrollLeft).toBe(0);
-    expect(scrollTop).toBe(0);
+  it('tracks the anchor on a scaled rect (zoomed measurement)', () => {
+    // Same content point measured after the rect doubled (transform: scale(2))
+    const zoomedRect = { left: -50, top: 0, width: 800, height: 1200 };
+    expect(anchorScreenPosition(zoomedRect, 0.5, 0.25)).toEqual({ x: 350, y: 300 });
   });
 });
 
-describe('contentToScreen (validation inverse)', () => {
-  it('round-trips: screen->content->scroll->screen gives original position', () => {
-    const clickX = 700;
-    const clickY = 400;
-    const currentZoom = 1;
-    const wrapperVisualLeft = 0;
-    const wrapperVisualTop = WRAPPER_OFFSET_Y - 200; // scrolled down 200px
-
-    // Step 1: screen to content
-    const { contentX, contentY } = screenToContent(
-      clickX,
-      clickY,
-      wrapperVisualLeft,
-      wrapperVisualTop,
-      currentZoom
-    );
-
-    // Step 2: compute scroll for new zoom, target = screen center
-    const targetZoom = 2;
-    const { scrollLeft, scrollTop } = computeScrollPosition(
-      contentX,
-      contentY,
-      VIEWPORT_W / 2,
-      VIEWPORT_H / 2,
-      targetZoom,
-      WRAPPER_OFFSET_X,
-      WRAPPER_OFFSET_Y
-    );
-
-    // Step 3: verify the content point appears at viewport center
-    const result = contentToScreen(
-      contentX,
-      contentY,
-      scrollLeft,
-      scrollTop,
-      targetZoom,
-      WRAPPER_OFFSET_X,
-      WRAPPER_OFFSET_Y
-    );
-
-    expect(result.screenX).toBeCloseTo(VIEWPORT_W / 2, 5);
-    expect(result.screenY).toBeCloseTo(VIEWPORT_H / 2, 5);
+describe('zoomProgress', () => {
+  it('is 0 at the start zoom', () => {
+    expect(zoomProgress(1, 1, 2)).toBe(0);
   });
 
-  it('round-trips for wheel zoom: content stays at cursor', () => {
-    const cursorX = 1200;
-    const cursorY = 600;
-    const currentZoom = 1.5;
-    // At zoom 1.5, wrapper rect depends on scroll
-    const scrollLeft = 400;
-    const scrollTop = 300;
-    const wrapperVisualLeft = WRAPPER_OFFSET_X - scrollLeft; // 0 - 400 = -400
-    const wrapperVisualTop = WRAPPER_OFFSET_Y - scrollTop; // 540 - 300 = 240
-
-    // Step 1: screen to content
-    const { contentX, contentY } = screenToContent(
-      cursorX,
-      cursorY,
-      wrapperVisualLeft,
-      wrapperVisualTop,
-      currentZoom
-    );
-
-    // Step 2: compute scroll for new zoom, target = SAME screen position (cursor stays fixed)
-    const targetZoom = 2;
-    const { scrollLeft: newScrollLeft, scrollTop: newScrollTop } = computeScrollPosition(
-      contentX,
-      contentY,
-      cursorX,
-      cursorY, // target = cursor position (keep fixed)
-      targetZoom,
-      WRAPPER_OFFSET_X,
-      WRAPPER_OFFSET_Y
-    );
-
-    // Step 3: verify the content point appears at cursor position
-    const result = contentToScreen(
-      contentX,
-      contentY,
-      newScrollLeft,
-      newScrollTop,
-      targetZoom,
-      WRAPPER_OFFSET_X,
-      WRAPPER_OFFSET_Y
-    );
-
-    expect(result.screenX).toBeCloseTo(cursorX, 5);
-    expect(result.screenY).toBeCloseTo(cursorY, 5);
+  it('is 0.5 halfway', () => {
+    expect(zoomProgress(1.5, 1, 2)).toBe(0.5);
   });
 
-  it('double-tap on right side of page zooms it to center', () => {
-    // Click at x=1500 (right side of page which goes from 210 to 1710)
-    const clickX = 1500;
-    const clickY = 540;
-    const currentZoom = 1;
-    const wrapperVisualLeft = 0;
-    const wrapperVisualTop = WRAPPER_OFFSET_Y; // At top of volume, scrollTop=0
-
-    const { contentX, contentY } = screenToContent(
-      clickX,
-      clickY,
-      wrapperVisualLeft,
-      wrapperVisualTop,
-      currentZoom
-    );
-
-    // contentX should be 1500 (in wrapper coordinates)
-    expect(contentX).toBe(1500);
-
-    const targetZoom = 2;
-    const { scrollLeft, scrollTop } = computeScrollPosition(
-      contentX,
-      contentY,
-      VIEWPORT_W / 2,
-      VIEWPORT_H / 2,
-      targetZoom,
-      WRAPPER_OFFSET_X,
-      WRAPPER_OFFSET_Y
-    );
-
-    // Verify: content point at center
-    const result = contentToScreen(
-      contentX,
-      contentY,
-      scrollLeft,
-      scrollTop,
-      targetZoom,
-      WRAPPER_OFFSET_X,
-      WRAPPER_OFFSET_Y
-    );
-
-    expect(result.screenX).toBeCloseTo(VIEWPORT_W / 2, 5);
-    expect(result.screenY).toBeCloseTo(VIEWPORT_H / 2, 5);
-
-    // scrollLeft should be positive (scrolled right to show right side of page)
-    expect(scrollLeft).toBe(0 + 1500 * 2 - 960); // = 2040
-    expect(scrollLeft).toBeGreaterThan(0);
+  it('is 1 at the target', () => {
+    expect(zoomProgress(2, 1, 2)).toBe(1);
   });
 
-  it('double-tap on left side of page zooms it to center', () => {
-    const clickX = 300;
-    const clickY = 540;
+  it('works zooming out', () => {
+    expect(zoomProgress(1.5, 2, 1)).toBe(0.5);
+  });
 
-    const { contentX } = screenToContent(clickX, 540, 0, WRAPPER_OFFSET_Y, 1);
-    expect(contentX).toBe(300);
+  it('clamps overshoot', () => {
+    expect(zoomProgress(2.5, 1, 2)).toBe(1);
+    expect(zoomProgress(0.5, 1, 2)).toBe(0);
+  });
 
-    const { scrollLeft } = computeScrollPosition(
-      contentX,
-      0,
-      VIEWPORT_W / 2,
-      VIEWPORT_H / 2,
-      2,
-      WRAPPER_OFFSET_X,
-      WRAPPER_OFFSET_Y
-    );
+  it('returns 1 when target equals start (snapTo/pinch degenerate case, never NaN)', () => {
+    expect(zoomProgress(1.7, 1.7, 1.7)).toBe(1);
+    expect(zoomProgress(1, 1, 1)).toBe(1);
+  });
+});
 
-    // scrollLeft = 0 + 300*2 - 960 = -360
-    // Negative = scroll container clamps to 0, page appears right of center
-    // This is correct — the left edge of content IS to the left of where we can scroll
-    expect(scrollLeft).toBe(-360);
+describe('lerp2', () => {
+  it('interpolates between two points', () => {
+    expect(lerp2({ x: 0, y: 100 }, { x: 200, y: 0 }, 0.25)).toEqual({ x: 50, y: 75 });
+  });
 
-    const result = contentToScreen(300, 0, Math.max(0, scrollLeft), 0, 2, 0, WRAPPER_OFFSET_Y);
-    // With clamped scrollLeft=0, content at 300*2=600, screen position = 600
-    // Not centered (960), but as close as scroll bounds allow
-    expect(result.screenX).toBe(600);
+  it('returns endpoints at t=0 and t=1', () => {
+    const a = { x: 3, y: 4 };
+    const b = { x: 7, y: 8 };
+    expect(lerp2(a, b, 0)).toEqual(a);
+    expect(lerp2(a, b, 1)).toEqual(b);
+  });
+
+  it('returns the point when both endpoints coincide, even for non-finite t', () => {
+    const a = { x: 5, y: 6 };
+    expect(lerp2(a, { x: 5, y: 6 }, NaN)).toEqual(a);
+  });
+});
+
+describe('nearestZoomLevel', () => {
+  const levels = [1, 1.5, 2, 3];
+
+  it('snaps to the closest level', () => {
+    expect(nearestZoomLevel(levels, 1.7)).toBe(1.5);
+    expect(nearestZoomLevel(levels, 1.8)).toBe(2);
+    expect(nearestZoomLevel(levels, 5)).toBe(3);
+    expect(nearestZoomLevel(levels, 0.2)).toBe(1);
+  });
+
+  it('keeps the lower level on an exact tie', () => {
+    expect(nearestZoomLevel(levels, 1.75)).toBe(1.5);
+  });
+});
+
+describe('nextZoomLevel', () => {
+  const levels = [1, 1.5, 2, 3];
+
+  it('steps up and down from a level', () => {
+    expect(nextZoomLevel(levels, 1.5, 1)).toBe(2);
+    expect(nextZoomLevel(levels, 1.5, -1)).toBe(1);
+  });
+
+  it('clamps at the ends', () => {
+    expect(nextZoomLevel(levels, 3, 1)).toBe(3);
+    expect(nextZoomLevel(levels, 1, -1)).toBe(1);
+  });
+
+  it('resolves an off-level zoom (e.g. after a pinch) to the adjacent level', () => {
+    expect(nextZoomLevel(levels, 1.7, 1)).toBe(2);
+    expect(nextZoomLevel(levels, 1.7, -1)).toBe(1.5);
+  });
+
+  it('handles off-level zoom beyond the ends', () => {
+    expect(nextZoomLevel(levels, 0.5, 1)).toBe(1);
+    expect(nextZoomLevel(levels, 0.5, -1)).toBe(1);
+    expect(nextZoomLevel(levels, 4, 1)).toBe(3);
+    expect(nextZoomLevel(levels, 4, -1)).toBe(3);
+  });
+});
+
+describe('wheelIntentIsZoom', () => {
+  it('requires ctrl/meta by default', () => {
+    expect(wheelIntentIsZoom(true, false)).toBe(true);
+    expect(wheelIntentIsZoom(false, false)).toBe(false);
+  });
+
+  it('inverts with swapWheelBehavior', () => {
+    expect(wheelIntentIsZoom(false, true)).toBe(true);
+    expect(wheelIntentIsZoom(true, true)).toBe(false);
+  });
+});
+
+describe('normalizeWheelDelta', () => {
+  it('passes pixel deltas through (deltaMode 0)', () => {
+    expect(normalizeWheelDelta(-100, 0)).toBe(-100);
+  });
+
+  it('converts line deltas (deltaMode 1, Firefox)', () => {
+    expect(normalizeWheelDelta(-3, 1)).toBe(-120);
+  });
+
+  it('converts page deltas (deltaMode 2)', () => {
+    expect(normalizeWheelDelta(1, 2)).toBe(800);
+  });
+});
+
+describe('WheelAccumulator', () => {
+  it('emits one zoom-in step for a single mouse-wheel notch up', () => {
+    const acc = new WheelAccumulator();
+    expect(acc.add(-120, 1000)).toBe(1);
+  });
+
+  it('emits one zoom-out step for a notch down', () => {
+    const acc = new WheelAccumulator();
+    expect(acc.add(120, 1000)).toBe(-1);
+  });
+
+  it('emits multiple steps for a large delta', () => {
+    const acc = new WheelAccumulator();
+    expect(acc.add(-240, 1000)).toBe(2);
+  });
+
+  it('accumulates small trackpad deltas until the step size', () => {
+    const acc = new WheelAccumulator();
+    let steps = 0;
+    let t = 1000;
+    for (let i = 0; i < 12; i++) {
+      steps += acc.add(-10, t);
+      t += 16;
+    }
+    expect(steps).toBe(1);
+  });
+
+  it('resets after an idle gap', () => {
+    const acc = new WheelAccumulator();
+    acc.add(-90, 1000);
+    // 90 accumulated, but 500ms later the remnant is stale
+    expect(acc.add(-30, 1500)).toBe(0);
+  });
+
+  it('resets when the direction flips', () => {
+    const acc = new WheelAccumulator();
+    acc.add(-90, 1000);
+    expect(acc.add(60, 1016)).toBe(0);
+    expect(acc.add(60, 1032)).toBe(-1);
+  });
+
+  it('keeps the remainder after emitting steps', () => {
+    const acc = new WheelAccumulator();
+    expect(acc.add(-150, 1000)).toBe(1);
+    expect(acc.add(-50, 1016)).toBe(1);
+  });
+});
+
+describe('pinchDistance / pinchMidpoint', () => {
+  it('computes distance and midpoint of two points', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 30, y: 40 }
+    ];
+    expect(pinchDistance(pts)).toBe(50);
+    expect(pinchMidpoint(pts)).toEqual({ x: 15, y: 20 });
+  });
+
+  it('returns safe values with fewer than two points', () => {
+    expect(pinchDistance([{ x: 5, y: 5 }])).toBe(0);
+    expect(pinchMidpoint([])).toEqual({ x: 0, y: 0 });
   });
 });

--- a/src/lib/reader/zoom-math.ts
+++ b/src/lib/reader/zoom-math.ts
@@ -165,39 +165,3 @@ export function pinchMidpoint(points: readonly Point[]): Point {
     y: (points[0].y + points[1].y) / 2
   };
 }
-
-/**
- * @deprecated Superseded by the measurement-based correction above; still
- * referenced by the scroll readers until they move to ContinuousZoomController.
- */
-export function screenToContent(
-  screenX: number,
-  screenY: number,
-  wrapperVisualLeft: number,
-  wrapperVisualTop: number,
-  currentZoom: number
-): { contentX: number; contentY: number } {
-  return {
-    contentX: (screenX - wrapperVisualLeft) / currentZoom,
-    contentY: (screenY - wrapperVisualTop) / currentZoom
-  };
-}
-
-/**
- * @deprecated Superseded by the measurement-based correction above; still
- * referenced by the scroll readers until they move to ContinuousZoomController.
- */
-export function computeScrollPosition(
-  contentX: number,
-  contentY: number,
-  targetScreenX: number,
-  targetScreenY: number,
-  zoom: number,
-  wrapperOffsetX: number,
-  wrapperOffsetY: number
-): { scrollLeft: number; scrollTop: number } {
-  return {
-    scrollLeft: wrapperOffsetX + contentX * zoom - targetScreenX,
-    scrollTop: wrapperOffsetY + contentY * zoom - targetScreenY
-  };
-}

--- a/src/lib/reader/zoom-math.ts
+++ b/src/lib/reader/zoom-math.ts
@@ -1,34 +1,174 @@
 /**
- * Pure zoom math — no DOM, fully testable.
+ * Pure zoom math for the continuous-mode targeted zoom — no DOM, fully testable.
  *
- * Coordinate system:
- * - Content space: native pixel coordinates within the unscaled content
- * - Screen space: pixel coordinates on the viewport (0,0 = top-left of viewport)
- * - Scroll space: scrollLeft/scrollTop of the scroll container
+ * The continuous readers zoom by applying transform: scale(zoom) to a wrapper
+ * and correcting scroll per frame from *measured* geometry: an anchor is
+ * captured as a fractional position inside a page element's rect, and each
+ * frame the difference between where that anchor actually is and where it
+ * should be is applied as a relative scroll delta. Relative deltas behave
+ * identically in LTR and RTL scroll containers.
  *
- * The zoom wrapper uses transform: scale(zoom) with transform-origin: top left.
- * The wrapper is offset in the scroll flow by spacers (e.g., 50vh centering spacer).
+ * See docs/superpowers/specs/2026-06-09-continuous-targeted-zoom-design.md.
  */
 
-export interface ZoomState {
-  /** Current content-space X of the anchor point */
-  contentX: number;
-  /** Current content-space Y of the anchor point */
-  contentY: number;
-  /** Screen position where the anchor should appear */
-  screenX: number;
-  /** Screen position where the anchor should appear */
-  screenY: number;
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/** The subset of DOMRect the math needs (testable without a DOM). */
+export interface RectLike {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
 }
 
 /**
- * Compute content-space coordinates from a screen position.
+ * Fractional position of a screen point within a rect.
+ * Values outside [0, 1] are valid (linear extrapolation); zero-size rects
+ * yield 0 to avoid division by zero.
+ */
+export function anchorFraction(rect: RectLike, x: number, y: number): { fx: number; fy: number } {
+  return {
+    fx: rect.width > 0 ? (x - rect.left) / rect.width : 0,
+    fy: rect.height > 0 ? (y - rect.top) / rect.height : 0
+  };
+}
+
+/**
+ * Where a fractional anchor currently sits on screen, given a fresh rect
+ * measurement. The rect comes from getBoundingClientRect, which reflects
+ * transforms — so this is exact at any zoom.
+ */
+export function anchorScreenPosition(rect: RectLike, fx: number, fy: number): Point {
+  return {
+    x: rect.left + fx * rect.width,
+    y: rect.top + fy * rect.height
+  };
+}
+
+/**
+ * Animation progress of the zoom between start and target, clamped to [0, 1].
  *
- * @param screenX Screen X position (e.g., click position)
- * @param screenY Screen Y position
- * @param wrapperVisualLeft Wrapper's getBoundingClientRect().left
- * @param wrapperVisualTop Wrapper's getBoundingClientRect().top
- * @param currentZoom Current zoom level
+ * Returns 1 when start === target: pinch drives the animator via snapTo where
+ * start == target on every move, and 0/0 = NaN would survive clamping and
+ * poison the scroll write (browsers coerce NaN scroll values to 0).
+ */
+export function zoomProgress(current: number, start: number, target: number): number {
+  if (start === target) return 1;
+  const t = (current - start) / (target - start);
+  return Math.max(0, Math.min(1, t));
+}
+
+/**
+ * Linear interpolation between two points. When the endpoints coincide the
+ * result is that point regardless of t (guards non-finite t).
+ */
+export function lerp2(from: Point, to: Point, t: number): Point {
+  if (from.x === to.x && from.y === to.y) return { x: from.x, y: from.y };
+  return {
+    x: from.x + (to.x - from.x) * t,
+    y: from.y + (to.y - from.y) * t
+  };
+}
+
+/** Closest level to a zoom value; the lower level wins exact ties. */
+export function nearestZoomLevel(levels: readonly number[], zoom: number): number {
+  return levels.reduce((prev, curr) =>
+    Math.abs(curr - zoom) < Math.abs(prev - zoom) ? curr : prev
+  );
+}
+
+/**
+ * The next level stepping up or down from a zoom value.
+ * Off-level values (e.g. after a pinch) resolve to the adjacent level in the
+ * step direction; values beyond the ends clamp to the nearest end.
+ */
+export function nextZoomLevel(levels: readonly number[], zoom: number, direction: 1 | -1): number {
+  const idx = levels.indexOf(zoom);
+  if (idx >= 0) {
+    const next = Math.max(0, Math.min(levels.length - 1, idx + direction));
+    return levels[next];
+  }
+  if (direction > 0) {
+    for (const level of levels) {
+      if (level > zoom) return level;
+    }
+    return levels[levels.length - 1];
+  }
+  for (let i = levels.length - 1; i >= 0; i--) {
+    if (levels[i] < zoom) return levels[i];
+  }
+  return levels[0];
+}
+
+/**
+ * Whether a wheel event means zoom, matching paged-mode semantics:
+ * ctrl/meta+wheel zooms by default; swapWheelBehavior inverts so bare wheel
+ * zooms and ctrl/meta+wheel scrolls.
+ */
+export function wheelIntentIsZoom(ctrlOrMeta: boolean, swapWheelBehavior: boolean): boolean {
+  return swapWheelBehavior ? !ctrlOrMeta : ctrlOrMeta;
+}
+
+/** Normalize a wheel delta to pixels across deltaMode values. */
+export function normalizeWheelDelta(deltaY: number, deltaMode: number): number {
+  if (deltaMode === 1) return deltaY * 40; // lines (Firefox)
+  if (deltaMode === 2) return deltaY * 800; // pages
+  return deltaY;
+}
+
+/**
+ * Accumulates normalized wheel deltas into discrete zoom level steps.
+ *
+ * One classic mouse notch (|deltaY| ≈ 100–120 px) emits one step immediately;
+ * trackpad streams of small deltas accumulate until the step size. The
+ * accumulator resets after an idle gap or when the scroll direction flips.
+ *
+ * Returns zoom steps: positive = zoom in (wheel up / negative deltaY).
+ */
+export class WheelAccumulator {
+  private acc = 0;
+  private lastTime = -Infinity;
+
+  constructor(
+    private stepSize = 100,
+    private idleResetMs = 250
+  ) {}
+
+  add(deltaPx: number, timestampMs: number): number {
+    if (timestampMs - this.lastTime > this.idleResetMs) this.acc = 0;
+    if (this.acc !== 0 && Math.sign(deltaPx) !== Math.sign(this.acc)) this.acc = 0;
+    this.lastTime = timestampMs;
+    this.acc += deltaPx;
+
+    const steps = Math.trunc(this.acc / this.stepSize);
+    this.acc -= steps * this.stepSize;
+    return steps === 0 ? 0 : -steps;
+  }
+}
+
+/** Distance between the first two points; 0 when fewer than two. */
+export function pinchDistance(points: readonly Point[]): number {
+  if (points.length < 2) return 0;
+  const dx = points[1].x - points[0].x;
+  const dy = points[1].y - points[0].y;
+  return Math.hypot(dx, dy);
+}
+
+/** Midpoint of the first two points; origin when fewer than two. */
+export function pinchMidpoint(points: readonly Point[]): Point {
+  if (points.length < 2) return { x: 0, y: 0 };
+  return {
+    x: (points[0].x + points[1].x) / 2,
+    y: (points[0].y + points[1].y) / 2
+  };
+}
+
+/**
+ * @deprecated Superseded by the measurement-based correction above; still
+ * referenced by the scroll readers until they move to ContinuousZoomController.
  */
 export function screenToContent(
   screenX: number,
@@ -44,23 +184,8 @@ export function screenToContent(
 }
 
 /**
- * Compute the scroll position that places a content point at a screen position.
- *
- * With transform-origin: top left, a content point at (cx, cy) appears at
- * visual position (wrapperOffset + cx * zoom, wrapperOffset + cy * zoom)
- * relative to the scroll container's content origin.
- *
- * To place it at screen position (sx, sy):
- *   scrollLeft = wrapperOffsetX + cx * zoom - sx
- *   scrollTop = wrapperOffsetY + cy * zoom - sy
- *
- * @param contentX Content-space X
- * @param contentY Content-space Y
- * @param targetScreenX Desired screen X position
- * @param targetScreenY Desired screen Y position
- * @param zoom Zoom level
- * @param wrapperOffsetX Wrapper's fixed offset in scroll flow (X)
- * @param wrapperOffsetY Wrapper's fixed offset in scroll flow (Y)
+ * @deprecated Superseded by the measurement-based correction above; still
+ * referenced by the scroll readers until they move to ContinuousZoomController.
  */
 export function computeScrollPosition(
   contentX: number,
@@ -74,24 +199,5 @@ export function computeScrollPosition(
   return {
     scrollLeft: wrapperOffsetX + contentX * zoom - targetScreenX,
     scrollTop: wrapperOffsetY + contentY * zoom - targetScreenY
-  };
-}
-
-/**
- * Verify: given a scroll position and zoom, where does a content point appear on screen?
- * This is the inverse of computeScrollPosition — used for test validation.
- */
-export function contentToScreen(
-  contentX: number,
-  contentY: number,
-  scrollLeft: number,
-  scrollTop: number,
-  zoom: number,
-  wrapperOffsetX: number,
-  wrapperOffsetY: number
-): { screenX: number; screenY: number } {
-  return {
-    screenX: wrapperOffsetX + contentX * zoom - scrollLeft,
-    screenY: wrapperOffsetY + contentY * zoom - scrollTop
   };
 }

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
Closes #195.

Re-enables wheel, double-tap, and pinch zoom in both continuous reading modes — disabled in d7f4e55 because "the zoom targeting math causes position loss and page jumps" — by replacing the predictive absolute-scroll targeting with **measurement-based correction**: each frame applies the zoom layout, measures where the anchored page content actually is (`getBoundingClientRect`, which reflects transforms, alignment, and RTL), and applies the difference as a *relative* scroll delta. Any layout surprise is corrected the next frame instead of compounding.

## Root causes fixed (see the [design spec](docs/superpowers/specs/2026-06-09-continuous-targeted-zoom-design.md))

1. **Absolute scroll math assumed a fixed wrapper offset** — alignment flips and `mx-auto` re-centering invalidated the anchor every frame.
2. **RTL coordinates**: `scrollLeft` is `0`-at-right/negative-leftward in RTL; computed positive values clamped to 0 → jump to page 1.
3. **RTL reachability**: inline-start overflow is unscrollable, so the wrapper now scales from `transform-origin: top right` under RTL.
4. **Vertical fit-to-width page boxes resized every frame** (zoom² growth) — the wrapper's layout width is pinned while zoomed.
5. **"Aberrant paging"**: vertical page detection compared unscaled `offsetTop` to scaled `scrollTop` (at 2× on page 10 it detected ~20, corrupting stats and nav). Detection is now pure visual-rect math (`page-detection.ts`), suppressed mid-gesture, re-run on settle.
6. **NaN landmine**: pinch via `snapTo` made `zoomProgress` compute 0/0; NaN scroll writes coerce to 0 (teleport). Guarded at three layers.

## Gestures

- **Wheel**: `Ctrl/Meta`+wheel (or bare wheel with *Swap mouse wheel scroll/zoom*, matching paged mode) steps 1 → 1.5 → 2 → 3×, anchored at the cursor; deltas normalized + accumulated so one notch = one step and trackpad streams don't fly through levels. The vertical reader gains a real modifier-scroll branch under swap (previously a no-op that fell through to browser page zoom).
- **Double-tap/click**: zoom to 2× panning the tapped point toward center; again to reset (paged-mode semantics).
- **Pinch**: continuous 1:1 (pointer events; Safari-desktop `gesture*` events too), anchored to content under the midpoint, pan+zoom in one gesture, re-baselines on pointer-set changes, snaps back to exactly 1× when released below 1.05.
- Competing intents (keyboard nav, manual page input, scroll wheel, drag) finish the zoom first and act on settled geometry; resets (Z key, resize, layout-setting changes) are silent and stay on the current page.

## Architecture

- `zoom-math.ts` — pure anchor/progress/level/wheel/pinch math (35 tests)
- `zoom-controller.ts` — shared gesture state machine + frame-step correction (18 tests, incl. RTL ranges, NaN coercion, settle bookkeeping, dead-zone)
- `zoom-layout.ts` — the reader-specific layout rules, element-parametrized so components **and** the e2e suite drive the same code
- `page-detection.ts` — visual-space page detection (12 tests with zoomed-rect fixtures)
- Both readers slim down to thin adapters; `ScrollAnimator` gains `stop()`/`sync()`

## Testing

- 514 unit tests; `e2e/zoom.spec.ts` rewritten to import the **production** modules through Vite (the old spec re-implemented the superseded math inline and tested nothing real) — LTR + RTL strips, anchor pinning, layout invariance, NaN regression, RTL reachability, detection at zoom. New `npm run test:e2e` (+ `E2E_PORT`/`E2E_CHROMIUM` overrides for multi-worktree setups).
- Real-browser verification against the actual readers with trusted input (mouse wheel + Ctrl, double-click, CDP touch pinch, keyboard): anchor pinning within 0.5px in both modes, page counter correct at 2×, Z-key/resize while zoomed keeps the page, nav interrupting a zoom advances exactly one page.
- An adversarial multi-agent review of the design and of the branch ran before merge prep; all confirmed findings are fixed in the final commit (including a progress-corruption path on reset-while-zoomed and an Anki QuickActions regression from an over-eager cache optimization, both caught before shipping).

## Notes

- Safari-desktop pinch (`gesturestart/change/end`) is implemented but untested in this environment (isolated to three listeners feeding the standard pinch path).
- Fixes a pre-existing stale "n,n+1" page display after switching horizontal → vertical scroll mode, and pre-existing unreachable page tops in horizontal fit-to-width at 1× (alignment is now computed from measured geometry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)