### PR TITLE
refactor(reader): rebuild the input layer around shared, tested gesture modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,13 +215,16 @@ Tracked per volume in the `volumes` store:
 - Time spent reading (tracked by Timer component)
 - Last read date and current page
 
-### Text Selection Handling
+### Reader Input Handling
 
-The reader has complex text selection logic to prevent interference with drag panning:
+All reader gesture handling (pan, pinch, tap, swipe, wheel, keyboard) goes
+through the shared modules in `src/lib/reader/input/` — see
+**`docs/INPUT-CONTRACTS.md`** for the architecture and the contracts that
+must not break. Highlights:
 
-- Pointer handlers skip pan initiation for `.textBox` targets (PagedViewport.svelte and the scroll readers), so text selection works inside boxes
-- Double-clicking text to select it does not trigger zoom (`.textBox` guard in Reader's onDoubleTap)
-- Text selection is only allowed within text boxes, not on background
+- `.textBox` is an input-routing protocol: double-tap there is the AnkiConnect capture gesture, mouse/pen drags are text selection (Yomitan/Migaku) — never pans, never zoom
+- Each surface owns its gestures via `PointerGestureTracker` config; Reader owns only keyboard + intent callbacks
+- Before starting any motion, handlers call their surface's `MotionGate` intent method instead of ad-hoc `finishNow()`/`stop()` combinations
 
 ### Modal Button Z-Index
 

--- a/docs/INPUT-CONTRACTS.md
+++ b/docs/INPUT-CONTRACTS.md
@@ -1,0 +1,123 @@
+# Reader Input Contracts
+
+How user input flows through the reader, and the contracts every input
+handler must respect. The modules in `src/lib/reader/input/` are the
+load-bearing implementation of this document — their doc comments carry the
+details; this file is the map.
+
+## Architecture
+
+```
+                        ┌─────────────────────────────┐
+                        │   Reader.svelte             │
+                        │   keyboard shortcuts,       │
+                        │   page-flip + overlay       │
+                        │   intents, volume nav       │
+                        └─────────┬───────────────────┘
+              props (callbacks)   │   keyboard / $pagedZoom
+        ┌─────────────────────────┼─────────────────────────┐
+        ▼                         ▼                         ▼
+┌───────────────┐        ┌───────────────┐        ┌───────────────────┐
+│ PagedViewport │        │ VerticalScroll │       │ HorizontalScroll  │
+│               │        │ Reader         │       │ Reader            │
+└───────┬───────┘        └───────┬───────┘        └─────────┬─────────┘
+        │     each surface owns ALL of its pointer input    │
+        ▼                        ▼                          ▼
+   PointerGestureTracker · TapDiscriminator · classifySwipe · MotionGate
+                  (src/lib/reader/input/ — shared machinery)
+```
+
+Each reading surface owns every gesture that starts on it. Reader owns
+keyboard shortcuts and supplies intent callbacks (`onPageFlip`,
+`onOverlayToggle`); it never touches pointer events.
+
+## The shared machinery
+
+| Module               | Owns                                                                                                                                                 |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pointer-tracker.ts` | THE pointer state machine: pan threshold, pinch upgrade/downgrade/re-baseline, capture policy, leak-proof window-level release, `wasDrag`/`wasPinch` |
+| `gesture-target.ts`  | Element-role classification (`textbox` / `interactive` / `page`) and the keyboard-ignore guard                                                       |
+| `tap.ts`             | Tap vs double-tap timing (300 ms), deferred vs immediate commit, text-box dismissal swallowing                                                       |
+| `swipe.ts`           | Pure swipe-to-flip classification (edge gating #186, pinch suppression, thresholds)                                                                  |
+| `motion-gate.ts`     | The interrupt contract: what must stop before new motion starts (`beforeZoom` / `beforeManualPan` / `beforeAnimatedScroll` / `beforeNav`)            |
+
+Surfaces hold only **policy** (config objects) and **actuation** (scroll
+writes, camera moves); classification and lifecycle live in the shared
+modules.
+
+## Contracts that must not break
+
+### `.textBox` is an input-routing protocol, not styling
+
+OCR text boxes own their gestures (see `gesture-target.ts`):
+
+- **Double-tap on a text box is the AnkiConnect card-capture gesture.**
+  TextBoxes.svelte handles it and `stopPropagation()`s; surfaces must also
+  filter taps by role so pointer-based detection never zooms from a text
+  box. Breaking this breaks users' Anki mining flow.
+- Mouse/pen drags on a text box are **text selection** (Yomitan/Migaku
+  scanning) — never a pan. Single-finger **touch** is the exception: it
+  pans everywhere, because touch has no drag-selection gesture.
+- After interacting with a text box, the next tap outside is a
+  **dismissal** — it must not toggle the overlay
+  (`TapDiscriminator.noteTextBoxInteraction`).
+
+### Pinch always wins
+
+Two pointers upgrade to pinch no matter where they pressed (text box
+included). Pointer-set changes re-baseline; dropping to one pointer
+ends the pinch. The survivor continues as a pan only on surfaces with
+incremental deltas (`pinchSurvivorPans` — paged); absolute-baseline
+surfaces (scroll readers) require a fresh press.
+
+### Releases are window-level
+
+`pointerup`/`pointercancel` listen on the window, always. A release landing
+on an overlay or outside the browser must still clean the pointer map —
+phantom entries get misread as pinches (this was a live production bug).
+
+### One gesture at a time (MotionGate)
+
+Every handler that starts motion opens with the gate call matching its
+intent. Never call `finishNow`/`stop`/`stopPan` combinations inline — add
+to the gate if a new intent appears.
+
+### Swipe-to-flip is edge-gated (#186)
+
+A touch swipe flips the page only if no pannable content was hidden in the
+swipe's direction **when the gesture began**. Gestures that pinched never
+flip (`tracker.wasPinch`).
+
+### Tap timing differs by surface family — deliberately
+
+- Scroll readers: **deferred** — overlay toggles 300 ms late so a
+  double-tap (zoom) never flashes it.
+- Paged: **immediate** — overlay toggles instantly on every tap; a
+  double-tap toggles twice (net zero) and zooms, reproducing the native
+  click/click/dblclick sequence paged mode has always had.
+
+### Settle reasons gate progress reporting
+
+Zoom settles carry a `SettleReason` (`zoom-controller.ts`): only
+`'gesture'`/`'interrupt'` settles report reading progress; `'nav'` and
+`'reset'` settles are superseded by whatever caused them.
+
+## Per-surface policy matrix
+
+| Policy         | PagedViewport                     | Scroll readers                          |
+| -------------- | --------------------------------- | --------------------------------------- |
+| Capture        | deferred (at drag threshold)      | immediate (at pan press)                |
+| Pan deltas     | incremental → `camera.adjustView` | totals → absolute scroll from baselines |
+| Text-box pan   | suppressed for mouse/pen only     | suppressed for all pointer types        |
+| Pinch survivor | keeps panning                     | ignored until fresh press               |
+| Tap commit     | immediate                         | deferred (300 ms)                       |
+| Swipe-to-flip  | yes (mobile setting, edge-gated)  | no (panning is the scroll)              |
+| Wheel          | zoom or camera glide              | zoom or (native/strip) scroll           |
+
+## Testing
+
+Unit tests cover the shared machinery (`src/lib/reader/input/*.test.ts`,
+`src/lib/reader/page-nav.test.ts`); Playwright e2e covers zoom geometry
+(`e2e/zoom.spec.ts`). When changing gesture behavior, test manually with a
+Japanese-learning extension (Yomitan/Migaku) enabled and verify the Anki
+double-tap flow still captures.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mokuro-reader",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mokuro-reader",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "dependencies": {
         "@types/gapi": "^0.0.47",
         "@vercel/analytics": "^1.5.0",

--- a/src/app.css
+++ b/src/app.css
@@ -140,3 +140,12 @@ input[type='radio']:checked::after {
   display: none !important;
   content: none !important;
 }
+
+/* Scrollable reader strips hide their scrollbars (used by both scroll readers). */
+.scrollbar-hide {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}

--- a/src/lib/components/Reader/HorizontalScrollReader.svelte
+++ b/src/lib/components/Reader/HorizontalScrollReader.svelte
@@ -12,6 +12,7 @@
   import { detectHorizontalPage, horizontalVisibilityRatio } from '$lib/reader/page-detection';
   import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
   import { gestureTargetRole, keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
+  import { PointerGestureTracker } from '$lib/reader/input/pointer-tracker';
   import { onMount, onDestroy, tick } from 'svelte';
 
   interface Props {
@@ -346,7 +347,7 @@
       scroller?.stop();
       // A held-button drag would keep writing absolute positions from its
       // pre-zoom baseline, fighting the correction frames.
-      isDragging = false;
+      tracker.cancelGestures();
       zoomController.wheelZoom(e);
       return;
     }
@@ -359,102 +360,63 @@
   }
 
   // ============================================================
-  // Click-drag panning
+  // Click-drag panning — classification lives in PointerGestureTracker
+  // (src/lib/reader/input/pointer-tracker.ts); this config holds only the
+  // scroll surface's policy:
+  //
+  // - capture 'immediate': the whole surface is one big drag target, so
+  //   capture on press (the old behavior) — clicks still fire normally
+  // - a press on a text box never pans, for ANY pointer type: drag there is
+  //   text selection (Yomitan/Migaku scanning)
+  // - pan writes absolute scroll positions from press-time baselines
+  //   (totals), with vertical gated on actual overflow
+  // - no pinch-survivor pan: an absolute-baseline pan starting mid-settle
+  //   would fight the post-pinch snap animation
   // ============================================================
 
-  let isDragging = false;
-  let wasDrag = false;
   let textBoxWasActive = false;
-  let dragStartX = 0;
-  let dragStartY = 0;
   let dragScrollLeft = 0;
   let dragScrollTop = 0;
-  const DRAG_THRESHOLD = 5;
 
-  let activePointers = new Map<number, { x: number; y: number }>();
-
-  function handlePointerDown(e: PointerEvent) {
-    activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
-
-    if (gestureTargetRole(e.target) === 'textbox') {
-      textBoxWasActive = true;
-      return;
-    }
-
-    if (activePointers.size >= 2) {
-      // Pinch start — also re-baselines when the pointer set changes
-      // (third finger down) so the gesture stays continuous.
-      isDragging = false;
-      wasDrag = true;
-      scroller?.stop();
-      zoomController.pinchStart([...activePointers.values()]);
-      return;
-    }
-
-    if (e.button !== 0) return;
-
-    if (zoomController.isActive) zoomController.finishNow();
-    isDragging = true;
-    wasDrag = false;
-    dragStartX = e.clientX;
-    dragStartY = e.clientY;
-    dragScrollLeft = scrollContainer?.scrollLeft ?? 0;
-    dragScrollTop = scrollContainer?.scrollTop ?? 0;
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-  }
-
-  function handlePointerMove(e: PointerEvent) {
-    if (activePointers.has(e.pointerId)) {
-      activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
-    }
-
-    if (activePointers.size >= 2) {
-      zoomController.pinchMove([...activePointers.values()]);
-      return;
-    }
-
-    if (!isDragging || !scrollContainer) return;
-    const dx = e.clientX - dragStartX;
-    const dy = e.clientY - dragStartY;
-
-    if (!wasDrag && dx * dx + dy * dy > DRAG_THRESHOLD * DRAG_THRESHOLD) {
-      wasDrag = true;
-      window.getSelection()?.removeAllRanges();
-    }
-
-    if (wasDrag) {
-      e.preventDefault();
-      scrollContainer.scrollLeft = dragScrollLeft - dx;
+  const tracker = new PointerGestureTracker({
+    getElement: () => outerDiv,
+    capturePolicy: 'immediate',
+    suppressPan: (e) => {
+      if (gestureTargetRole(e.target) === 'textbox') {
+        textBoxWasActive = true;
+        return true;
+      }
+      return false;
+    },
+    onPress: () => {
+      if (zoomController.isActive) zoomController.finishNow();
+      dragScrollLeft = scrollContainer?.scrollLeft ?? 0;
+      dragScrollTop = scrollContainer?.scrollTop ?? 0;
+    },
+    onPanMove: (_p, d) => {
+      if (!scrollContainer) return;
+      scrollContainer.scrollLeft = dragScrollLeft - d.totalDx;
       if (isZoomed || scrollContainer.scrollHeight > scrollContainer.clientHeight + 1) {
-        scrollContainer.scrollTop = dragScrollTop - dy;
+        scrollContainer.scrollTop = dragScrollTop - d.totalDy;
       }
+    },
+    onPinchStart: (pts) => {
+      scroller?.stop();
+      zoomController.pinchStart(pts);
+    },
+    onPinchMove: (pts) => zoomController.pinchMove(pts),
+    onPinchEnd: () => zoomController.pinchEnd(),
+    isPinchAlive: () => zoomController.isActive,
+    safariGestures: {
+      start: (x, y) => {
+        scroller?.stop();
+        zoomController.gestureStart(x || viewportWidth / 2, y || viewportHeight / 2);
+      },
+      change: (scale, x, y) =>
+        zoomController.gestureChange(scale, x || viewportWidth / 2, y || viewportHeight / 2),
+      end: () => zoomController.gestureEnd()
     }
-  }
-
-  function handlePointerUp(e: PointerEvent) {
-    const hadPointer = activePointers.has(e.pointerId);
-    activePointers.delete(e.pointerId);
-
-    if (hadPointer && activePointers.size >= 1 && zoomController.isActive) {
-      if (activePointers.size >= 2) {
-        // A pinch finger lifted but two remain — re-baseline on the new pair.
-        zoomController.pinchStart([...activePointers.values()]);
-      } else {
-        zoomController.pinchEnd();
-      }
-      return;
-    }
-    if (activePointers.size === 0) zoomController.pinchEnd();
-
-    if (isDragging) {
-      try {
-        (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
-      } catch {
-        /* ignore */
-      }
-    }
-    isDragging = false;
-  }
+  });
 
   // ============================================================
   // Overlay toggle + double-tap zoom
@@ -465,7 +427,7 @@
 
   function handleClick(e: MouseEvent) {
     if (gestureTargetRole(e.target) !== 'page') return;
-    if (wasDrag) return;
+    if (tracker.wasDrag) return;
 
     // First tap outside after interacting with a text box dismisses it without toggling
     if (textBoxWasActive) {
@@ -485,38 +447,6 @@
     setTimeout(() => {
       if (lastTapTime === tapTime) onOverlayToggle?.();
     }, DOUBLE_TAP_DELAY);
-  }
-
-  // ============================================================
-  // Safari desktop trackpad pinch (proprietary gesture events)
-  // ============================================================
-
-  interface WebKitGestureEvent extends Event {
-    scale: number;
-    clientX: number;
-    clientY: number;
-  }
-
-  function handleGestureStart(e: Event) {
-    e.preventDefault();
-    const ge = e as WebKitGestureEvent;
-    scroller?.stop();
-    zoomController.gestureStart(ge.clientX ?? viewportWidth / 2, ge.clientY ?? viewportHeight / 2);
-  }
-
-  function handleGestureChange(e: Event) {
-    e.preventDefault();
-    const ge = e as WebKitGestureEvent;
-    zoomController.gestureChange(
-      ge.scale ?? 1,
-      ge.clientX ?? viewportWidth / 2,
-      ge.clientY ?? viewportHeight / 2
-    );
-  }
-
-  function handleGestureEnd(e: Event) {
-    e.preventDefault();
-    zoomController.gestureEnd();
   }
 
   // ============================================================
@@ -549,9 +479,7 @@
       scroller = new ScrollAnimator(scrollContainer);
     }
     outerDiv?.addEventListener('wheel', handleWheel, { passive: false });
-    outerDiv?.addEventListener('gesturestart', handleGestureStart);
-    outerDiv?.addEventListener('gesturechange', handleGestureChange);
-    outerDiv?.addEventListener('gestureend', handleGestureEnd);
+    tracker.attach();
     requestAnimationFrame(() => {
       applyAlignment(1);
       // Use navigateToPage for pair centering on landscape mount
@@ -568,9 +496,7 @@
     scroller?.destroy();
     zoomController.destroy();
     outerDiv?.removeEventListener('wheel', handleWheel);
-    outerDiv?.removeEventListener('gesturestart', handleGestureStart);
-    outerDiv?.removeEventListener('gesturechange', handleGestureChange);
-    outerDiv?.removeEventListener('gestureend', handleGestureEnd);
+    tracker.detach();
     if (settleTimer) clearTimeout(settleTimer);
   });
 </script>
@@ -582,10 +508,6 @@
   class="fixed inset-0"
   style:background-color="var(--reader-bg)"
   style:touch-action="none"
-  onpointerdown={handlePointerDown}
-  onpointermove={handlePointerMove}
-  onpointerup={handlePointerUp}
-  onpointercancel={handlePointerUp}
   onclick={handleClick}
   role="none"
 >

--- a/src/lib/components/Reader/HorizontalScrollReader.svelte
+++ b/src/lib/components/Reader/HorizontalScrollReader.svelte
@@ -12,7 +12,8 @@
   import { detectHorizontalPage, horizontalVisibilityRatio } from '$lib/reader/page-detection';
   import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
   import { gestureTargetRole, keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
-  import { PointerGestureTracker } from '$lib/reader/input/pointer-tracker';
+  import { volumeEdgeNav } from '$lib/reader/page-nav';
+  import { PointerGestureTracker, zoomGestureConfig } from '$lib/reader/input/pointer-tracker';
   import { TapDiscriminator } from '$lib/reader/input/tap';
   import type { MotionGate } from '$lib/reader/input/motion-gate';
   import { onMount, onDestroy, tick } from 'svelte';
@@ -254,18 +255,7 @@
   function navigateToPage(pageIdx: number) {
     if (!scroller || !scrollContainer) return;
 
-    // Past the end — mark complete and exit
-    if (pageIdx >= pages.length) {
-      const { charCount } = getCharCount(pages, pages.length);
-      onPageChange(pages.length, charCount, true);
-      onVolumeNav('next');
-      return;
-    }
-    // Before the start — exit
-    if (pageIdx < 0) {
-      onVolumeNav('prev');
-      return;
-    }
+    if (volumeEdgeNav(pageIdx, pages, onPageChange, onVolumeNav)) return;
     motion.beforeNav?.();
     navTarget = pageIdx;
     navIsKeyboard = true;
@@ -411,22 +401,11 @@
         scrollContainer.scrollTop = dragScrollTop - d.totalDy;
       }
     },
-    onPinchStart: (pts) => {
-      motion.beforeZoom();
-      zoomController.pinchStart(pts);
-    },
-    onPinchMove: (pts) => zoomController.pinchMove(pts),
-    onPinchEnd: () => zoomController.pinchEnd(),
-    isPinchAlive: () => zoomController.isActive,
-    safariGestures: {
-      start: (x, y) => {
-        motion.beforeZoom();
-        zoomController.gestureStart(x || viewportWidth / 2, y || viewportHeight / 2);
-      },
-      change: (scale, x, y) =>
-        zoomController.gestureChange(scale, x || viewportWidth / 2, y || viewportHeight / 2),
-      end: () => zoomController.gestureEnd()
-    }
+    ...zoomGestureConfig({
+      beforeZoom: () => motion.beforeZoom(),
+      controller: zoomController,
+      getViewport: () => ({ width: viewportWidth, height: viewportHeight })
+    })
   });
 
   // ============================================================
@@ -572,13 +551,3 @@
     </div>
   </div>
 </div>
-
-<style>
-  .scrollbar-hide {
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-  }
-  .scrollbar-hide::-webkit-scrollbar {
-    display: none;
-  }
-</style>

--- a/src/lib/components/Reader/HorizontalScrollReader.svelte
+++ b/src/lib/components/Reader/HorizontalScrollReader.svelte
@@ -14,6 +14,7 @@
   import { gestureTargetRole, keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
   import { PointerGestureTracker } from '$lib/reader/input/pointer-tracker';
   import { TapDiscriminator } from '$lib/reader/input/tap';
+  import type { MotionGate } from '$lib/reader/input/motion-gate';
   import { onMount, onDestroy, tick } from 'svelte';
 
   interface Props {
@@ -124,19 +125,32 @@
   });
 
   /**
-   * Finish an in-flight zoom before a competing scroll intent (keyboard nav,
-   * external page change) so it acts on settled geometry — the 'nav' settle
-   * reason keeps it from reporting progress the navigation supersedes. The
-   * scroller then adopts the corrected position (its state only syncs via
-   * async scroll events; without this the next scrollBy would animate from
-   * a stale position and undo the zoom's final correction).
+   * Interrupt choke points — see MotionGate for the contract. Notable here:
+   * beforeNav resyncs the scroller because its state only updates via async
+   * scroll events; without sync() the next scrollBy would animate from a
+   * stale position and undo the zoom's final correction. It also clears
+   * navIsKeyboard: a nav that interrupted a zoom realigns, so the next
+   * scroll event must not be misread as keyboard-driven.
    */
-  function interruptZoomForNav() {
-    if (!zoomController.isActive) return;
-    zoomController.finishNow('nav');
-    scroller?.sync();
-    navIsKeyboard = false;
-  }
+  const motion: MotionGate = {
+    beforeZoom() {
+      scroller?.stop();
+      tracker.cancelPan();
+    },
+    beforeManualPan() {
+      if (zoomController.isActive) zoomController.finishNow();
+      scroller?.stop();
+    },
+    beforeAnimatedScroll() {
+      if (zoomController.isActive) zoomController.finishNow();
+    },
+    beforeNav() {
+      if (!zoomController.isActive) return;
+      zoomController.finishNow('nav');
+      scroller?.sync();
+      navIsKeyboard = false;
+    }
+  };
 
   // When the zoom mode (Z key) or a layout-affecting setting changes, reset
   // any user zoom (its measured spacer/transform are stale against the new
@@ -252,7 +266,7 @@
       onVolumeNav('prev');
       return;
     }
-    interruptZoomForNav();
+    motion.beforeNav?.();
     navTarget = pageIdx;
     navIsKeyboard = true;
     const el = pageElements[pageIdx];
@@ -301,12 +315,12 @@
         break;
       case 'ArrowUp':
         e.preventDefault();
-        interruptZoomForNav();
+        motion.beforeNav?.();
         scroller?.scrollBy(0, -viewportHeight * 0.5);
         break;
       case 'ArrowDown':
         e.preventDefault();
-        interruptZoomForNav();
+        motion.beforeNav?.();
         scroller?.scrollBy(0, viewportHeight * 0.5);
         break;
       case 'PageDown':
@@ -345,17 +359,14 @@
 
     if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {
       e.preventDefault();
-      scroller?.stop();
-      // A held-button drag would keep writing absolute positions from its
-      // pre-zoom baseline, fighting the correction frames.
-      tracker.cancelGestures();
+      motion.beforeZoom();
       zoomController.wheelZoom(e);
       return;
     }
 
     // Scroll intent: convert vertical wheel to horizontal strip scroll.
     e.preventDefault();
-    if (zoomController.isActive) zoomController.finishNow();
+    motion.beforeAnimatedScroll();
     const delta = normalizeWheelDelta(e.deltaY, e.deltaMode);
     scrollContainer.scrollLeft += rtl ? -delta : delta;
   }
@@ -389,7 +400,7 @@
       return false;
     },
     onPress: () => {
-      if (zoomController.isActive) zoomController.finishNow();
+      motion.beforeManualPan();
       dragScrollLeft = scrollContainer?.scrollLeft ?? 0;
       dragScrollTop = scrollContainer?.scrollTop ?? 0;
     },
@@ -401,7 +412,7 @@
       }
     },
     onPinchStart: (pts) => {
-      scroller?.stop();
+      motion.beforeZoom();
       zoomController.pinchStart(pts);
     },
     onPinchMove: (pts) => zoomController.pinchMove(pts),
@@ -409,7 +420,7 @@
     isPinchAlive: () => zoomController.isActive,
     safariGestures: {
       start: (x, y) => {
-        scroller?.stop();
+        motion.beforeZoom();
         zoomController.gestureStart(x || viewportWidth / 2, y || viewportHeight / 2);
       },
       change: (scale, x, y) =>
@@ -425,7 +436,7 @@
   const taps = new TapDiscriminator({
     onTap: () => onOverlayToggle?.(),
     onDoubleTap: (x, y) => {
-      scroller?.stop();
+      motion.beforeZoom();
       zoomController.toggleZoom(x, y);
     }
   });

--- a/src/lib/components/Reader/HorizontalScrollReader.svelte
+++ b/src/lib/components/Reader/HorizontalScrollReader.svelte
@@ -13,6 +13,7 @@
   import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
   import { gestureTargetRole, keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
   import { PointerGestureTracker } from '$lib/reader/input/pointer-tracker';
+  import { TapDiscriminator } from '$lib/reader/input/tap';
   import { onMount, onDestroy, tick } from 'svelte';
 
   interface Props {
@@ -374,7 +375,6 @@
   //   would fight the post-pinch snap animation
   // ============================================================
 
-  let textBoxWasActive = false;
   let dragScrollLeft = 0;
   let dragScrollTop = 0;
 
@@ -383,7 +383,7 @@
     capturePolicy: 'immediate',
     suppressPan: (e) => {
       if (gestureTargetRole(e.target) === 'textbox') {
-        textBoxWasActive = true;
+        taps.noteTextBoxInteraction();
         return true;
       }
       return false;
@@ -422,31 +422,18 @@
   // Overlay toggle + double-tap zoom
   // ============================================================
 
-  let lastTapTime = 0;
-  const DOUBLE_TAP_DELAY = 300;
+  const taps = new TapDiscriminator({
+    onTap: () => onOverlayToggle?.(),
+    onDoubleTap: (x, y) => {
+      scroller?.stop();
+      zoomController.toggleZoom(x, y);
+    }
+  });
 
   function handleClick(e: MouseEvent) {
     if (gestureTargetRole(e.target) !== 'page') return;
     if (tracker.wasDrag) return;
-
-    // First tap outside after interacting with a text box dismisses it without toggling
-    if (textBoxWasActive) {
-      textBoxWasActive = false;
-      return;
-    }
-
-    const now = Date.now();
-    if (now - lastTapTime < DOUBLE_TAP_DELAY) {
-      lastTapTime = 0;
-      scroller?.stop();
-      zoomController.toggleZoom(e.clientX, e.clientY);
-      return;
-    }
-    lastTapTime = now;
-    const tapTime = now;
-    setTimeout(() => {
-      if (lastTapTime === tapTime) onOverlayToggle?.();
-    }, DOUBLE_TAP_DELAY);
+    taps.tap(e.clientX, e.clientY);
   }
 
   // ============================================================
@@ -497,6 +484,7 @@
     zoomController.destroy();
     outerDiv?.removeEventListener('wheel', handleWheel);
     tracker.detach();
+    taps.cancel();
     if (settleTimer) clearTimeout(settleTimer);
   });
 </script>

--- a/src/lib/components/Reader/HorizontalScrollReader.svelte
+++ b/src/lib/components/Reader/HorizontalScrollReader.svelte
@@ -11,6 +11,7 @@
   import { applyHorizontalAlignment, applyHorizontalZoomLayout } from '$lib/reader/zoom-layout';
   import { detectHorizontalPage, horizontalVisibilityRatio } from '$lib/reader/page-detection';
   import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
+  import { gestureTargetRole, keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
   import { onMount, onDestroy, tick } from 'svelte';
 
   interface Props {
@@ -279,14 +280,7 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    const target = e.target as HTMLElement;
-    if (
-      target.tagName === 'INPUT' ||
-      target.tagName === 'TEXTAREA' ||
-      target.tagName === 'SELECT' ||
-      target.isContentEditable
-    )
-      return;
+    if (keyboardShouldIgnore(e.target)) return;
     if (!scrollContainer) return;
 
     // Always use navTarget — it's authoritative.
@@ -382,7 +376,7 @@
   function handlePointerDown(e: PointerEvent) {
     activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
 
-    if ((e.target as HTMLElement).closest('.textBox')) {
+    if (gestureTargetRole(e.target) === 'textbox') {
       textBoxWasActive = true;
       return;
     }
@@ -470,7 +464,7 @@
   const DOUBLE_TAP_DELAY = 300;
 
   function handleClick(e: MouseEvent) {
-    if ((e.target as HTMLElement).closest('.textBox, button, [role="button"], a')) return;
+    if (gestureTargetRole(e.target) !== 'page') return;
     if (wasDrag) return;
 
     // First tap outside after interacting with a text box dismisses it without toggling

--- a/src/lib/components/Reader/HorizontalScrollReader.svelte
+++ b/src/lib/components/Reader/HorizontalScrollReader.svelte
@@ -7,7 +7,7 @@
   import { activityTracker } from '$lib/util/activity-tracker';
   import MangaPage from './MangaPage.svelte';
   import { ScrollAnimator } from '$lib/reader/scroll-animator';
-  import { ContinuousZoomController } from '$lib/reader/zoom-controller';
+  import { ContinuousZoomController, type SettleReason } from '$lib/reader/zoom-controller';
   import { applyHorizontalAlignment, applyHorizontalZoomLayout } from '$lib/reader/zoom-layout';
   import { detectHorizontalPage, horizontalVisibilityRatio } from '$lib/reader/page-detection';
   import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
@@ -70,7 +70,6 @@
   let zoomWrapperEl: HTMLDivElement | undefined = $state();
   let zoomSpacerEl: HTMLDivElement | undefined = $state();
   let isZoomed = $state(false);
-  let suppressSettleReport = false;
 
   // Reader-specific zoomed layout (transform origin per direction, spacer
   // dims, measured cross-axis alignment) — shared with the e2e suite, see
@@ -92,7 +91,7 @@
     );
   }
 
-  function handleZoomSettled(zoom: number) {
+  function handleZoomSettled(zoom: number, reason: SettleReason) {
     if (zoom <= 1 && scrollContainer) {
       // Reset the cross axis only when no scroll range legitimately remains
       // at 1× (fit-to-width/original pages taller than the viewport keep it).
@@ -100,10 +99,10 @@
         scrollContainer.scrollTop = 0;
       }
     }
-    // Suppressed settles (nav interrupts, resets) are followed by their own
-    // navTarget update against restored geometry — detection here would read
-    // the shifted layout and land on a garbage page.
-    if (!suppressSettleReport) {
+    // 'nav' settles are followed by the navigation's own navTarget update,
+    // and 'reset' settles have stale scroll geometry the caller re-anchors
+    // next — detection on either would land on a garbage page.
+    if (reason === 'gesture' || reason === 'interrupt') {
       navTarget = detectCurrentPage();
       navIsKeyboard = false;
       reportProgress();
@@ -123,31 +122,17 @@
 
   /**
    * Finish an in-flight zoom before a competing scroll intent (keyboard nav,
-   * external page change) so it acts on settled geometry. The settle report
-   * is suppressed — the navigation is about to change the page anyway —
-   * and the scroller adopts the corrected position (its state only syncs
-   * via async scroll events; without this the next scrollBy would animate
-   * from a stale position and undo the zoom's final correction).
+   * external page change) so it acts on settled geometry — the 'nav' settle
+   * reason keeps it from reporting progress the navigation supersedes. The
+   * scroller then adopts the corrected position (its state only syncs via
+   * async scroll events; without this the next scrollBy would animate from
+   * a stale position and undo the zoom's final correction).
    */
   function interruptZoomForNav() {
     if (!zoomController.isActive) return;
-    suppressSettleReport = true;
-    zoomController.finishNow();
-    suppressSettleReport = false;
+    zoomController.finishNow('nav');
     scroller?.sync();
     navIsKeyboard = false;
-  }
-
-  /**
-   * Instant zoom reset with the settle report suppressed: reset() skips the
-   * anchor correction, so the scroll offset is stale zoomed-space garbage —
-   * detection would land pages ahead and corrupt progress before the caller
-   * re-anchors to the page it captured.
-   */
-  function resetZoom() {
-    suppressSettleReport = true;
-    zoomController.reset();
-    suppressSettleReport = false;
   }
 
   // When the zoom mode (Z key) or a layout-affecting setting changes, reset
@@ -160,7 +145,7 @@
     prevLayoutKey = layoutKey;
 
     const pageIdx = lastReportedPage - 1;
-    resetZoom();
+    zoomController.reset();
     tick().then(() => {
       applyAlignment(1);
       const el = pageElements[pageIdx];
@@ -547,7 +532,7 @@
   function handleResize() {
     const wasLandscape = viewportWidth > viewportHeight;
     const pageIdx = lastReportedPage - 1;
-    resetZoom();
+    zoomController.reset();
     viewportWidth = window.innerWidth;
     viewportHeight = window.innerHeight;
     const isLandscape = viewportWidth > viewportHeight;

--- a/src/lib/components/Reader/PagedViewport.svelte
+++ b/src/lib/components/Reader/PagedViewport.svelte
@@ -253,6 +253,9 @@
   // surface was built on — instant overlay toggles, zoom on the second tap.
   const taps = new TapDiscriminator({
     commitPolicy: 'immediate',
+    // Native dblclick (which this surface used before) required the clicks
+    // to land near each other — keep that gate.
+    maxDoubleTapDistancePx: 40,
     onTap: () => onOverlayToggle?.(),
     onDoubleTap: (x, y) => doubleTap(x, y)
   });

--- a/src/lib/components/Reader/PagedViewport.svelte
+++ b/src/lib/components/Reader/PagedViewport.svelte
@@ -15,6 +15,8 @@
   import { pagedZoom, type PagedZoomApi } from '$lib/reader/paged-zoom';
   import { PointerGestureTracker } from '$lib/reader/input/pointer-tracker';
   import { gestureTargetRole } from '$lib/reader/input/gesture-target';
+  import { TapDiscriminator } from '$lib/reader/input/tap';
+  import { classifySwipe } from '$lib/reader/input/swipe';
   import type { MotionGate } from '$lib/reader/input/motion-gate';
 
   interface Props {
@@ -27,10 +29,18 @@
      */
     pageKey: number | string;
     rtl: boolean;
+    /**
+     * An edge-gated swipe asked for the page on this VISUAL side ('left' =
+     * rightward swipe revealing the left page). RTL mapping is the
+     * caller's concern.
+     */
+    onPageFlip?: (side: 'left' | 'right') => void;
+    /** A lone tap on the page surface (not text box / chrome). */
+    onOverlayToggle?: () => void;
     children?: Snippet;
   }
 
-  let { contentSize, pageKey, rtl, children }: Props = $props();
+  let { contentSize, pageKey, rtl, onPageFlip, onOverlayToggle, children }: Props = $props();
 
   let wrapperEl: HTMLDivElement | undefined = $state();
   let viewportWidth = $state(typeof window !== 'undefined' ? window.innerWidth : 1024);
@@ -98,7 +108,8 @@
   }
 
   // ============================================================
-  // Wheel (window-level delegate — Reader routes reader-targeted events here)
+  // Wheel — attached to the wrapper (non-passive, so ctrl+wheel can
+  // preventDefault the browser page-zoom)
   // ============================================================
 
   /** Interrupt choke points — see MotionGate for the contract. */
@@ -164,10 +175,7 @@
   }
 
   const api: PagedZoomApi = {
-    handleWheel,
-    doubleTap,
     scrollImage,
-    edgeState: () => camera.edgeState(),
     zoomFitToScreen
   };
 
@@ -187,14 +195,36 @@
   //   was cleared mid-gesture by a base re-application (rotation, page turn)
   // ============================================================
 
+  // Edge state sampled at press, BEFORE the pan moves the camera — swipe
+  // classification needs to know what was hidden when the gesture began.
+  let edgeAtPress = { canRevealLeft: false, canRevealRight: false };
+
   const tracker = new PointerGestureTracker({
     getElement: () => wrapperEl,
     capturePolicy: 'deferred',
-    suppressPan: (e) => e.pointerType !== 'touch' && gestureTargetRole(e.target) === 'textbox',
-    onPress: () => motion.beforeManualPan(),
+    suppressPan: (e) => {
+      if (gestureTargetRole(e.target) !== 'textbox') return false;
+      // Any press on a text box marks the next outside tap as a dismissal.
+      taps.noteTextBoxInteraction();
+      return e.pointerType !== 'touch';
+    },
+    onPress: () => {
+      motion.beforeManualPan();
+      edgeAtPress = camera.edgeState();
+    },
     onPanMove: (_p, d) => camera.adjustView(-d.dx, -d.dy),
     onPanEnd: (s) => {
       if (s.panned) camera.settle();
+      if (!$settings.mobile) return;
+      const side = classifySwipe({
+        summary: s,
+        wasPinch: tracker.wasPinch,
+        viewport: { width: viewportWidth, height: viewportHeight },
+        thresholdPercent: $settings.swipeThreshold,
+        canRevealLeftAtStart: edgeAtPress.canRevealLeft,
+        canRevealRightAtStart: edgeAtPress.canRevealRight
+      });
+      if (side) onPageFlip?.(side);
     },
     onPinchStart: (pts) => {
       motion.beforeZoom();
@@ -219,14 +249,31 @@
     }
   });
 
+  // 'immediate' reproduces the native click/click/dblclick sequence this
+  // surface was built on — instant overlay toggles, zoom on the second tap.
+  const taps = new TapDiscriminator({
+    commitPolicy: 'immediate',
+    onTap: () => onOverlayToggle?.(),
+    onDoubleTap: (x, y) => doubleTap(x, y)
+  });
+
+  function handleClick(e: MouseEvent) {
+    if (gestureTargetRole(e.target) !== 'page') return;
+    if (tracker.wasDrag) return;
+    taps.tap(e.clientX, e.clientY);
+  }
+
   onMount(() => {
     pagedZoom.set(api);
     tracker.attach();
+    wrapperEl?.addEventListener('wheel', handleWheel, { passive: false });
   });
 
   onDestroy(() => {
     pagedZoom.set(undefined);
     tracker.detach();
+    taps.cancel();
+    wrapperEl?.removeEventListener('wheel', handleWheel);
     controller.destroy();
     camera.destroy();
   });
@@ -234,6 +281,12 @@
 
 <svelte:window onresize={handleResize} />
 
-<div bind:this={wrapperEl} data-mokuro-reader style:touch-action="none" role="none">
+<div
+  bind:this={wrapperEl}
+  data-mokuro-reader
+  style:touch-action="none"
+  onclick={handleClick}
+  role="none"
+>
   {@render children?.()}
 </div>

--- a/src/lib/components/Reader/PagedViewport.svelte
+++ b/src/lib/components/Reader/PagedViewport.svelte
@@ -13,6 +13,7 @@
   } from '$lib/reader/paged-zoom-session';
   import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
   import { pagedZoom, type PagedZoomApi } from '$lib/reader/paged-zoom';
+  import { PointerGestureTracker } from '$lib/reader/input/pointer-tracker';
   import { gestureTargetRole } from '$lib/reader/input/gesture-target';
 
   interface Props {
@@ -154,191 +155,71 @@
   };
 
   // ============================================================
-  // Pointer state machine
+  // Pointer gestures — classification lives in PointerGestureTracker
+  // (src/lib/reader/input/pointer-tracker.ts); this config holds only the
+  // paged surface's policy:
   //
-  // - every pointer enters the map; .textBox suppresses PAN initiation for
-  //   mouse/pen only (drag selection) — touch pans everywhere, exactly like
-  //   the old panzoom touch path, which handled single-finger touches
-  //   unconditionally (its onTouch option only gated preventDefault)
-  // - single-finger touch pan COEXISTS with Reader's swipe-to-flip: touch
-  //   events aren't retargeted by pointer capture, so the window-level swipe
-  //   handlers still see them and stay edge-gated (#186)
-  // - capture is deferred until DRAG_THRESHOLD so gutter-button clicks and
-  //   text-selection drags behave exactly as before
-  // - two pointers always upgrade to pinch; back down to one re-baselines
-  //   as a fresh pan with the remaining pointer
+  // - capture 'deferred': gutter-button clicks and text-selection drags
+  //   deliver natively; capture engages only once a drag crosses threshold
+  // - mouse/pen on a text box is a selection drag, never a pan; touch has no
+  //   drag-selection gesture, so touch pans everywhere (exactly like the old
+  //   panzoom touch path) and COEXISTS with Reader's window-level
+  //   swipe-to-flip, which stays edge-gated (#186)
+  // - pan deltas are incremental — the camera accumulates them
+  // - isPinchAlive lets the tracker resurrect a pinch whose controller state
+  //   was cleared mid-gesture by a base re-application (rotation, page turn)
   // ============================================================
 
-  const DRAG_THRESHOLD = 5;
-  let activePointers = new Map<number, { x: number; y: number; type: string }>();
-  let panPointerId: number | null = null;
-  let panMoved = false;
-  let lastPanX = 0;
-  let lastPanY = 0;
-
-  function points() {
-    return [...activePointers.values()];
-  }
-
-  function beginPan(e: { pointerId: number; clientX: number; clientY: number }) {
-    panPointerId = e.pointerId;
-    panMoved = false;
-    lastPanX = e.clientX;
-    lastPanY = e.clientY;
-  }
-
-  function endPan() {
-    if (panPointerId !== null && panMoved && wrapperEl) {
-      try {
-        wrapperEl.releasePointerCapture(panPointerId);
-      } catch {
-        /* ignore */
-      }
-      camera.settle();
-    }
-    panPointerId = null;
-    panMoved = false;
-  }
-
-  function handlePointerDown(e: PointerEvent) {
-    activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY, type: e.pointerType });
-
-    if (activePointers.size >= 2) {
-      // Pinch — always, even when a finger started on a text box.
-      endPan();
+  const tracker = new PointerGestureTracker({
+    getElement: () => wrapperEl,
+    capturePolicy: 'deferred',
+    suppressPan: (e) => e.pointerType !== 'touch' && gestureTargetRole(e.target) === 'textbox',
+    onPress: () => {
+      if (controller.isActive) controller.finishNow();
       camera.stopPan();
-      controller.pinchStart(points());
-      return;
+    },
+    onPanMove: (_p, d) => camera.adjustView(-d.dx, -d.dy),
+    onPanEnd: (s) => {
+      if (s.panned) camera.settle();
+    },
+    onPinchStart: (pts) => {
+      camera.stopPan();
+      controller.pinchStart(pts);
+    },
+    onPinchMove: (pts) => controller.pinchMove(pts),
+    onPinchEnd: () => controller.pinchEnd(),
+    // The finger remaining after a pinch keeps panning (the old panzoom
+    // pinch→drag handoff) — safe here because deltas are incremental.
+    pinchSurvivorPans: true,
+    isPinchAlive: () => controller.isActive,
+    // Safari desktop trackpad pinch. A gesture at exactly x=0 falls back to
+    // center — indistinguishable from WebKit omitting the coordinate.
+    safariGestures: {
+      start: (x, y) => {
+        camera.stopPan();
+        controller.gestureStart(x || viewportWidth / 2, y || viewportHeight / 2);
+      },
+      change: (scale, x, y) =>
+        controller.gestureChange(scale, x || viewportWidth / 2, y || viewportHeight / 2),
+      end: () => controller.gestureEnd()
     }
-
-    // Mouse/pen on a text box is a selection drag, never a pan; touch has no
-    // drag-selection gesture and panned over text in production too.
-    if (e.pointerType !== 'touch' && gestureTargetRole(e.target) === 'textbox') return;
-    if (e.button !== 0) return;
-
-    if (controller.isActive) controller.finishNow();
-    camera.stopPan();
-    beginPan(e);
-  }
-
-  function handlePointerMove(e: PointerEvent) {
-    if (activePointers.has(e.pointerId)) {
-      activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY, type: e.pointerType });
-    }
-
-    if (activePointers.size >= 2) {
-      // A base re-application mid-pinch (rotation, page change) clears the
-      // controller's pinch state — re-baseline on the next move so the
-      // gesture stays alive instead of dying until fingers re-press.
-      if (!controller.isActive) controller.pinchStart(points());
-      controller.pinchMove(points());
-      return;
-    }
-
-    if (panPointerId !== e.pointerId) return;
-    const dx = e.clientX - lastPanX;
-    const dy = e.clientY - lastPanY;
-
-    if (!panMoved) {
-      const fromStart = Math.hypot(dx, dy);
-      if (fromStart <= DRAG_THRESHOLD) return;
-      panMoved = true;
-      window.getSelection()?.removeAllRanges();
-      wrapperEl?.setPointerCapture(e.pointerId);
-    }
-
-    lastPanX = e.clientX;
-    lastPanY = e.clientY;
-    camera.adjustView(-dx, -dy);
-  }
-
-  function handlePointerUp(e: PointerEvent) {
-    const had = activePointers.has(e.pointerId);
-    activePointers.delete(e.pointerId);
-
-    if (had && controller.isActive && activePointers.size >= 1) {
-      if (activePointers.size >= 2) {
-        controller.pinchStart(points()); // re-baseline on the new pair
-      } else {
-        controller.pinchEnd();
-        // The remaining pointer continues as a pan — for touch too, matching
-        // the old panzoom pinch→drag handoff.
-        const rest = points()[0];
-        const restId = [...activePointers.keys()][0];
-        if (rest) {
-          beginPan({ pointerId: restId, clientX: rest.x, clientY: rest.y });
-        }
-      }
-      return;
-    }
-    if (activePointers.size === 0) controller.pinchEnd();
-
-    if (panPointerId === e.pointerId) endPan();
-  }
-
-  // Safari desktop trackpad pinch (proprietary gesture events).
-  interface WebKitGestureEvent extends Event {
-    scale: number;
-    clientX: number;
-    clientY: number;
-  }
-
-  function handleGestureStart(e: Event) {
-    e.preventDefault();
-    const ge = e as WebKitGestureEvent;
-    camera.stopPan();
-    controller.gestureStart(ge.clientX ?? viewportWidth / 2, ge.clientY ?? viewportHeight / 2);
-  }
-
-  function handleGestureChange(e: Event) {
-    e.preventDefault();
-    const ge = e as WebKitGestureEvent;
-    controller.gestureChange(
-      ge.scale ?? 1,
-      ge.clientX ?? viewportWidth / 2,
-      ge.clientY ?? viewportHeight / 2
-    );
-  }
-
-  function handleGestureEnd(e: Event) {
-    e.preventDefault();
-    controller.gestureEnd();
-  }
+  });
 
   onMount(() => {
     pagedZoom.set(api);
-    wrapperEl?.addEventListener('gesturestart', handleGestureStart);
-    wrapperEl?.addEventListener('gesturechange', handleGestureChange);
-    wrapperEl?.addEventListener('gestureend', handleGestureEnd);
+    tracker.attach();
   });
 
   onDestroy(() => {
     pagedZoom.set(undefined);
-    wrapperEl?.removeEventListener('gesturestart', handleGestureStart);
-    wrapperEl?.removeEventListener('gesturechange', handleGestureChange);
-    wrapperEl?.removeEventListener('gestureend', handleGestureEnd);
+    tracker.detach();
     controller.destroy();
     camera.destroy();
   });
 </script>
 
-<!-- pointerup/cancel listen on the window: an uncaptured release outside the
-     wrapper (text-selection drag ending over an overlay, right-click menus)
-     must still clean the pointer map, or the next mixed-input press would be
-     misread as a pinch with a phantom stale point. -->
-<svelte:window
-  onresize={handleResize}
-  onpointerup={handlePointerUp}
-  onpointercancel={handlePointerUp}
-/>
+<svelte:window onresize={handleResize} />
 
-<div
-  bind:this={wrapperEl}
-  data-mokuro-reader
-  style:touch-action="none"
-  onpointerdown={handlePointerDown}
-  onpointermove={handlePointerMove}
-  role="none"
->
+<div bind:this={wrapperEl} data-mokuro-reader style:touch-action="none" role="none">
   {@render children?.()}
 </div>

--- a/src/lib/components/Reader/PagedViewport.svelte
+++ b/src/lib/components/Reader/PagedViewport.svelte
@@ -13,6 +13,7 @@
   } from '$lib/reader/paged-zoom-session';
   import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
   import { pagedZoom, type PagedZoomApi } from '$lib/reader/paged-zoom';
+  import { gestureTargetRole } from '$lib/reader/input/gesture-target';
 
   interface Props {
     /** Native pixel size of the displayed page or pair — from page data, not DOM. */
@@ -212,7 +213,7 @@
 
     // Mouse/pen on a text box is a selection drag, never a pan; touch has no
     // drag-selection gesture and panned over text in production too.
-    if (e.pointerType !== 'touch' && (e.target as HTMLElement).closest('.textBox')) return;
+    if (e.pointerType !== 'touch' && gestureTargetRole(e.target) === 'textbox') return;
     if (e.button !== 0) return;
 
     if (controller.isActive) controller.finishNow();

--- a/src/lib/components/Reader/PagedViewport.svelte
+++ b/src/lib/components/Reader/PagedViewport.svelte
@@ -13,7 +13,7 @@
   } from '$lib/reader/paged-zoom-session';
   import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
   import { pagedZoom, type PagedZoomApi } from '$lib/reader/paged-zoom';
-  import { PointerGestureTracker } from '$lib/reader/input/pointer-tracker';
+  import { PointerGestureTracker, zoomGestureConfig } from '$lib/reader/input/pointer-tracker';
   import { gestureTargetRole } from '$lib/reader/input/gesture-target';
   import { TapDiscriminator } from '$lib/reader/input/tap';
   import { classifySwipe } from '$lib/reader/input/swipe';
@@ -188,8 +188,9 @@
   //   deliver natively; capture engages only once a drag crosses threshold
   // - mouse/pen on a text box is a selection drag, never a pan; touch has no
   //   drag-selection gesture, so touch pans everywhere (exactly like the old
-  //   panzoom touch path) and COEXISTS with Reader's window-level
-  //   swipe-to-flip, which stays edge-gated (#186)
+  //   panzoom touch path)
+  // - swipe-to-flip is classified HERE from pan summaries (onPanEnd below),
+  //   edge-gated via press-time camera state (#186)
   // - pan deltas are incremental — the camera accumulates them
   // - isPinchAlive lets the tracker resurrect a pinch whose controller state
   //   was cleared mid-gesture by a base re-application (rotation, page turn)
@@ -226,27 +227,14 @@
       });
       if (side) onPageFlip?.(side);
     },
-    onPinchStart: (pts) => {
-      motion.beforeZoom();
-      controller.pinchStart(pts);
-    },
-    onPinchMove: (pts) => controller.pinchMove(pts),
-    onPinchEnd: () => controller.pinchEnd(),
     // The finger remaining after a pinch keeps panning (the old panzoom
     // pinch→drag handoff) — safe here because deltas are incremental.
     pinchSurvivorPans: true,
-    isPinchAlive: () => controller.isActive,
-    // Safari desktop trackpad pinch. A gesture at exactly x=0 falls back to
-    // center — indistinguishable from WebKit omitting the coordinate.
-    safariGestures: {
-      start: (x, y) => {
-        motion.beforeZoom();
-        controller.gestureStart(x || viewportWidth / 2, y || viewportHeight / 2);
-      },
-      change: (scale, x, y) =>
-        controller.gestureChange(scale, x || viewportWidth / 2, y || viewportHeight / 2),
-      end: () => controller.gestureEnd()
-    }
+    ...zoomGestureConfig({
+      beforeZoom: () => motion.beforeZoom(),
+      controller,
+      getViewport: () => ({ width: viewportWidth, height: viewportHeight })
+    })
   });
 
   // 'immediate' reproduces the native click/click/dblclick sequence this

--- a/src/lib/components/Reader/PagedViewport.svelte
+++ b/src/lib/components/Reader/PagedViewport.svelte
@@ -15,6 +15,7 @@
   import { pagedZoom, type PagedZoomApi } from '$lib/reader/paged-zoom';
   import { PointerGestureTracker } from '$lib/reader/input/pointer-tracker';
   import { gestureTargetRole } from '$lib/reader/input/gesture-target';
+  import type { MotionGate } from '$lib/reader/input/motion-gate';
 
   interface Props {
     /** Native pixel size of the displayed page or pair — from page data, not DOM. */
@@ -100,23 +101,41 @@
   // Wheel (window-level delegate — Reader routes reader-targeted events here)
   // ============================================================
 
+  /** Interrupt choke points — see MotionGate for the contract. */
+  const motion: MotionGate = {
+    beforeZoom() {
+      camera.stopPan();
+      tracker.cancelPan();
+    },
+    beforeManualPan() {
+      if (controller.isActive) controller.finishNow();
+      camera.stopPan();
+    },
+    beforeAnimatedScroll() {
+      // camera.panBy chains glides itself — only the zoom must yield.
+      if (controller.isActive) controller.finishNow();
+    }
+    // No beforeNav: page turns are owned by Reader and re-apply the base
+    // through the pageKey effect.
+  };
+
   function handleWheel(e: WheelEvent) {
     const modifier = e.ctrlKey || e.metaKey;
     if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {
       e.preventDefault();
-      camera.stopPan();
+      motion.beforeZoom();
       controller.wheelZoom(e);
       return;
     }
     e.preventDefault();
-    if (controller.isActive) controller.finishNow();
+    motion.beforeAnimatedScroll();
     camera.panBy(0, -normalizeWheelDelta(e.deltaY, e.deltaMode));
   }
 
   function doubleTap(x: number, y: number) {
     const levels = pagedLevels(session.baseScale, session.fitScale);
     const target = doubleTapTarget(controller.currentZoom, levels[0]);
-    camera.stopPan();
+    motion.beforeZoom();
     // Zooming in animates the tapped content toward the CLAMPED center
     // position — aiming at the raw center fights the bounds near edges.
     controller.animateToLevel(
@@ -127,9 +146,7 @@
   }
 
   function scrollImage(direction: 'up' | 'down') {
-    // A running zoom animation owns the camera — finish it first or its
-    // per-frame corrections stomp the pan.
-    if (controller.isActive) controller.finishNow();
+    motion.beforeAnimatedScroll();
     const amount = viewportHeight * 0.75;
     camera.panBy(0, direction === 'down' ? -amount : amount);
   }
@@ -174,16 +191,13 @@
     getElement: () => wrapperEl,
     capturePolicy: 'deferred',
     suppressPan: (e) => e.pointerType !== 'touch' && gestureTargetRole(e.target) === 'textbox',
-    onPress: () => {
-      if (controller.isActive) controller.finishNow();
-      camera.stopPan();
-    },
+    onPress: () => motion.beforeManualPan(),
     onPanMove: (_p, d) => camera.adjustView(-d.dx, -d.dy),
     onPanEnd: (s) => {
       if (s.panned) camera.settle();
     },
     onPinchStart: (pts) => {
-      camera.stopPan();
+      motion.beforeZoom();
       controller.pinchStart(pts);
     },
     onPinchMove: (pts) => controller.pinchMove(pts),
@@ -196,7 +210,7 @@
     // center — indistinguishable from WebKit omitting the coordinate.
     safariGestures: {
       start: (x, y) => {
-        camera.stopPan();
+        motion.beforeZoom();
         controller.gestureStart(x || viewportWidth / 2, y || viewportHeight / 2);
       },
       change: (scale, x, y) =>

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -6,7 +6,7 @@
   import PagedViewport from './PagedViewport.svelte';
   import { pagedZoom } from '$lib/reader/paged-zoom';
   import { setInstantAnimations } from '$lib/reader/animator';
-  import { gestureTargetRole, keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
+  import { keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
   import { toggleFullScreen } from '$lib/util/fullscreen';
   import {
     effectiveVolumeSettings,
@@ -26,7 +26,6 @@
   import MangaPage from './MangaPage.svelte';
   import TextBoxContextMenu from './TextBoxContextMenu.svelte';
   import {
-    cropperStore,
     openCreateModal,
     openUpdateModal,
     sendQuickCapture,
@@ -75,43 +74,9 @@
   );
 
   let start: Date;
-  let textBoxWasActive = false;
-  let pointerDownX = 0;
-  let pointerDownY = 0;
-  const DRAG_THRESHOLD = 5;
 
   function mouseDown() {
     start = new Date();
-  }
-
-  function handleOverlayPointerDown(e: PointerEvent) {
-    pointerDownX = e.clientX;
-    pointerDownY = e.clientY;
-
-    const target = e.target as HTMLElement;
-    if (gestureTargetRole(target) === 'textbox') {
-      textBoxWasActive = true;
-    }
-  }
-
-  function handleOverlayToggle(e: MouseEvent) {
-    const target = e.target as HTMLElement;
-
-    // Clicking on a text box — don't toggle
-    if (gestureTargetRole(target) === 'textbox') return;
-
-    // Ignore drags/pans — only toggle on stationary clicks
-    const dx = e.clientX - pointerDownX;
-    const dy = e.clientY - pointerDownY;
-    if (dx * dx + dy * dy > DRAG_THRESHOLD * DRAG_THRESHOLD) return;
-
-    // First tap outside after interacting with a text box dismisses it without toggling
-    if (textBoxWasActive) {
-      textBoxWasActive = false;
-      return;
-    }
-
-    overlaysVisible = !overlaysVisible;
   }
 
   export function toggleHasCover(volumeId: string) {
@@ -447,98 +412,6 @@
     }
   }
 
-  let startX = 0;
-  let startY = 0;
-  let touchStart: Date;
-  let lastMultiTouchTime = 0; // Timestamp of last multi-touch event
-  // Pan-edge state captured at the start of a single-finger gesture.
-  // When the user begins a gesture while more content is hidden in a given
-  // direction, we treat any horizontal motion in that direction as a pan
-  // rather than a page-flip swipe (issue #186).
-  let canRevealLeftAtStart = false;
-  let canRevealRightAtStart = false;
-
-  function handleTouchStart(event: TouchEvent) {
-    if (!$settings.mobile) return;
-    if ($cropperStore?.open) return;
-    if ($settings.continuousScroll) return; // Continuous mode handles its own touch
-    if (event.touches.length > 1) return; // Ignore multi-touch starts
-
-    // Capture start position for single-finger gesture
-    const { clientX, clientY } = event.touches[0];
-    touchStart = new Date();
-    startX = clientX;
-    startY = clientY;
-
-    // Snapshot how much pannable content exists in each horizontal direction
-    // right now, so that a subsequent swipe can be classified as either a
-    // page-flip (only when already at the relevant edge) or an intra-page pan.
-    const edgeState = $pagedZoom?.edgeState() ?? { canRevealLeft: false, canRevealRight: false };
-    canRevealLeftAtStart = edgeState.canRevealLeft;
-    canRevealRightAtStart = edgeState.canRevealRight;
-  }
-
-  function handlePointerUp(event: TouchEvent) {
-    if (!$settings.mobile) return;
-    if ($settings.continuousScroll) return; // Continuous mode handles its own touch
-    if ($cropperStore?.open) return; // Don't process swipes when Anki modal is open
-
-    // If fingers remain, this was a multi-touch gesture - mark it and wait
-    if (event.touches.length !== 0) {
-      lastMultiTouchTime = Date.now();
-      return;
-    }
-
-    // Ignore swipes within 200ms of a multi-touch gesture (pinch-zoom)
-    if (Date.now() - lastMultiTouchTime < 200) return;
-
-    const { clientX, clientY } = event.changedTouches[0];
-
-    const distanceX = clientX - startX;
-    const distanceY = clientY - startY;
-
-    // Vertical threshold scales with viewport for consistent feel across devices
-    const verticalThreshold = Math.min(200, window.innerHeight * 0.3);
-    const isSwipe = Math.abs(distanceY) < verticalThreshold;
-
-    const touchDuration = Date.now() - touchStart?.getTime();
-
-    if (isSwipe && touchDuration < 500) {
-      const swipeThreshold = ($settings.swipeThreshold / 100) * window.innerWidth;
-
-      // Only flip if the user was already at the relevant pan edge when the
-      // gesture began. Otherwise the gesture is an intra-page pan and we
-      // leave page navigation alone (issue #186).
-      if (distanceX > swipeThreshold && !canRevealLeftAtStart) {
-        left(event, true);
-      } else if (distanceX < -swipeThreshold && !canRevealRightAtStart) {
-        right(event, true);
-      }
-    }
-  }
-
-  function onDoubleTap(event: MouseEvent) {
-    // Double-tap on a text box is the AnkiConnect capture gesture.
-    if (gestureTargetRole(event.target) === 'textbox') return;
-    $pagedZoom?.doubleTap(event.clientX, event.clientY);
-  }
-
-  // Wheel handler wrapper.
-  // We only intercept wheel events that originate inside our reader content
-  // (the paged viewport marked with data-mokuro-reader). Anything else —
-  // settings drawer, popovers, dialogs, and extension overlays like Migaku
-  // and Yomitan popups (which inject into <body>, often inside shadow DOM) —
-  // is left alone so the browser's default scroll handling can apply.
-  function handleWheelEvent(e: WheelEvent) {
-    // In continuous scroll mode, let the scroll readers handle wheel events
-    if ($settings.continuousScroll) return;
-
-    const target = e.target as HTMLElement;
-    if (!target.closest('[data-mokuro-reader]')) return;
-
-    $pagedZoom?.handleWheel(e);
-  }
-
   onMount(() => {
     // Set the timeout duration from settings
     activityTracker.setTimeoutDuration($settings.inactivityTimeoutMinutes);
@@ -553,17 +426,11 @@
     // Prevent scrollbars from appearing when in reader mode
     document.documentElement.style.overflow = 'hidden';
 
-    // Add wheel listener with capture to intercept ctrl+wheel before browser handles it
-    // passive: false is required to allow preventDefault()
-    window.addEventListener('wheel', handleWheelEvent, { capture: true, passive: false });
-
     return () => {
       // Stop activity tracker when component unmounts
       activityTracker.stop();
       // Restore overflow when leaving reader
       document.documentElement.style.overflow = '';
-      // Remove wheel listener
-      window.removeEventListener('wheel', handleWheelEvent, { capture: true });
     };
   });
 
@@ -1258,8 +1125,6 @@
     // The paged viewport re-applies its base on resize internally.
   }}
   onkeydown={handleShortcuts}
-  ontouchstart={handleTouchStart}
-  ontouchend={handlePointerUp}
   onscroll={() => {
     // Detect and fix scroll position drift caused by scrolling in overlays
     // (e.g., settings menu) that affects the underlying document
@@ -1380,6 +1245,8 @@
         contentSize={pagedContentSize}
         pageKey={page}
         rtl={volumeSettings.rightToLeft ?? true}
+        onPageFlip={(side) => (side === 'left' ? left(null, true) : right(null, true))}
+        onOverlayToggle={() => (overlaysVisible = !overlaysVisible)}
       >
         <button
           aria-label="Previous page (left edge)"
@@ -1407,15 +1274,7 @@
           onmousedown={mouseDown}
           onmouseup={right}
         ></button>
-        <div
-          class="grid"
-          style:filter={$imageFilter}
-          ondblclick={onDoubleTap}
-          onpointerdown={handleOverlayPointerDown}
-          onclick={handleOverlayToggle}
-          role="none"
-          id="manga-panel"
-        >
+        <div class="grid" style:filter={$imageFilter} id="manga-panel">
           {#key page}
             <div
               class="col-start-1 row-start-1 flex flex-row"

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -53,7 +53,8 @@
   import { nav, navigateBack } from '$lib/util/hash-router';
   import { onMount, onDestroy, tick } from 'svelte';
   import { activityTracker } from '$lib/util/activity-tracker';
-  import { isWideSpread, shouldShowSinglePage } from '$lib/reader/page-mode-detection';
+  import { shouldShowSinglePage } from '$lib/reader/page-mode-detection';
+  import { calculateForwardTarget, calculateBackwardTarget } from '$lib/reader/page-nav';
   import { ImageCache } from '$lib/reader/image-cache';
   import '$lib/styles/page-transitions.css';
 
@@ -107,103 +108,22 @@
     }
   }
 
-  // Calculate target page when navigating forward.
-  // Uses "half-step" (+1) when the next image is a spread while current view is dual.
-  function calculateForwardTarget(currentPage: number): number {
-    const currentIndex = currentPage - 1;
-
-    if (!pages || currentIndex < 0 || currentIndex >= pages.length) {
-      return currentPage + navAmount;
-    }
-
-    const currentPageData = pages[currentIndex];
-    const nextPageData = pages[currentIndex + 1];
-    const previousPageData = currentIndex > 0 ? pages[currentIndex - 1] : undefined;
-
-    const currentIsSingle = shouldShowSinglePage(
-      $settings.singlePageView,
-      currentPageData,
-      nextPageData,
-      previousPageData,
-      currentIndex === 0,
-      volumeSettings.hasCover
-    );
-
-    if (currentIsSingle) {
-      return currentPage + 1;
-    }
-
-    // Half-step correction for off-alignment spreads:
-    // Current dual view is [N, N+1], next spread is [N+2, N+3].
-    // The further page from current in forward direction is N+3.
-    const forwardLookaheadPage = pages[currentIndex + 3];
-    const lookaheadIsWide =
-      forwardLookaheadPage !== undefined && isWideSpread(forwardLookaheadPage);
-
-    if (currentPageData && nextPageData && !isWideSpread(currentPageData) && lookaheadIsWide) {
-      return currentPage + 1;
-    }
-
-    return currentPage + 2;
-  }
-
-  // Calculate target page when navigating backward, accounting for single-page exceptions
-  function calculateBackwardTarget(currentPage: number): number {
-    if (currentPage <= 1) return 0;
-
-    const currentIndex = currentPage - 1;
-    const currentPageData = pages?.[currentIndex];
-    const currentNextPageData = pages?.[currentIndex + 1];
-    const currentPreviousPageData = currentIndex > 0 ? pages?.[currentIndex - 1] : undefined;
-
-    const currentShouldBeSingle = shouldShowSinglePage(
-      $settings.singlePageView,
-      currentPageData,
-      currentNextPageData,
-      currentPreviousPageData,
-      currentIndex === 0,
-      volumeSettings.hasCover
-    );
-
-    // Mirror of forward half-step fix:
-    // when moving backward from a dual view, inspect the further page in the
-    // previous spread chunk (currentPage - 2). If that page is wide, half-step.
-    if (!currentShouldBeSingle) {
-      const previousSpreadFurtherPage = pages?.[currentIndex - 2];
-      if (previousSpreadFurtherPage && isWideSpread(previousSpreadFurtherPage)) {
-        return currentPage - 1;
-      }
-    }
-
-    const targetIndex = currentPage - 2;
-    if (targetIndex < 0) {
-      return currentPage - 1;
-    }
-
-    const targetPage = pages?.[targetIndex];
-    const targetNextPage = pages?.[targetIndex + 1];
-    const targetPreviousPage = targetIndex > 0 ? pages?.[targetIndex - 1] : undefined;
-
-    const targetShouldBeSingle = shouldShowSinglePage(
-      $settings.singlePageView,
-      targetPage,
-      targetNextPage,
-      targetPreviousPage,
-      targetIndex === 0,
-      volumeSettings.hasCover
-    );
-
-    return targetShouldBeSingle ? currentPage - 1 : currentPage - 2;
+  // Spread-alignment target math lives in $lib/reader/page-nav (pure, tested).
+  function pageNavContext() {
+    return {
+      pages,
+      mode: $settings.singlePageView,
+      hasCover: volumeSettings.hasCover ?? false,
+      fallbackStep: navAmount
+    };
   }
 
   function navigateForward(ingoreTimeOut?: boolean): void {
-    const targetPage = calculateForwardTarget(page);
-    changePage(targetPage, ingoreTimeOut);
+    changePage(calculateForwardTarget(page, pageNavContext()), ingoreTimeOut);
   }
 
   function navigateBackward(ingoreTimeOut?: boolean): void {
-    const targetPage = calculateBackwardTarget(page);
-    changePage(targetPage, ingoreTimeOut);
+    changePage(calculateBackwardTarget(page, pageNavContext()), ingoreTimeOut);
   }
 
   function changePage(newPage: number, ingoreTimeOut = false) {

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -6,6 +6,7 @@
   import PagedViewport from './PagedViewport.svelte';
   import { pagedZoom } from '$lib/reader/paged-zoom';
   import { setInstantAnimations } from '$lib/reader/animator';
+  import { gestureTargetRole, keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
   import { toggleFullScreen } from '$lib/util/fullscreen';
   import {
     effectiveVolumeSettings,
@@ -88,7 +89,7 @@
     pointerDownY = e.clientY;
 
     const target = e.target as HTMLElement;
-    if (target.closest('.textBox')) {
+    if (gestureTargetRole(target) === 'textbox') {
       textBoxWasActive = true;
     }
   }
@@ -97,7 +98,7 @@
     const target = e.target as HTMLElement;
 
     // Clicking on a text box — don't toggle
-    if (target.closest('.textBox')) return;
+    if (gestureTargetRole(target) === 'textbox') return;
 
     // Ignore drags/pans — only toggle on stationary clicks
     const dx = e.clientX - pointerDownX;
@@ -308,16 +309,8 @@
   }
 
   function handleShortcuts(event: KeyboardEvent & { currentTarget: EventTarget & Window }) {
-    // Ignore shortcuts when user is in a text input, editable field, text box, or UI overlay
-    const target = event.target as HTMLElement;
-    if (
-      target.tagName === 'INPUT' ||
-      target.tagName === 'TEXTAREA' ||
-      target.isContentEditable ||
-      target.closest('#settings') || // Settings drawer
-      target.closest('[data-popover]') || // Page number popover and other popovers
-      target.closest('.textBox') // OCR text boxes (even when not editable)
-    ) {
+    // Ignore shortcuts when the user is typing or inside reader UI overlays
+    if (keyboardShouldIgnore(event.target)) {
       return;
     }
 
@@ -525,8 +518,8 @@
   }
 
   function onDoubleTap(event: MouseEvent) {
-    // Double-clicking a word to select it shouldn't zoom.
-    if ((event.target as HTMLElement).closest('.textBox')) return;
+    // Double-tap on a text box is the AnkiConnect capture gesture.
+    if (gestureTargetRole(event.target) === 'textbox') return;
     $pagedZoom?.doubleTap(event.clientX, event.clientY);
   }
 

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -21,7 +21,7 @@
     type ContinuousZoomMode,
     type ScheduleSettingKey
   } from '$lib/settings';
-  import { clamp, debounce, fireExstaticEvent, resetScrollPosition } from '$lib/util';
+  import { clamp, fireExstaticEvent, resetScrollPosition } from '$lib/util';
   import { Input, Popover, Range, Spinner } from 'flowbite-svelte';
   import MangaPage from './MangaPage.svelte';
   import TextBoxContextMenu from './TextBoxContextMenu.svelte';
@@ -51,7 +51,7 @@
   import VerticalScrollReader from './VerticalScrollReader.svelte';
   import HorizontalScrollReader from './HorizontalScrollReader.svelte';
   import { nav, navigateBack } from '$lib/util/hash-router';
-  import { onMount, onDestroy, tick } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import { activityTracker } from '$lib/util/activity-tracker';
   import { shouldShowSinglePage } from '$lib/reader/page-mode-detection';
   import { calculateForwardTarget, calculateBackwardTarget } from '$lib/reader/page-nav';

--- a/src/lib/components/Reader/VerticalScrollReader.svelte
+++ b/src/lib/components/Reader/VerticalScrollReader.svelte
@@ -11,6 +11,7 @@
   import { applyVerticalZoomLayout } from '$lib/reader/zoom-layout';
   import { closestPageToCenter } from '$lib/reader/page-detection';
   import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
+  import { gestureTargetRole, keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
   import { onMount, onDestroy, tick } from 'svelte';
 
   interface Props {
@@ -268,14 +269,7 @@
   }
 
   function handleKeydown(e: KeyboardEvent) {
-    const target = e.target as HTMLElement;
-    if (
-      target.tagName === 'INPUT' ||
-      target.tagName === 'TEXTAREA' ||
-      target.tagName === 'SELECT' ||
-      target.isContentEditable
-    )
-      return;
+    if (keyboardShouldIgnore(e.target)) return;
     if (!scrollContainer) return;
 
     // In fit-to-screen, pages fit viewport — arrows page.
@@ -380,7 +374,7 @@
   function handlePointerDown(e: PointerEvent) {
     activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
 
-    if ((e.target as HTMLElement).closest('.textBox')) {
+    if (gestureTargetRole(e.target) === 'textbox') {
       textBoxWasActive = true;
       return;
     }
@@ -468,7 +462,7 @@
   const DOUBLE_TAP_DELAY = 300;
 
   function handleClick(e: MouseEvent) {
-    if ((e.target as HTMLElement).closest('.textBox, button, [role="button"], a')) return;
+    if (gestureTargetRole(e.target) !== 'page') return;
     if (wasDrag) return;
 
     // First tap outside after interacting with a text box dismisses it without toggling

--- a/src/lib/components/Reader/VerticalScrollReader.svelte
+++ b/src/lib/components/Reader/VerticalScrollReader.svelte
@@ -12,6 +12,7 @@
   import { closestPageToCenter } from '$lib/reader/page-detection';
   import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
   import { gestureTargetRole, keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
+  import { PointerGestureTracker } from '$lib/reader/input/pointer-tracker';
   import { onMount, onDestroy, tick } from 'svelte';
 
   interface Props {
@@ -338,7 +339,7 @@
       scroller?.stop();
       // A held-button drag would keep writing absolute positions from its
       // pre-zoom baseline, fighting the correction frames.
-      isDragging = false;
+      tracker.cancelGestures();
       zoomController.wheelZoom(e);
       return;
     }
@@ -357,102 +358,63 @@
   }
 
   // ============================================================
-  // Click-drag panning
+  // Click-drag panning — classification lives in PointerGestureTracker
+  // (src/lib/reader/input/pointer-tracker.ts); this config holds only the
+  // scroll surface's policy:
+  //
+  // - capture 'immediate': the whole surface is one big drag target, so
+  //   capture on press (the old behavior) — clicks still fire normally
+  // - a press on a text box never pans, for ANY pointer type: drag there is
+  //   text selection (Yomitan/Migaku scanning)
+  // - pan writes absolute scroll positions from press-time baselines
+  //   (totals), with horizontal gated on actual overflow
+  // - no pinch-survivor pan: an absolute-baseline pan starting mid-settle
+  //   would fight the post-pinch snap animation
   // ============================================================
 
-  let isDragging = false;
-  let wasDrag = false;
   let textBoxWasActive = false;
-  let dragStartX = 0;
-  let dragStartY = 0;
   let dragScrollLeft = 0;
   let dragScrollTop = 0;
-  const DRAG_THRESHOLD = 5;
 
-  let activePointers = new Map<number, { x: number; y: number }>();
-
-  function handlePointerDown(e: PointerEvent) {
-    activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
-
-    if (gestureTargetRole(e.target) === 'textbox') {
-      textBoxWasActive = true;
-      return;
-    }
-
-    if (activePointers.size >= 2) {
-      // Pinch start — also re-baselines when the pointer set changes
-      // (third finger down) so the gesture stays continuous.
-      isDragging = false;
-      wasDrag = true;
-      scroller?.stop();
-      zoomController.pinchStart([...activePointers.values()]);
-      return;
-    }
-
-    if (e.button !== 0) return;
-
-    if (zoomController.isActive) zoomController.finishNow();
-    isDragging = true;
-    wasDrag = false;
-    dragStartX = e.clientX;
-    dragStartY = e.clientY;
-    dragScrollLeft = scrollContainer?.scrollLeft ?? 0;
-    dragScrollTop = scrollContainer?.scrollTop ?? 0;
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-  }
-
-  function handlePointerMove(e: PointerEvent) {
-    if (activePointers.has(e.pointerId)) {
-      activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
-    }
-
-    if (activePointers.size >= 2) {
-      zoomController.pinchMove([...activePointers.values()]);
-      return;
-    }
-
-    if (!isDragging || !scrollContainer) return;
-    const dx = e.clientX - dragStartX;
-    const dy = e.clientY - dragStartY;
-
-    if (!wasDrag && dx * dx + dy * dy > DRAG_THRESHOLD * DRAG_THRESHOLD) {
-      wasDrag = true;
-      window.getSelection()?.removeAllRanges();
-    }
-
-    if (wasDrag) {
-      e.preventDefault();
-      scrollContainer.scrollTop = dragScrollTop - dy;
+  const tracker = new PointerGestureTracker({
+    getElement: () => outerDiv,
+    capturePolicy: 'immediate',
+    suppressPan: (e) => {
+      if (gestureTargetRole(e.target) === 'textbox') {
+        textBoxWasActive = true;
+        return true;
+      }
+      return false;
+    },
+    onPress: () => {
+      if (zoomController.isActive) zoomController.finishNow();
+      dragScrollLeft = scrollContainer?.scrollLeft ?? 0;
+      dragScrollTop = scrollContainer?.scrollTop ?? 0;
+    },
+    onPanMove: (_p, d) => {
+      if (!scrollContainer) return;
+      scrollContainer.scrollTop = dragScrollTop - d.totalDy;
       if (isZoomed || scrollContainer.scrollWidth > scrollContainer.clientWidth + 1) {
-        scrollContainer.scrollLeft = dragScrollLeft - dx;
+        scrollContainer.scrollLeft = dragScrollLeft - d.totalDx;
       }
+    },
+    onPinchStart: (pts) => {
+      scroller?.stop();
+      zoomController.pinchStart(pts);
+    },
+    onPinchMove: (pts) => zoomController.pinchMove(pts),
+    onPinchEnd: () => zoomController.pinchEnd(),
+    isPinchAlive: () => zoomController.isActive,
+    safariGestures: {
+      start: (x, y) => {
+        scroller?.stop();
+        zoomController.gestureStart(x || viewportWidth / 2, y || viewportHeight / 2);
+      },
+      change: (scale, x, y) =>
+        zoomController.gestureChange(scale, x || viewportWidth / 2, y || viewportHeight / 2),
+      end: () => zoomController.gestureEnd()
     }
-  }
-
-  function handlePointerUp(e: PointerEvent) {
-    const hadPointer = activePointers.has(e.pointerId);
-    activePointers.delete(e.pointerId);
-
-    if (hadPointer && activePointers.size >= 1 && zoomController.isActive) {
-      if (activePointers.size >= 2) {
-        // A pinch finger lifted but two remain — re-baseline on the new pair.
-        zoomController.pinchStart([...activePointers.values()]);
-      } else {
-        zoomController.pinchEnd();
-      }
-      return;
-    }
-    if (activePointers.size === 0) zoomController.pinchEnd();
-
-    if (isDragging) {
-      try {
-        (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
-      } catch {
-        /* ignore */
-      }
-    }
-    isDragging = false;
-  }
+  });
 
   // ============================================================
   // Overlay toggle + double-tap zoom
@@ -463,7 +425,7 @@
 
   function handleClick(e: MouseEvent) {
     if (gestureTargetRole(e.target) !== 'page') return;
-    if (wasDrag) return;
+    if (tracker.wasDrag) return;
 
     // First tap outside after interacting with a text box dismisses it without toggling
     if (textBoxWasActive) {
@@ -483,38 +445,6 @@
     setTimeout(() => {
       if (lastTapTime === tapTime) onOverlayToggle?.();
     }, DOUBLE_TAP_DELAY);
-  }
-
-  // ============================================================
-  // Safari desktop trackpad pinch (proprietary gesture events)
-  // ============================================================
-
-  interface WebKitGestureEvent extends Event {
-    scale: number;
-    clientX: number;
-    clientY: number;
-  }
-
-  function handleGestureStart(e: Event) {
-    e.preventDefault();
-    const ge = e as WebKitGestureEvent;
-    scroller?.stop();
-    zoomController.gestureStart(ge.clientX ?? viewportWidth / 2, ge.clientY ?? viewportHeight / 2);
-  }
-
-  function handleGestureChange(e: Event) {
-    e.preventDefault();
-    const ge = e as WebKitGestureEvent;
-    zoomController.gestureChange(
-      ge.scale ?? 1,
-      ge.clientX ?? viewportWidth / 2,
-      ge.clientY ?? viewportHeight / 2
-    );
-  }
-
-  function handleGestureEnd(e: Event) {
-    e.preventDefault();
-    zoomController.gestureEnd();
   }
 
   // ============================================================
@@ -541,9 +471,7 @@
       scroller = new ScrollAnimator(scrollContainer);
     }
     outerDiv?.addEventListener('wheel', handleWheel, { passive: false });
-    outerDiv?.addEventListener('gesturestart', handleGestureStart);
-    outerDiv?.addEventListener('gesturechange', handleGestureChange);
-    outerDiv?.addEventListener('gestureend', handleGestureEnd);
+    tracker.attach();
     requestAnimationFrame(() => {
       const el = pageElements[currentPage - 1];
       if (el) el.scrollIntoView({ behavior: 'instant', block: 'start' });
@@ -554,9 +482,7 @@
     scroller?.destroy();
     zoomController.destroy();
     outerDiv?.removeEventListener('wheel', handleWheel);
-    outerDiv?.removeEventListener('gesturestart', handleGestureStart);
-    outerDiv?.removeEventListener('gesturechange', handleGestureChange);
-    outerDiv?.removeEventListener('gestureend', handleGestureEnd);
+    tracker.detach();
     if (settleTimer) clearTimeout(settleTimer);
   });
 </script>
@@ -568,10 +494,6 @@
   class="fixed inset-0"
   style:background-color="var(--reader-bg)"
   style:touch-action="none"
-  onpointerdown={handlePointerDown}
-  onpointermove={handlePointerMove}
-  onpointerup={handlePointerUp}
-  onpointercancel={handlePointerUp}
   onclick={handleClick}
   role="none"
 >

--- a/src/lib/components/Reader/VerticalScrollReader.svelte
+++ b/src/lib/components/Reader/VerticalScrollReader.svelte
@@ -13,6 +13,7 @@
   import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
   import { gestureTargetRole, keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
   import { PointerGestureTracker } from '$lib/reader/input/pointer-tracker';
+  import { TapDiscriminator } from '$lib/reader/input/tap';
   import { onMount, onDestroy, tick } from 'svelte';
 
   interface Props {
@@ -372,7 +373,6 @@
   //   would fight the post-pinch snap animation
   // ============================================================
 
-  let textBoxWasActive = false;
   let dragScrollLeft = 0;
   let dragScrollTop = 0;
 
@@ -381,7 +381,7 @@
     capturePolicy: 'immediate',
     suppressPan: (e) => {
       if (gestureTargetRole(e.target) === 'textbox') {
-        textBoxWasActive = true;
+        taps.noteTextBoxInteraction();
         return true;
       }
       return false;
@@ -420,31 +420,18 @@
   // Overlay toggle + double-tap zoom
   // ============================================================
 
-  let lastTapTime = 0;
-  const DOUBLE_TAP_DELAY = 300;
+  const taps = new TapDiscriminator({
+    onTap: () => onOverlayToggle?.(),
+    onDoubleTap: (x, y) => {
+      scroller?.stop();
+      zoomController.toggleZoom(x, y);
+    }
+  });
 
   function handleClick(e: MouseEvent) {
     if (gestureTargetRole(e.target) !== 'page') return;
     if (tracker.wasDrag) return;
-
-    // First tap outside after interacting with a text box dismisses it without toggling
-    if (textBoxWasActive) {
-      textBoxWasActive = false;
-      return;
-    }
-
-    const now = Date.now();
-    if (now - lastTapTime < DOUBLE_TAP_DELAY) {
-      lastTapTime = 0;
-      scroller?.stop();
-      zoomController.toggleZoom(e.clientX, e.clientY);
-      return;
-    }
-    lastTapTime = now;
-    const tapTime = now;
-    setTimeout(() => {
-      if (lastTapTime === tapTime) onOverlayToggle?.();
-    }, DOUBLE_TAP_DELAY);
+    taps.tap(e.clientX, e.clientY);
   }
 
   // ============================================================
@@ -483,6 +470,7 @@
     zoomController.destroy();
     outerDiv?.removeEventListener('wheel', handleWheel);
     tracker.detach();
+    taps.cancel();
     if (settleTimer) clearTimeout(settleTimer);
   });
 </script>

--- a/src/lib/components/Reader/VerticalScrollReader.svelte
+++ b/src/lib/components/Reader/VerticalScrollReader.svelte
@@ -14,6 +14,7 @@
   import { gestureTargetRole, keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
   import { PointerGestureTracker } from '$lib/reader/input/pointer-tracker';
   import { TapDiscriminator } from '$lib/reader/input/tap';
+  import type { MotionGate } from '$lib/reader/input/motion-gate';
   import { onMount, onDestroy, tick } from 'svelte';
 
   interface Props {
@@ -143,18 +144,29 @@
   });
 
   /**
-   * Finish an in-flight zoom before a competing scroll intent (keyboard nav,
-   * external page change) so it acts on settled geometry — the 'nav' settle
-   * reason keeps it from reporting progress the navigation supersedes. The
-   * scroller then adopts the corrected position (its state only syncs via
-   * async scroll events; without this the next scrollBy would animate from
-   * a stale position and undo the zoom's final correction).
+   * Interrupt choke points — see MotionGate for the contract. Notable here:
+   * beforeNav resyncs the scroller because its state only updates via async
+   * scroll events; without sync() the next scrollBy would animate from a
+   * stale position and undo the zoom's final correction.
    */
-  function interruptZoomForNav() {
-    if (!zoomController.isActive) return;
-    zoomController.finishNow('nav');
-    scroller?.sync();
-  }
+  const motion: MotionGate = {
+    beforeZoom() {
+      scroller?.stop();
+      tracker.cancelPan();
+    },
+    beforeManualPan() {
+      if (zoomController.isActive) zoomController.finishNow();
+      scroller?.stop();
+    },
+    beforeAnimatedScroll() {
+      if (zoomController.isActive) zoomController.finishNow();
+    },
+    beforeNav() {
+      if (!zoomController.isActive) return;
+      zoomController.finishNow('nav');
+      scroller?.sync();
+    }
+  };
 
   // When the zoom mode (Z key) or a layout-affecting setting changes, reset
   // any user zoom (its measured spacer/transform are stale against the new
@@ -263,7 +275,7 @@
       return;
     }
 
-    interruptZoomForNav();
+    motion.beforeNav?.();
     const el = pageElements[pageIdx];
     if (!el) return;
 
@@ -282,7 +294,7 @@
       case 'ArrowDown':
         e.preventDefault();
         if (shouldPanVertically) {
-          interruptZoomForNav();
+          motion.beforeNav?.();
           scroller?.scrollBy(0, viewportHeight * 0.5);
         } else {
           scrollToPageVertical(detectCurrentPage() + 1);
@@ -291,7 +303,7 @@
       case 'ArrowUp':
         e.preventDefault();
         if (shouldPanVertically) {
-          interruptZoomForNav();
+          motion.beforeNav?.();
           scroller?.scrollBy(0, -viewportHeight * 0.5);
         } else {
           scrollToPageVertical(detectCurrentPage() - 1);
@@ -299,12 +311,12 @@
         break;
       case 'ArrowLeft':
         e.preventDefault();
-        interruptZoomForNav();
+        motion.beforeNav?.();
         scroller?.scrollBy(-viewportWidth * 0.5, 0);
         break;
       case 'ArrowRight':
         e.preventDefault();
-        interruptZoomForNav();
+        motion.beforeNav?.();
         scroller?.scrollBy(viewportWidth * 0.5, 0);
         break;
       case 'PageDown':
@@ -337,10 +349,7 @@
 
     if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {
       e.preventDefault();
-      scroller?.stop();
-      // A held-button drag would keep writing absolute positions from its
-      // pre-zoom baseline, fighting the correction frames.
-      tracker.cancelGestures();
+      motion.beforeZoom();
       zoomController.wheelZoom(e);
       return;
     }
@@ -349,13 +358,13 @@
       // Swap mode: modifier+wheel is the scroll intent. Scroll manually —
       // letting it fall through would trigger browser page zoom instead.
       e.preventDefault();
-      if (zoomController.isActive) zoomController.finishNow();
+      motion.beforeAnimatedScroll();
       scrollContainer.scrollTop += normalizeWheelDelta(e.deltaY, e.deltaMode);
       return;
     }
 
     // Bare wheel scrolls natively; don't let it fight an active zoom.
-    if (zoomController.isActive) zoomController.finishNow();
+    motion.beforeAnimatedScroll();
   }
 
   // ============================================================
@@ -387,7 +396,7 @@
       return false;
     },
     onPress: () => {
-      if (zoomController.isActive) zoomController.finishNow();
+      motion.beforeManualPan();
       dragScrollLeft = scrollContainer?.scrollLeft ?? 0;
       dragScrollTop = scrollContainer?.scrollTop ?? 0;
     },
@@ -399,7 +408,7 @@
       }
     },
     onPinchStart: (pts) => {
-      scroller?.stop();
+      motion.beforeZoom();
       zoomController.pinchStart(pts);
     },
     onPinchMove: (pts) => zoomController.pinchMove(pts),
@@ -407,7 +416,7 @@
     isPinchAlive: () => zoomController.isActive,
     safariGestures: {
       start: (x, y) => {
-        scroller?.stop();
+        motion.beforeZoom();
         zoomController.gestureStart(x || viewportWidth / 2, y || viewportHeight / 2);
       },
       change: (scale, x, y) =>
@@ -423,7 +432,7 @@
   const taps = new TapDiscriminator({
     onTap: () => onOverlayToggle?.(),
     onDoubleTap: (x, y) => {
-      scroller?.stop();
+      motion.beforeZoom();
       zoomController.toggleZoom(x, y);
     }
   });

--- a/src/lib/components/Reader/VerticalScrollReader.svelte
+++ b/src/lib/components/Reader/VerticalScrollReader.svelte
@@ -7,7 +7,7 @@
   import { activityTracker } from '$lib/util/activity-tracker';
   import MangaPage from './MangaPage.svelte';
   import { ScrollAnimator } from '$lib/reader/scroll-animator';
-  import { ContinuousZoomController } from '$lib/reader/zoom-controller';
+  import { ContinuousZoomController, type SettleReason } from '$lib/reader/zoom-controller';
   import { applyVerticalZoomLayout } from '$lib/reader/zoom-layout';
   import { closestPageToCenter } from '$lib/reader/page-detection';
   import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
@@ -81,7 +81,6 @@
   let zoomWrapperEl: HTMLDivElement | undefined = $state();
   let zoomSpacerEl: HTMLDivElement | undefined = $state();
   let isZoomed = $state(false);
-  let suppressSettleReport = false;
 
   /**
    * Widest page's scaled layout width at the current zoom mode — the zoomed
@@ -116,7 +115,7 @@
     );
   }
 
-  function handleZoomSettled(zoom: number) {
+  function handleZoomSettled(zoom: number, reason: SettleReason) {
     if (zoom <= 1 && scrollContainer) {
       // Reset the cross axis only when no scroll range legitimately remains
       // at 1× (zoomOriginal pages wider than the viewport keep theirs).
@@ -124,7 +123,9 @@
         scrollContainer.scrollLeft = 0;
       }
     }
-    if (!suppressSettleReport) reportProgress();
+    // 'nav' settles are superseded by the navigation that caused them, and
+    // 'reset' settles have stale scroll geometry the caller re-anchors next.
+    if (reason === 'gesture' || reason === 'interrupt') reportProgress();
   }
 
   const zoomController = new ContinuousZoomController({
@@ -140,30 +141,16 @@
 
   /**
    * Finish an in-flight zoom before a competing scroll intent (keyboard nav,
-   * external page change) so it acts on settled geometry. The settle report
-   * is suppressed — the navigation is about to change the page anyway —
-   * and the scroller adopts the corrected position (its state only syncs
-   * via async scroll events; without this the next scrollBy would animate
-   * from a stale position and undo the zoom's final correction).
+   * external page change) so it acts on settled geometry — the 'nav' settle
+   * reason keeps it from reporting progress the navigation supersedes. The
+   * scroller then adopts the corrected position (its state only syncs via
+   * async scroll events; without this the next scrollBy would animate from
+   * a stale position and undo the zoom's final correction).
    */
   function interruptZoomForNav() {
     if (!zoomController.isActive) return;
-    suppressSettleReport = true;
-    zoomController.finishNow();
-    suppressSettleReport = false;
+    zoomController.finishNow('nav');
     scroller?.sync();
-  }
-
-  /**
-   * Instant zoom reset with the settle report suppressed: reset() skips the
-   * anchor correction, so the scroll offset is stale zoomed-space garbage —
-   * detection would land pages ahead and corrupt progress before the caller
-   * re-anchors to the page it captured.
-   */
-  function resetZoom() {
-    suppressSettleReport = true;
-    zoomController.reset();
-    suppressSettleReport = false;
   }
 
   // When the zoom mode (Z key) or a layout-affecting setting changes, reset
@@ -178,7 +165,7 @@
     prevLayoutKey = layoutKey;
 
     const pageIdx = lastReportedPage - 1;
-    resetZoom();
+    zoomController.reset();
     tick().then(() => {
       const el = pageElements[pageIdx];
       if (el)
@@ -542,7 +529,7 @@
 
   function handleResize() {
     const pageIdx = lastReportedPage - 1;
-    resetZoom();
+    zoomController.reset();
     viewportWidth = window.innerWidth;
     viewportHeight = window.innerHeight;
     tick().then(() => {

--- a/src/lib/components/Reader/VerticalScrollReader.svelte
+++ b/src/lib/components/Reader/VerticalScrollReader.svelte
@@ -12,7 +12,8 @@
   import { closestPageToCenter } from '$lib/reader/page-detection';
   import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
   import { gestureTargetRole, keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
-  import { PointerGestureTracker } from '$lib/reader/input/pointer-tracker';
+  import { volumeEdgeNav } from '$lib/reader/page-nav';
+  import { PointerGestureTracker, zoomGestureConfig } from '$lib/reader/input/pointer-tracker';
   import { TapDiscriminator } from '$lib/reader/input/tap';
   import type { MotionGate } from '$lib/reader/input/motion-gate';
   import { onMount, onDestroy, tick } from 'svelte';
@@ -181,14 +182,7 @@
 
     const pageIdx = lastReportedPage - 1;
     zoomController.reset();
-    tick().then(() => {
-      const el = pageElements[pageIdx];
-      if (el)
-        el.scrollIntoView({
-          behavior: 'instant',
-          block: pageFitsVertically(pageIdx) ? 'center' : 'start'
-        });
-    });
+    tick().then(() => reanchorToPage(pageIdx));
   });
 
   // ============================================================
@@ -259,21 +253,20 @@
     return el.getBoundingClientRect().height <= viewportHeight * 1.05;
   }
 
+  /** Instant re-anchor after a layout reset (zoom-mode change, resize). */
+  function reanchorToPage(pageIdx: number) {
+    const el = pageElements[pageIdx];
+    if (el)
+      el.scrollIntoView({
+        behavior: 'instant',
+        block: pageFitsVertically(pageIdx) ? 'center' : 'start'
+      });
+  }
+
   function scrollToPageVertical(pageIdx: number) {
     if (!scroller) return;
 
-    // Past the end — mark complete and exit
-    if (pageIdx >= pages.length) {
-      const { charCount } = getCharCount(pages, pages.length);
-      onPageChange(pages.length, charCount, true);
-      onVolumeNav('next');
-      return;
-    }
-    // Before the start — exit
-    if (pageIdx < 0) {
-      onVolumeNav('prev');
-      return;
-    }
+    if (volumeEdgeNav(pageIdx, pages, onPageChange, onVolumeNav)) return;
 
     motion.beforeNav?.();
     const el = pageElements[pageIdx];
@@ -407,22 +400,11 @@
         scrollContainer.scrollLeft = dragScrollLeft - d.totalDx;
       }
     },
-    onPinchStart: (pts) => {
-      motion.beforeZoom();
-      zoomController.pinchStart(pts);
-    },
-    onPinchMove: (pts) => zoomController.pinchMove(pts),
-    onPinchEnd: () => zoomController.pinchEnd(),
-    isPinchAlive: () => zoomController.isActive,
-    safariGestures: {
-      start: (x, y) => {
-        motion.beforeZoom();
-        zoomController.gestureStart(x || viewportWidth / 2, y || viewportHeight / 2);
-      },
-      change: (scale, x, y) =>
-        zoomController.gestureChange(scale, x || viewportWidth / 2, y || viewportHeight / 2),
-      end: () => zoomController.gestureEnd()
-    }
+    ...zoomGestureConfig({
+      beforeZoom: () => motion.beforeZoom(),
+      controller: zoomController,
+      getViewport: () => ({ width: viewportWidth, height: viewportHeight })
+    })
   });
 
   // ============================================================
@@ -452,14 +434,7 @@
     zoomController.reset();
     viewportWidth = window.innerWidth;
     viewportHeight = window.innerHeight;
-    tick().then(() => {
-      const el = pageElements[pageIdx];
-      if (el)
-        el.scrollIntoView({
-          behavior: 'instant',
-          block: pageFitsVertically(pageIdx) ? 'center' : 'start'
-        });
-    });
+    tick().then(() => reanchorToPage(pageIdx));
   }
 
   onMount(() => {
@@ -546,13 +521,3 @@
     </div>
   </div>
 </div>
-
-<style>
-  .scrollbar-hide {
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-  }
-  .scrollbar-hide::-webkit-scrollbar {
-    display: none;
-  }
-</style>

--- a/src/lib/reader/index.ts
+++ b/src/lib/reader/index.ts
@@ -1,5 +1,0 @@
-// TODO: Make reader navigation less awful
-
-// This file will be used for reader-related functionality
-// It now supports tracking the last time read progress was updated via the lastProgressUpdate property in VolumeData
-// This will be used for sorting and cross-device progress syncing in the future

--- a/src/lib/reader/input/gesture-target.test.ts
+++ b/src/lib/reader/input/gesture-target.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { gestureTargetRole, keyboardShouldIgnore } from './gesture-target';
+
+function el(html: string): HTMLElement {
+  const host = document.createElement('div');
+  host.innerHTML = html;
+  document.body.appendChild(host);
+  return host.querySelector('[data-probe]') as HTMLElement;
+}
+
+describe('gestureTargetRole', () => {
+  it('classifies text boxes — including descendants (extension-injected spans)', () => {
+    expect(gestureTargetRole(el('<div class="textBox" data-probe></div>'))).toBe('textbox');
+    expect(
+      gestureTargetRole(el('<div class="textBox"><p><span data-probe>言葉</span></p></div>'))
+    ).toBe('textbox');
+  });
+
+  it('classifies interactive chrome', () => {
+    expect(gestureTargetRole(el('<button data-probe></button>'))).toBe('interactive');
+    expect(gestureTargetRole(el('<div role="button" data-probe></div>'))).toBe('interactive');
+    expect(gestureTargetRole(el('<a href="#" data-probe>x</a>'))).toBe('interactive');
+    expect(gestureTargetRole(el('<button><svg data-probe></svg></button>'))).toBe('interactive');
+  });
+
+  it('textbox wins over interactive when nested (Anki controls inside a box)', () => {
+    expect(gestureTargetRole(el('<div class="textBox"><button data-probe></button></div>'))).toBe(
+      'textbox'
+    );
+  });
+
+  it('defaults to page', () => {
+    expect(gestureTargetRole(el('<div data-probe></div>'))).toBe('page');
+    expect(gestureTargetRole(null)).toBe('page');
+    expect(gestureTargetRole(document)).toBe('page'); // non-Element targets
+  });
+});
+
+describe('keyboardShouldIgnore', () => {
+  it('ignores form fields and editable content', () => {
+    expect(keyboardShouldIgnore(el('<input data-probe />'))).toBe(true);
+    expect(keyboardShouldIgnore(el('<textarea data-probe></textarea>'))).toBe(true);
+    expect(keyboardShouldIgnore(el('<select data-probe></select>'))).toBe(true);
+    const ce = el('<div contenteditable="true" data-probe></div>');
+    Object.defineProperty(ce, 'isContentEditable', { value: true });
+    expect(keyboardShouldIgnore(ce)).toBe(true);
+  });
+
+  it('ignores text boxes and UI overlays', () => {
+    expect(keyboardShouldIgnore(el('<div class="textBox"><span data-probe>x</span></div>'))).toBe(
+      true
+    );
+    expect(keyboardShouldIgnore(el('<div id="settings"><div data-probe></div></div>'))).toBe(true);
+    expect(keyboardShouldIgnore(el('<div data-popover><div data-probe></div></div>'))).toBe(true);
+  });
+
+  it('allows the page itself', () => {
+    expect(keyboardShouldIgnore(el('<div data-probe></div>'))).toBe(false);
+    expect(keyboardShouldIgnore(null)).toBe(false);
+  });
+});

--- a/src/lib/reader/input/gesture-target.ts
+++ b/src/lib/reader/input/gesture-target.ts
@@ -1,0 +1,56 @@
+/**
+ * Gesture target classification — THE statement of the reader's
+ * element-routing contracts. Every input handler classifies its event target
+ * through here instead of scattering `closest('.textBox')` calls.
+ *
+ * # The contracts
+ *
+ * **`.textBox` (role 'textbox') is an input-routing protocol, not styling.**
+ * OCR text boxes own their gestures: double-tap is the AnkiConnect
+ * card-capture gesture (TextBoxes.svelte's own dblclick handler — which also
+ * stopPropagation()s as defense in depth), mouse/pen drags are text
+ * selection (Yomitan/Migaku scanning), and the custom context menu lives
+ * there. Reader surfaces must never start a pan from a mouse/pen press on a
+ * text box, never treat clicks on one as overlay toggles, and never zoom on
+ * its double-taps. Single-finger TOUCH is the exception: touch has no
+ * drag-selection gesture, so touch pans across text boxes (as the old
+ * panzoom touch path always did).
+ *
+ * **'interactive'** is reader chrome (buttons, links): taps belong to the
+ * control, not to overlay toggling or zoom.
+ *
+ * **'page'** is everything else — pannable, zoomable, tappable surface.
+ *
+ * The classification walks ancestors (`closest`), so extension-injected
+ * wrappers inside a text box (Yomitan spans, Migaku rubies) classify as the
+ * text box they live in.
+ */
+
+export type GestureTargetRole = 'textbox' | 'interactive' | 'page';
+
+export function gestureTargetRole(target: EventTarget | null): GestureTargetRole {
+  if (!(target instanceof Element)) return 'page';
+  // textbox wins over interactive: controls inside a box belong to the box's
+  // domain (Anki capture UI), not to reader chrome.
+  if (target.closest('.textBox')) return 'textbox';
+  if (target.closest('button, [role="button"], a')) return 'interactive';
+  return 'page';
+}
+
+/**
+ * Whether a keyboard event's target means reader shortcuts must not fire —
+ * the union of the guards that previously drifted apart between Reader.svelte
+ * (.textBox / #settings / [data-popover] / inputs) and the scroll readers
+ * (INPUT / TEXTAREA / SELECT / contentEditable only).
+ */
+export function keyboardShouldIgnore(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (target instanceof HTMLElement && target.isContentEditable) return true;
+  return !!(
+    target.closest('.textBox') ||
+    target.closest('#settings') ||
+    target.closest('[data-popover]')
+  );
+}

--- a/src/lib/reader/input/motion-gate.ts
+++ b/src/lib/reader/input/motion-gate.ts
@@ -1,0 +1,55 @@
+/**
+ * Motion interrupt contract — THE statement of what must stop before new
+ * motion starts.
+ *
+ * Each reading surface has several motion owners that can animate the view
+ * concurrently: a zoom controller (pinch/wheel/double-tap animations), a
+ * scroll or pan animator, and the user's own drag. Letting two of them run
+ * at once is how the worst input bugs happened — a zoom's per-frame
+ * corrections stomping a pan, a drag writing absolute positions from a
+ * pre-zoom baseline, a scroll animator gliding from a stale position after
+ * a zoom correction.
+ *
+ * Instead of every input handler remembering which owners to stop (the old
+ * scattered ritual: `if (controller.isActive) controller.finishNow();
+ * camera.stopPan(); scroller?.stop(); scroller?.sync(); ...` in a dozen
+ * variations), each surface builds ONE MotionGate and every handler opens
+ * with the call matching its intent. A new input handler that forgets the
+ * gate is a review smell; a handler that calls the wrong intent is at
+ * least explicit about what it expects to interrupt.
+ *
+ * The gate interrupts COMPETING owners only — the input's own machinery
+ * (the zoom controller for a zoom gesture, the tracker for a pointer pan)
+ * manages its own state and must not be reset by the gate.
+ */
+export interface MotionGate {
+  /**
+   * A zoom gesture is starting (pinch, wheel zoom, double-tap, Safari
+   * trackpad). Stop scroll/pan animations AND any held drag — its absolute
+   * baselines would fight the zoom's correction frames. (Held drags are
+   * cancelled via PointerGestureTracker.cancelPan, which is pinch-safe.)
+   */
+  beforeZoom(): void;
+
+  /**
+   * The user grabbed the surface (pan press). Finish any in-flight zoom so
+   * the drag acts on settled geometry, and stop pan/scroll animations so
+   * they don't fight the drag.
+   */
+  beforeManualPan(): void;
+
+  /**
+   * An animated or native scroll is starting (wheel scroll, scroll-image
+   * key). Finish any in-flight zoom; scroll animations are left alone so
+   * successive ticks chain smoothly.
+   */
+  beforeAnimatedScroll(): void;
+
+  /**
+   * A navigation jump is starting (keyboard page nav, external page
+   * change). Finish any in-flight zoom with the 'nav' settle reason (its
+   * progress report would be superseded) and resync the scroll animator to
+   * the corrected position. Surfaces without their own navigation omit it.
+   */
+  beforeNav?(): void;
+}

--- a/src/lib/reader/input/pointer-tracker.test.ts
+++ b/src/lib/reader/input/pointer-tracker.test.ts
@@ -367,3 +367,74 @@ describe('PointerGestureTracker — cancelPan', () => {
     expect(events.onPinchMove).toHaveBeenCalledTimes(1);
   });
 });
+
+const cancelWin = (p: Parameters<typeof pe>[1]) => window.dispatchEvent(pe('pointercancel', p));
+
+describe('PointerGestureTracker — adversarial review fixes', () => {
+  it('sets wasPinch BEFORE the upgrade onPanEnd fires (no swipe at pinch start)', () => {
+    let wasPinchAtPanEnd: boolean | null = null;
+    const world = makeWorld({
+      onPanEnd: vi.fn(() => {
+        wasPinchAtPanEnd = world.tracker.wasPinch;
+      })
+    });
+    const { element } = world;
+    // fast swipe-shaped touch pan...
+    down(element, { x: 300, y: 100, ptype: 'touch' });
+    move(element, { x: 140, y: 100, ptype: 'touch' });
+    // ...then a second finger lands: pan upgrades to pinch
+    down(element, { id: 2, x: 400, y: 200, ptype: 'touch' });
+    expect(wasPinchAtPanEnd).toBe(true);
+  });
+
+  it('marks cancelled pans in the summary, using the last-known pan position', () => {
+    const { element, events } = makeWorld();
+    down(element, { x: 300, y: 100, ptype: 'touch' });
+    move(element, { x: 150, y: 100, ptype: 'touch' });
+    cancelWin({ x: 0, y: 0, ptype: 'touch' }); // browsers may report 0,0 on cancel
+    expect(events.onPanEnd).toHaveBeenCalledTimes(1);
+    const [summary] = events.onPanEnd.mock.calls[0];
+    expect(summary.cancelled).toBe(true);
+    expect(summary.endX).toBe(150); // last move, not the cancel's bogus coords
+  });
+
+  it('a normal release reports cancelled: false', () => {
+    const { element, events } = makeWorld();
+    down(element, { x: 100, y: 100 });
+    move(element, { x: 150, y: 100 });
+    upWin({ x: 150, y: 100 });
+    expect(events.onPanEnd.mock.calls[0][0].cancelled).toBe(false);
+  });
+
+  it('evaluates suppressPan for non-primary buttons (right-click arms textbox dismissal)', () => {
+    const suppressPan = vi.fn(() => true);
+    const { element } = makeWorld({ suppressPan });
+    down(element, { x: 100, y: 100, button: 2 });
+    expect(suppressPan).toHaveBeenCalledTimes(1);
+    upWin({ x: 100, y: 100, button: 2 });
+  });
+
+  it('does not hand the pinch-survivor pan to a suppressed pointer', () => {
+    const { element, events } = makeWorld({
+      suppressPan: (e) => (e as any).clientX === 999, // pointer at x=999 is on a "textbox"
+      pinchSurvivorPans: true
+    });
+    down(element, { x: 999, y: 100 }); // suppressed (selection drag)
+    down(element, { id: 2, x: 300, y: 100 }); // pinch
+    upWin({ id: 2, x: 300, y: 100 }); // survivor = suppressed pointer
+    move(element, { x: 950, y: 100 });
+    move(element, { x: 900, y: 100 });
+    expect(events.onPanStart).not.toHaveBeenCalled();
+    upWin({ x: 900, y: 100 });
+  });
+
+  it('a suppressed press that moves past the threshold still counts as a drag (click suppression)', () => {
+    const { tracker, element } = makeWorld({ suppressPan: () => true });
+    down(element, { x: 100, y: 100 });
+    move(element, { x: 160, y: 100 }); // selection drag, not a pan
+    expect(tracker.isPanning).toBe(false);
+    expect(tracker.wasDrag).toBe(true); // but the ensuing click must not count as a tap
+    upWin({ x: 160, y: 100 });
+    expect(tracker.wasDrag).toBe(true);
+  });
+});

--- a/src/lib/reader/input/pointer-tracker.test.ts
+++ b/src/lib/reader/input/pointer-tracker.test.ts
@@ -40,7 +40,6 @@ function makeWorld(config?: Partial<PointerTrackerConfig>) {
 
   const calls: string[] = [];
   const events: any = {
-    onPanStart: vi.fn(() => calls.push('panStart')),
     onPanMove: vi.fn(() => calls.push('panMove')),
     onPanEnd: vi.fn(() => calls.push('panEnd')),
     onPinchStart: vi.fn(() => calls.push('pinchStart')),
@@ -70,7 +69,6 @@ describe('PointerGestureTracker — pan lifecycle', () => {
     expect(events.onPanMove).not.toHaveBeenCalled();
 
     move(element, { x: 110, y: 100 });
-    expect(events.onPanStart).toHaveBeenCalledTimes(1);
     expect(events.onPanMove).toHaveBeenCalledTimes(1);
     const [, deltas] = events.onPanMove.mock.calls[0];
     expect(deltas.dx).toBe(10);
@@ -129,7 +127,7 @@ describe('PointerGestureTracker — pan lifecycle', () => {
     });
     down(element, { x: 100, y: 100 });
     move(element, { x: 200, y: 100 });
-    expect(events.onPanStart).not.toHaveBeenCalled();
+    expect(events.onPanMove).not.toHaveBeenCalled();
     expect(tracker.pointerCount).toBe(1);
 
     down(element, { id: 2, x: 300, y: 100 });
@@ -140,7 +138,7 @@ describe('PointerGestureTracker — pan lifecycle', () => {
     const { tracker, element, events } = makeWorld();
     down(element, { x: 100, y: 100, button: 2 });
     move(element, { x: 200, y: 100, button: 2 });
-    expect(events.onPanStart).not.toHaveBeenCalled();
+    expect(events.onPanMove).not.toHaveBeenCalled();
     expect(tracker.pointerCount).toBe(1);
     upWin({ x: 200, y: 100, button: 2 });
     expect(tracker.pointerCount).toBe(0);
@@ -217,7 +215,7 @@ describe('PointerGestureTracker — pinch lifecycle', () => {
     // the survivor pans from its current position
     move(element, { x: 100, y: 100 });
     move(element, { x: 130, y: 100 });
-    expect(events.onPanStart).toHaveBeenCalledTimes(1);
+    expect(events.onPanMove).toHaveBeenCalled();
   });
 
   it('ignores the pinch survivor when pinchSurvivorPans is off (default)', () => {
@@ -231,7 +229,7 @@ describe('PointerGestureTracker — pinch lifecycle', () => {
     // require a fresh press after a pinch.
     move(element, { id: 2, x: 330, y: 100 });
     move(element, { id: 2, x: 360, y: 100 });
-    expect(events.onPanStart).not.toHaveBeenCalled();
+    expect(events.onPanMove).not.toHaveBeenCalled();
     expect(events.onPanMove).not.toHaveBeenCalled();
 
     upWin({ id: 2, x: 360, y: 100 });
@@ -349,7 +347,7 @@ describe('PointerGestureTracker — cancelPan', () => {
 
     tracker.cancelPan();
     move(element, { x: 200, y: 100 });
-    expect(events.onPanStart).not.toHaveBeenCalled();
+    expect(events.onPanMove).not.toHaveBeenCalled();
     expect(events.onPanEnd).not.toHaveBeenCalled();
   });
 
@@ -424,7 +422,7 @@ describe('PointerGestureTracker — adversarial review fixes', () => {
     upWin({ id: 2, x: 300, y: 100 }); // survivor = suppressed pointer
     move(element, { x: 950, y: 100 });
     move(element, { x: 900, y: 100 });
-    expect(events.onPanStart).not.toHaveBeenCalled();
+    expect(events.onPanMove).not.toHaveBeenCalled();
     upWin({ x: 900, y: 100 });
   });
 

--- a/src/lib/reader/input/pointer-tracker.test.ts
+++ b/src/lib/reader/input/pointer-tracker.test.ts
@@ -1,0 +1,324 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PointerGestureTracker, type PointerTrackerConfig } from './pointer-tracker';
+
+let clock = 0;
+
+beforeEach(() => {
+  clock = 1000;
+  vi.spyOn(performance, 'now').mockImplementation(() => clock);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Build a pointer-event-shaped Event (jsdom has no PointerEvent ctor). */
+function pe(
+  type: string,
+  props: { id?: number; x?: number; y?: number; ptype?: string; button?: number; target?: Element }
+): Event {
+  const e = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperties(e, {
+    pointerId: { value: props.id ?? 1 },
+    clientX: { value: props.x ?? 0 },
+    clientY: { value: props.y ?? 0 },
+    pointerType: { value: props.ptype ?? 'mouse' },
+    button: { value: props.button ?? 0 },
+    ...(props.target ? { target: { value: props.target } } : {})
+  });
+  return e;
+}
+
+function makeWorld(config?: Partial<PointerTrackerConfig>) {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const capture = vi.fn();
+  const release = vi.fn();
+  (element as any).setPointerCapture = capture;
+  (element as any).releasePointerCapture = release;
+
+  const calls: string[] = [];
+  const events: any = {
+    onPanStart: vi.fn(() => calls.push('panStart')),
+    onPanMove: vi.fn(() => calls.push('panMove')),
+    onPanEnd: vi.fn(() => calls.push('panEnd')),
+    onPinchStart: vi.fn(() => calls.push('pinchStart')),
+    onPinchMove: vi.fn(() => calls.push('pinchMove')),
+    onPinchEnd: vi.fn(() => calls.push('pinchEnd'))
+  };
+
+  const tracker = new PointerGestureTracker({
+    getElement: () => element,
+    capturePolicy: 'deferred',
+    ...events,
+    ...config
+  });
+  tracker.attach();
+  return { tracker, element, capture, release, events, calls };
+}
+
+const down = (el: Element, p: Parameters<typeof pe>[1]) => el.dispatchEvent(pe('pointerdown', p));
+const move = (el: Element, p: Parameters<typeof pe>[1]) => el.dispatchEvent(pe('pointermove', p));
+const upWin = (p: Parameters<typeof pe>[1]) => window.dispatchEvent(pe('pointerup', p));
+
+describe('PointerGestureTracker — pan lifecycle', () => {
+  it('starts a pan only past the drag threshold, with incremental and total deltas', () => {
+    const { element, events } = makeWorld();
+    down(element, { x: 100, y: 100 });
+    move(element, { x: 102, y: 102 }); // below threshold
+    expect(events.onPanMove).not.toHaveBeenCalled();
+
+    move(element, { x: 110, y: 100 });
+    expect(events.onPanStart).toHaveBeenCalledTimes(1);
+    expect(events.onPanMove).toHaveBeenCalledTimes(1);
+    const [, deltas] = events.onPanMove.mock.calls[0];
+    expect(deltas.dx).toBe(10);
+    expect(deltas.totalDx).toBe(10);
+
+    move(element, { x: 115, y: 90 });
+    const [, d2] = events.onPanMove.mock.calls[1];
+    expect(d2.dx).toBe(5);
+    expect(d2.dy).toBe(-10);
+    expect(d2.totalDx).toBe(15);
+    expect(d2.totalDy).toBe(-10);
+  });
+
+  it('ends the pan with a gesture summary (start, end, duration, type)', () => {
+    const { element, events } = makeWorld();
+    down(element, { x: 100, y: 100, ptype: 'touch' });
+    clock += 250;
+    move(element, { x: 200, y: 110, ptype: 'touch' });
+    clock += 100;
+    upWin({ x: 220, y: 112, ptype: 'touch' });
+
+    expect(events.onPanEnd).toHaveBeenCalledTimes(1);
+    const [summary] = events.onPanEnd.mock.calls[0];
+    expect(summary.panned).toBe(true);
+    expect(summary.startX).toBe(100);
+    expect(summary.endX).toBe(220);
+    expect(summary.durationMs).toBe(350);
+    expect(summary.pointerType).toBe('touch');
+  });
+
+  it('reports an unpanned summary for a plain press-release (tap)', () => {
+    const { element, events } = makeWorld();
+    down(element, { x: 100, y: 100 });
+    upWin({ x: 101, y: 101 });
+    const [summary] = events.onPanEnd.mock.calls[0];
+    expect(summary.panned).toBe(false);
+  });
+
+  it('defers capture until the threshold (deferred policy)', () => {
+    const { element, capture } = makeWorld({ capturePolicy: 'deferred' });
+    down(element, { x: 100, y: 100 });
+    expect(capture).not.toHaveBeenCalled(); // gutter buttons / selection safe
+    move(element, { x: 120, y: 100 });
+    expect(capture).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures on pan start immediately under the immediate policy', () => {
+    const { element, capture } = makeWorld({ capturePolicy: 'immediate' });
+    down(element, { x: 100, y: 100 });
+    expect(capture).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppressPan vetoes panning but the pointer still counts (pinch from a text box)', () => {
+    const { tracker, element, events } = makeWorld({
+      suppressPan: () => true
+    });
+    down(element, { x: 100, y: 100 });
+    move(element, { x: 200, y: 100 });
+    expect(events.onPanStart).not.toHaveBeenCalled();
+    expect(tracker.pointerCount).toBe(1);
+
+    down(element, { id: 2, x: 300, y: 100 });
+    expect(events.onPinchStart).toHaveBeenCalledTimes(1); // pinch always allowed
+  });
+
+  it('ignores non-primary buttons for panning but never leaks them', () => {
+    const { tracker, element, events } = makeWorld();
+    down(element, { x: 100, y: 100, button: 2 });
+    move(element, { x: 200, y: 100, button: 2 });
+    expect(events.onPanStart).not.toHaveBeenCalled();
+    expect(tracker.pointerCount).toBe(1);
+    upWin({ x: 200, y: 100, button: 2 });
+    expect(tracker.pointerCount).toBe(0);
+  });
+});
+
+describe('PointerGestureTracker — leak-proof lifecycle (the bug class)', () => {
+  it('cleans the map when an uncaptured release lands outside the element', () => {
+    const { tracker, element } = makeWorld({ suppressPan: () => true });
+    down(element, { x: 100, y: 100 }); // suppressed: no capture ever
+    expect(tracker.pointerCount).toBe(1);
+    // release over an overlay — reaches the window, never the element
+    upWin({ x: 500, y: 500 });
+    expect(tracker.pointerCount).toBe(0);
+
+    // and the next press must NOT be misread as a pinch
+    const { events } = (() => {
+      return { events: undefined as any };
+    })();
+    down(element, { id: 7, x: 100, y: 100 });
+    expect(tracker.pointerCount).toBe(1);
+  });
+
+  it('cleans up on pointercancel', () => {
+    const { tracker, element } = makeWorld();
+    down(element, { x: 100, y: 100 });
+    window.dispatchEvent(pe('pointercancel', { x: 100, y: 100 }));
+    expect(tracker.pointerCount).toBe(0);
+  });
+
+  it('detach removes the window listeners', () => {
+    const { tracker, element } = makeWorld();
+    down(element, { x: 100, y: 100 });
+    tracker.detach();
+    expect(tracker.pointerCount).toBe(0); // detach clears state
+  });
+});
+
+describe('PointerGestureTracker — pinch lifecycle', () => {
+  it('upgrades pan to pinch when a second pointer lands, ending the pan', () => {
+    const { element, events, calls } = makeWorld();
+    down(element, { x: 100, y: 100 });
+    move(element, { x: 130, y: 100 }); // panning
+    down(element, { id: 2, x: 300, y: 100 });
+
+    expect(events.onPinchStart).toHaveBeenCalledTimes(1);
+    expect(calls.indexOf('panEnd')).toBeLessThan(calls.indexOf('pinchStart'));
+    const [points] = events.onPinchStart.mock.calls[0];
+    expect(points).toHaveLength(2);
+  });
+
+  it('re-baselines on pointer-set changes (third finger down, back to two)', () => {
+    const { element, events } = makeWorld();
+    down(element, { x: 100, y: 100 });
+    down(element, { id: 2, x: 300, y: 100 });
+    down(element, { id: 3, x: 200, y: 300 });
+    expect(events.onPinchStart).toHaveBeenCalledTimes(2); // re-baselined on 3rd
+
+    upWin({ id: 3, x: 200, y: 300 });
+    expect(events.onPinchStart).toHaveBeenCalledTimes(3); // re-baselined on the remaining pair
+    expect(events.onPinchEnd).not.toHaveBeenCalled();
+  });
+
+  it('downgrades to a fresh pan with the remaining pointer', () => {
+    const { element, events } = makeWorld({ pinchSurvivorPans: true });
+    down(element, { x: 100, y: 100 });
+    down(element, { id: 2, x: 300, y: 100 });
+    upWin({ id: 2, x: 300, y: 100 });
+
+    expect(events.onPinchEnd).toHaveBeenCalledTimes(1);
+    const [remaining] = events.onPinchEnd.mock.calls[0];
+    expect(remaining?.id).toBe(1);
+
+    // the survivor pans from its current position
+    move(element, { x: 100, y: 100 });
+    move(element, { x: 130, y: 100 });
+    expect(events.onPanStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores the pinch survivor when pinchSurvivorPans is off (default)', () => {
+    const { tracker, element, events } = makeWorld();
+    down(element, { x: 100, y: 100 });
+    down(element, { id: 2, x: 300, y: 100 });
+    upWin({ id: 1, x: 100, y: 100 });
+    expect(events.onPinchEnd).toHaveBeenCalledTimes(1);
+
+    // The survivor moving does NOT start a pan — absolute-baseline surfaces
+    // require a fresh press after a pinch.
+    move(element, { id: 2, x: 330, y: 100 });
+    move(element, { id: 2, x: 360, y: 100 });
+    expect(events.onPanStart).not.toHaveBeenCalled();
+    expect(events.onPanMove).not.toHaveBeenCalled();
+
+    upWin({ id: 2, x: 360, y: 100 });
+    expect(events.onPanEnd).not.toHaveBeenCalled();
+    expect(tracker.pointerCount).toBe(0);
+  });
+
+  it('ends the pinch once, handing off to the survivor, then ends cleanly', () => {
+    const { tracker, element, events } = makeWorld({ pinchSurvivorPans: true });
+    down(element, { x: 100, y: 100 });
+    down(element, { id: 2, x: 300, y: 100 });
+    upWin({ id: 1, x: 100, y: 100 });
+    expect(events.onPinchEnd).toHaveBeenCalledTimes(1);
+    expect(events.onPinchEnd.mock.calls[0][0]?.id).toBe(2); // the survivor
+
+    upWin({ id: 2, x: 300, y: 100 });
+    expect(events.onPinchEnd).toHaveBeenCalledTimes(1); // no double end
+    expect(tracker.pointerCount).toBe(0);
+    const [summary] = events.onPanEnd.mock.calls.at(-1);
+    expect(summary.panned).toBe(false); // survivor never moved past threshold
+  });
+
+  it('resurrects a consumer-lost pinch on the next move (mid-gesture reset)', () => {
+    let alive = true;
+    const { element, events } = makeWorld({ isPinchAlive: () => alive });
+    down(element, { x: 100, y: 100 });
+    down(element, { id: 2, x: 300, y: 100 });
+    expect(events.onPinchStart).toHaveBeenCalledTimes(1);
+
+    alive = false; // a base re-application killed the consumer's pinch
+    move(element, { id: 2, x: 310, y: 100 });
+    expect(events.onPinchStart).toHaveBeenCalledTimes(2); // re-baselined
+    alive = true;
+    move(element, { id: 2, x: 320, y: 100 });
+    expect(events.onPinchStart).toHaveBeenCalledTimes(2); // no spurious restarts
+  });
+
+  it('exposes pinch participation since the last press (swipe suppression)', () => {
+    const { tracker, element } = makeWorld();
+    down(element, { x: 100, y: 100, ptype: 'touch' });
+    down(element, { id: 2, x: 300, y: 100, ptype: 'touch' });
+    upWin({ id: 2, x: 300, y: 100, ptype: 'touch' });
+    upWin({ id: 1, x: 100, y: 100, ptype: 'touch' });
+    expect(tracker.wasPinch).toBe(true);
+
+    down(element, { id: 3, x: 100, y: 100, ptype: 'touch' });
+    expect(tracker.wasPinch).toBe(false); // reset on a fresh single press
+  });
+});
+
+describe('PointerGestureTracker — wasDrag (click suppression)', () => {
+  it('is true after panning or pinching until the next single press', () => {
+    const { tracker, element } = makeWorld();
+    expect(tracker.wasDrag).toBe(false);
+    down(element, { x: 100, y: 100 });
+    move(element, { x: 130, y: 100 });
+    expect(tracker.wasDrag).toBe(true);
+    upWin({ x: 130, y: 100 });
+    expect(tracker.wasDrag).toBe(true); // survives until the next press (click fires after up)
+
+    down(element, { id: 5, x: 100, y: 100 });
+    expect(tracker.wasDrag).toBe(false);
+  });
+});
+
+describe('PointerGestureTracker — onPress and Safari gestures', () => {
+  it('fires onPress for eligible presses only', () => {
+    const onPress = vi.fn();
+    const { element } = makeWorld({ onPress, suppressPan: (e) => (e as any).clientX === 999 });
+    down(element, { x: 100, y: 100 });
+    expect(onPress).toHaveBeenCalledTimes(1);
+    upWin({ x: 100, y: 100 });
+    down(element, { id: 2, x: 999, y: 100 }); // suppressed
+    expect(onPress).toHaveBeenCalledTimes(1);
+    upWin({ id: 2, x: 999, y: 100 });
+    down(element, { id: 3, x: 100, y: 100, button: 2 }); // non-primary
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes Safari gesture events when configured', () => {
+    const safari = { start: vi.fn(), change: vi.fn(), end: vi.fn() };
+    const { element } = makeWorld({ safariGestures: safari });
+    element.dispatchEvent(new Event('gesturestart', { cancelable: true }));
+    element.dispatchEvent(new Event('gesturechange', { cancelable: true }));
+    element.dispatchEvent(new Event('gestureend', { cancelable: true }));
+    expect(safari.start).toHaveBeenCalledTimes(1);
+    expect(safari.change).toHaveBeenCalledTimes(1);
+    expect(safari.end).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/reader/input/pointer-tracker.test.ts
+++ b/src/lib/reader/input/pointer-tracker.test.ts
@@ -322,3 +322,48 @@ describe('PointerGestureTracker — onPress and Safari gestures', () => {
     expect(safari.end).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('PointerGestureTracker — cancelPan', () => {
+  it('ends an engaged pan and ignores further moves, but the release still cleans the map', () => {
+    const { tracker, element, events } = makeWorld();
+    down(element, { x: 100, y: 100 });
+    move(element, { x: 130, y: 100 });
+    expect(tracker.isPanning).toBe(true);
+
+    tracker.cancelPan();
+    expect(tracker.isPanning).toBe(false);
+    expect(events.onPanEnd).toHaveBeenCalledTimes(1);
+    expect(events.onPanEnd.mock.calls[0][0].panned).toBe(true);
+
+    move(element, { x: 200, y: 100 });
+    expect(events.onPanMove).toHaveBeenCalledTimes(1); // only the pre-cancel move
+
+    upWin({ x: 200, y: 100 });
+    expect(tracker.pointerCount).toBe(0);
+    expect(events.onPanEnd).toHaveBeenCalledTimes(1); // no double end
+  });
+
+  it('drops pan candidacy of a pressed-but-unengaged pointer without firing onPanEnd', () => {
+    const { tracker, element, events } = makeWorld();
+    down(element, { x: 100, y: 100 });
+
+    tracker.cancelPan();
+    move(element, { x: 200, y: 100 });
+    expect(events.onPanStart).not.toHaveBeenCalled();
+    expect(events.onPanEnd).not.toHaveBeenCalled();
+  });
+
+  it('is safe to call from onPinchStart — the pinch stays alive', () => {
+    let world: ReturnType<typeof makeWorld>;
+    world = makeWorld({
+      onPinchStart: () => world.tracker.cancelPan()
+    });
+    const { tracker, element, events } = world;
+    down(element, { x: 100, y: 100 });
+    down(element, { id: 2, x: 300, y: 100 });
+    expect(tracker.isPinching).toBe(true);
+
+    move(element, { id: 2, x: 320, y: 100 });
+    expect(events.onPinchMove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/reader/input/pointer-tracker.ts
+++ b/src/lib/reader/input/pointer-tracker.ts
@@ -192,11 +192,15 @@ export class PointerGestureTracker {
     this.attached = false;
   }
 
-  /** Force-end any gesture (e.g. before a programmatic content swap). */
-  cancelGestures(): void {
+  /**
+   * Force-end any pan (engaged or candidate) — e.g. a wheel zoom starting
+   * while a drag is held, whose absolute baselines would fight the zoom's
+   * correction frames. Never touches pinch state, so it is safe to call
+   * from onPinchStart (where the tracker is mid-upgrade).
+   */
+  cancelPan(): void {
     if (this.panEngaged) this.finishPan(this.panLastX, this.panLastY);
     this.resetPan();
-    this.pinching = false;
   }
 
   private onDown = (evt: Event): void => {

--- a/src/lib/reader/input/pointer-tracker.ts
+++ b/src/lib/reader/input/pointer-tracker.ts
@@ -1,0 +1,390 @@
+/**
+ * The reader's ONE pointer state machine — pan/pinch tracking shared by all
+ * three reading surfaces (PagedViewport and both scroll readers), which
+ * previously each carried a divergent ~80-line copy. The copies disagreed in
+ * ways that shipped bugs: two of three leaked pointers whose release never
+ * reached the surface element, and the capture policy was opposite between
+ * surfaces with neither stated.
+ *
+ * Structural guarantees:
+ *
+ * - **Leak-proof:** pointerup/pointercancel listen on the WINDOW, always.
+ *   A pointer that enters the map on pointerdown leaves it on release no
+ *   matter where the release lands (overlays, context menus, outside the
+ *   browser pane via capture). No phantom entries → no misread pinches.
+ * - **Capture policy is named config**, not an accident: 'deferred' waits
+ *   for the drag threshold so taps still deliver native clicks to in-wrapper
+ *   buttons and text-selection presses stay uncaptured; 'immediate' captures
+ *   on pan start.
+ * - **Pinch always wins and never cares about roles**: every pointer joins
+ *   the map (suppressPan only vetoes PAN initiation), two pointers upgrade
+ *   to pinch (ending any pan), pointer-set changes re-baseline, dropping to
+ *   one pointer downgrades to a fresh pan with the survivor.
+ * - **Consumer-lost pinches resurrect**: if ≥2 pointers move while
+ *   `isPinchAlive()` reports false (a mid-gesture reset cleared the zoom
+ *   controller's pinch), onPinchStart re-fires to re-baseline.
+ *
+ * The tracker owns classification and lifecycle only — surfaces keep full
+ * control of actuation through the callbacks (scroll writes, camera moves,
+ * cross-axis gating).
+ */
+
+export interface TrackedPointer {
+  id: number;
+  x: number;
+  y: number;
+  type: string;
+}
+
+export interface PanDeltas {
+  /** Incremental since the previous move (paged camera adjustments). */
+  dx: number;
+  dy: number;
+  /** Total since the pan pointer pressed (scroll readers' absolute drags). */
+  totalDx: number;
+  totalDy: number;
+}
+
+export interface PanSummary {
+  /** Whether the press ever crossed the drag threshold. */
+  panned: boolean;
+  startX: number;
+  startY: number;
+  endX: number;
+  endY: number;
+  durationMs: number;
+  pointerType: string;
+}
+
+export interface PointerTrackerConfig {
+  /** Surface element receiving pointerdown/pointermove. */
+  getElement(): HTMLElement | null | undefined;
+  /** See module doc — 'deferred' until threshold, or 'immediate' on press. */
+  capturePolicy: 'deferred' | 'immediate';
+  /** Movement (px) before a press becomes a pan. */
+  dragThreshold?: number;
+  /**
+   * Veto PAN initiation for this press (e.g. mouse/pen on a text box keeps
+   * drag selection). The pointer still joins the map and can pinch.
+   */
+  suppressPan?(e: PointerEvent): boolean;
+  /** Clear any text selection when a pan engages (all surfaces do). */
+  clearSelectionOnPan?: boolean;
+
+  /**
+   * A pan-eligible press registered (primary button, not suppressed) —
+   * before any threshold. Surfaces interrupt in-flight zoom animations and
+   * capture scroll baselines here.
+   */
+  onPress?(p: TrackedPointer, e: PointerEvent): void;
+  onPanStart?(p: TrackedPointer, e: PointerEvent): void;
+  onPanMove?(p: TrackedPointer, deltas: PanDeltas, e: PointerEvent): void;
+  onPanEnd?(summary: PanSummary): void;
+
+  /** Fires on pinch entry AND on every pointer-set re-baseline. */
+  onPinchStart?(points: TrackedPointer[]): void;
+  onPinchMove?(points: TrackedPointer[]): void;
+  /** Fires when dropping below two pointers; `remaining` survives, if any. */
+  onPinchEnd?(remaining: TrackedPointer | null): void;
+  /** Liveness probe for resurrecting consumer-lost pinches. */
+  isPinchAlive?(): boolean;
+  /**
+   * When a pinch drops to one pointer, the survivor continues as a fresh pan
+   * (the old panzoom pinch→drag handoff — right for incremental-delta
+   * surfaces). Absolute-baseline surfaces leave this off: their baselines
+   * would be stale and the pan would fight the post-pinch settle animation.
+   */
+  pinchSurvivorPans?: boolean;
+
+  /**
+   * Safari desktop trackpad pinch (proprietary gesturestart/change/end —
+   * Safari never synthesizes ctrl+wheel). Wired by the tracker so the
+   * listener trio isn't copied per surface.
+   */
+  safariGestures?: {
+    start(x: number, y: number): void;
+    change(scale: number, x: number, y: number): void;
+    end(): void;
+  };
+}
+
+export class PointerGestureTracker {
+  private config: PointerTrackerConfig;
+  private pointers = new Map<number, TrackedPointer>();
+  private attached = false;
+  private element: HTMLElement | null = null;
+
+  private pinching = false;
+  private pinchSinceLastPress = false;
+
+  private panId: number | null = null;
+  private panEligible = false;
+  private panEngaged = false;
+  private panStartX = 0;
+  private panStartY = 0;
+  private panLastX = 0;
+  private panLastY = 0;
+  private panStartTime = 0;
+  private panType = 'mouse';
+  private captured = false;
+  private dragSinceLastPress = false;
+
+  constructor(config: PointerTrackerConfig) {
+    this.config = config;
+  }
+
+  get pointerCount(): number {
+    return this.pointers.size;
+  }
+
+  get isPanning(): boolean {
+    return this.panEngaged;
+  }
+
+  get isPinching(): boolean {
+    return this.pinching;
+  }
+
+  /** True once this press sequence panned or pinched — suppresses the click. */
+  get wasDrag(): boolean {
+    return this.dragSinceLastPress;
+  }
+
+  /** A pinch happened since the last fresh single press (swipe suppression). */
+  get wasPinch(): boolean {
+    return this.pinchSinceLastPress;
+  }
+
+  attach(): void {
+    if (this.attached) return;
+    const el = this.config.getElement();
+    if (!el) return;
+    this.element = el;
+    el.addEventListener('pointerdown', this.onDown);
+    el.addEventListener('pointermove', this.onMove);
+    if (this.config.safariGestures) {
+      el.addEventListener('gesturestart', this.onGestureStart);
+      el.addEventListener('gesturechange', this.onGestureChange);
+      el.addEventListener('gestureend', this.onGestureEnd);
+    }
+    // Releases land wherever the pointer is — overlays, dialogs, the window
+    // edge. Listening here is what makes leaks structural rather than a
+    // per-surface fix.
+    window.addEventListener('pointerup', this.onUp);
+    window.addEventListener('pointercancel', this.onUp);
+    this.attached = true;
+  }
+
+  detach(): void {
+    if (!this.attached) return;
+    this.element?.removeEventListener('pointerdown', this.onDown);
+    this.element?.removeEventListener('pointermove', this.onMove);
+    if (this.config.safariGestures) {
+      this.element?.removeEventListener('gesturestart', this.onGestureStart);
+      this.element?.removeEventListener('gesturechange', this.onGestureChange);
+      this.element?.removeEventListener('gestureend', this.onGestureEnd);
+    }
+    window.removeEventListener('pointerup', this.onUp);
+    window.removeEventListener('pointercancel', this.onUp);
+    this.pointers.clear();
+    this.resetPan();
+    this.pinching = false;
+    this.attached = false;
+  }
+
+  /** Force-end any gesture (e.g. before a programmatic content swap). */
+  cancelGestures(): void {
+    if (this.panEngaged) this.finishPan(this.panLastX, this.panLastY);
+    this.resetPan();
+    this.pinching = false;
+  }
+
+  private onDown = (evt: Event): void => {
+    const e = evt as PointerEvent;
+    if (this.pointers.size === 0) {
+      this.dragSinceLastPress = false;
+      this.pinchSinceLastPress = false;
+    }
+    this.pointers.set(e.pointerId, {
+      id: e.pointerId,
+      x: e.clientX,
+      y: e.clientY,
+      type: e.pointerType
+    });
+
+    if (this.pointers.size >= 2) {
+      this.beginPinch();
+      return;
+    }
+
+    if (e.button !== 0) return;
+    if (this.config.suppressPan?.(e)) return;
+
+    this.panId = e.pointerId;
+    this.panEligible = true;
+    this.panEngaged = false;
+    this.panStartX = e.clientX;
+    this.panStartY = e.clientY;
+    this.panLastX = e.clientX;
+    this.panLastY = e.clientY;
+    this.panStartTime = performance.now();
+    this.panType = e.pointerType;
+
+    if (this.config.capturePolicy === 'immediate') this.capture(e.pointerId);
+    this.config.onPress?.(this.pointers.get(e.pointerId)!, e);
+  };
+
+  private onMove = (evt: Event): void => {
+    const e = evt as PointerEvent;
+    const tracked = this.pointers.get(e.pointerId);
+    if (!tracked) return;
+    tracked.x = e.clientX;
+    tracked.y = e.clientY;
+
+    if (this.pointers.size >= 2) {
+      // Resurrect a consumer-lost pinch (mid-gesture reset) before moving.
+      if (this.pinching && this.config.isPinchAlive && !this.config.isPinchAlive()) {
+        this.config.onPinchStart?.(this.points());
+      }
+      if (this.pinching) this.config.onPinchMove?.(this.points());
+      return;
+    }
+
+    if (!this.panEligible || this.panId !== e.pointerId) return;
+
+    const dx = e.clientX - this.panLastX;
+    const dy = e.clientY - this.panLastY;
+
+    if (!this.panEngaged) {
+      const fromStart = Math.hypot(e.clientX - this.panStartX, e.clientY - this.panStartY);
+      const threshold = this.config.dragThreshold ?? 5;
+      if (fromStart <= threshold) return;
+      this.panEngaged = true;
+      this.dragSinceLastPress = true;
+      if (this.config.clearSelectionOnPan ?? true) {
+        window.getSelection()?.removeAllRanges();
+      }
+      if (this.config.capturePolicy === 'deferred') this.capture(e.pointerId);
+      this.config.onPanStart?.(tracked, e);
+    }
+
+    this.panLastX = e.clientX;
+    this.panLastY = e.clientY;
+    this.config.onPanMove?.(
+      tracked,
+      {
+        dx,
+        dy,
+        totalDx: e.clientX - this.panStartX,
+        totalDy: e.clientY - this.panStartY
+      },
+      e
+    );
+  };
+
+  private onUp = (evt: Event): void => {
+    const e = evt as PointerEvent;
+    const had = this.pointers.has(e.pointerId);
+    this.pointers.delete(e.pointerId);
+    if (!had) return;
+
+    if (this.pinching) {
+      if (this.pointers.size >= 2) {
+        this.config.onPinchStart?.(this.points()); // re-baseline the new pair
+        return;
+      }
+      this.pinching = false;
+      const remaining = this.points()[0] ?? null;
+      this.config.onPinchEnd?.(remaining);
+      if (remaining && this.config.pinchSurvivorPans) {
+        // The survivor continues as a fresh pan from its current position.
+        this.panId = remaining.id;
+        this.panEligible = true;
+        this.panEngaged = false;
+        this.panStartX = remaining.x;
+        this.panStartY = remaining.y;
+        this.panLastX = remaining.x;
+        this.panLastY = remaining.y;
+        this.panStartTime = performance.now();
+        this.panType = remaining.type;
+      }
+      return;
+    }
+
+    if (this.panId === e.pointerId) {
+      this.finishPan(e.clientX, e.clientY);
+      this.resetPan();
+    }
+  };
+
+  private beginPinch(): void {
+    if (this.panEngaged) this.finishPan(this.panLastX, this.panLastY);
+    this.resetPan();
+    this.pinching = true;
+    this.pinchSinceLastPress = true;
+    this.dragSinceLastPress = true;
+    this.config.onPinchStart?.(this.points());
+  }
+
+  private finishPan(endX: number, endY: number): void {
+    this.releaseCapture();
+    this.config.onPanEnd?.({
+      panned: this.panEngaged,
+      startX: this.panStartX,
+      startY: this.panStartY,
+      endX,
+      endY,
+      durationMs: performance.now() - this.panStartTime,
+      pointerType: this.panType
+    });
+  }
+
+  private resetPan(): void {
+    this.releaseCapture();
+    this.panId = null;
+    this.panEligible = false;
+    this.panEngaged = false;
+  }
+
+  private capture(pointerId: number): void {
+    try {
+      this.element?.setPointerCapture(pointerId);
+      this.captured = true;
+    } catch {
+      /* inactive pointer (synthetic events) — ignore */
+    }
+  }
+
+  private releaseCapture(): void {
+    if (!this.captured) return;
+    this.captured = false;
+    if (this.panId === null) return;
+    try {
+      this.element?.releasePointerCapture(this.panId);
+    } catch {
+      /* already released */
+    }
+  }
+
+  private points(): TrackedPointer[] {
+    return [...this.pointers.values()];
+  }
+
+  // WebKit proprietary gesture events (typed minimally — Safari only).
+  private onGestureStart = (e: Event): void => {
+    e.preventDefault();
+    const ge = e as Event & { clientX?: number; clientY?: number };
+    this.config.safariGestures?.start(ge.clientX ?? 0, ge.clientY ?? 0);
+  };
+
+  private onGestureChange = (e: Event): void => {
+    e.preventDefault();
+    const ge = e as Event & { scale?: number; clientX?: number; clientY?: number };
+    this.config.safariGestures?.change(ge.scale ?? 1, ge.clientX ?? 0, ge.clientY ?? 0);
+  };
+
+  private onGestureEnd = (e: Event): void => {
+    e.preventDefault();
+    this.config.safariGestures?.end();
+  };
+}

--- a/src/lib/reader/input/pointer-tracker.ts
+++ b/src/lib/reader/input/pointer-tracker.ts
@@ -34,6 +34,11 @@ export interface TrackedPointer {
   x: number;
   y: number;
   type: string;
+  /** Position at press — drift detection for suppressed (selection) drags. */
+  pressX: number;
+  pressY: number;
+  /** Pan eligibility evaluated at press (primary button, not suppressed). */
+  canPan: boolean;
 }
 
 export interface PanDeltas {
@@ -48,6 +53,14 @@ export interface PanDeltas {
 export interface PanSummary {
   /** Whether the press ever crossed the drag threshold. */
   panned: boolean;
+  /**
+   * The gesture did not end by the user's release: the OS cancelled the
+   * pointer (pointercancel — system gestures, orientation change, overlays)
+   * or the surface interrupted it (cancelPan). Cancelled summaries must
+   * never classify as swipes; pointercancel coordinates are unreliable, so
+   * endX/endY hold the last-known pan position instead.
+   */
+  cancelled: boolean;
   startX: number;
   startY: number;
   endX: number;
@@ -199,7 +212,7 @@ export class PointerGestureTracker {
    * from onPinchStart (where the tracker is mid-upgrade).
    */
   cancelPan(): void {
-    if (this.panEngaged) this.finishPan(this.panLastX, this.panLastY);
+    if (this.panEngaged) this.finishPan(this.panLastX, this.panLastY, true);
     this.resetPan();
   }
 
@@ -209,11 +222,20 @@ export class PointerGestureTracker {
       this.dragSinceLastPress = false;
       this.pinchSinceLastPress = false;
     }
+    // Eligibility is decided at press time for EVERY pointer — suppressPan
+    // runs even for non-primary buttons and pinch fingers, both because its
+    // side effects matter (a right-click on a text box must still arm the
+    // tap-dismissal) and because the pinch-survivor handoff needs it later.
+    const suppressed = this.config.suppressPan?.(e) ?? false;
+    const canPan = e.button === 0 && !suppressed;
     this.pointers.set(e.pointerId, {
       id: e.pointerId,
       x: e.clientX,
       y: e.clientY,
-      type: e.pointerType
+      type: e.pointerType,
+      pressX: e.clientX,
+      pressY: e.clientY,
+      canPan
     });
 
     if (this.pointers.size >= 2) {
@@ -221,8 +243,7 @@ export class PointerGestureTracker {
       return;
     }
 
-    if (e.button !== 0) return;
-    if (this.config.suppressPan?.(e)) return;
+    if (!canPan) return;
 
     this.panId = e.pointerId;
     this.panEligible = true;
@@ -254,7 +275,16 @@ export class PointerGestureTracker {
       return;
     }
 
-    if (!this.panEligible || this.panId !== e.pointerId) return;
+    if (!this.panEligible || this.panId !== e.pointerId) {
+      // A suppressed press (selection drag, non-primary button) that drifts
+      // past the threshold is still a drag for click purposes — the ensuing
+      // click must not toggle overlays or consume the dismissal swallow.
+      if (!this.dragSinceLastPress && this.pointers.size === 1) {
+        const drift = Math.hypot(e.clientX - tracked.pressX, e.clientY - tracked.pressY);
+        if (drift > (this.config.dragThreshold ?? 5)) this.dragSinceLastPress = true;
+      }
+      return;
+    }
 
     const dx = e.clientX - this.panLastX;
     const dy = e.clientY - this.panLastY;
@@ -300,7 +330,10 @@ export class PointerGestureTracker {
       this.pinching = false;
       const remaining = this.points()[0] ?? null;
       this.config.onPinchEnd?.(remaining);
-      if (remaining && this.config.pinchSurvivorPans) {
+      // Only an eligible pointer may inherit the pan — a suppressed press
+      // (pen on a text box mid-selection) must not start panning because a
+      // stray second finger came and went.
+      if (remaining && remaining.canPan && this.config.pinchSurvivorPans) {
         // The survivor continues as a fresh pan from its current position.
         this.panId = remaining.id;
         this.panEligible = true;
@@ -316,24 +349,32 @@ export class PointerGestureTracker {
     }
 
     if (this.panId === e.pointerId) {
-      this.finishPan(e.clientX, e.clientY);
+      const cancelled = evt.type === 'pointercancel';
+      this.finishPan(
+        cancelled ? this.panLastX : e.clientX,
+        cancelled ? this.panLastY : e.clientY,
+        cancelled
+      );
       this.resetPan();
     }
   };
 
   private beginPinch(): void {
-    if (this.panEngaged) this.finishPan(this.panLastX, this.panLastY);
-    this.resetPan();
+    // Flags first: the upgrade's onPanEnd fires synchronously below, and
+    // consumers read wasPinch there to veto swipe classification.
     this.pinching = true;
     this.pinchSinceLastPress = true;
     this.dragSinceLastPress = true;
+    if (this.panEngaged) this.finishPan(this.panLastX, this.panLastY);
+    this.resetPan();
     this.config.onPinchStart?.(this.points());
   }
 
-  private finishPan(endX: number, endY: number): void {
+  private finishPan(endX: number, endY: number, cancelled = false): void {
     this.releaseCapture();
     this.config.onPanEnd?.({
       panned: this.panEngaged,
+      cancelled,
       startX: this.panStartX,
       startY: this.panStartY,
       endX,

--- a/src/lib/reader/input/pointer-tracker.ts
+++ b/src/lib/reader/input/pointer-tracker.ts
@@ -29,6 +29,9 @@
  * cross-axis gating).
  */
 
+/** Movement (px) before a press becomes a pan. */
+const DRAG_THRESHOLD = 5;
+
 export interface TrackedPointer {
   id: number;
   x: number;
@@ -74,15 +77,11 @@ export interface PointerTrackerConfig {
   getElement(): HTMLElement | null | undefined;
   /** See module doc — 'deferred' until threshold, or 'immediate' on press. */
   capturePolicy: 'deferred' | 'immediate';
-  /** Movement (px) before a press becomes a pan. */
-  dragThreshold?: number;
   /**
    * Veto PAN initiation for this press (e.g. mouse/pen on a text box keeps
    * drag selection). The pointer still joins the map and can pinch.
    */
   suppressPan?(e: PointerEvent): boolean;
-  /** Clear any text selection when a pan engages (all surfaces do). */
-  clearSelectionOnPan?: boolean;
 
   /**
    * A pan-eligible press registered (primary button, not suppressed) —
@@ -90,7 +89,6 @@ export interface PointerTrackerConfig {
    * capture scroll baselines here.
    */
   onPress?(p: TrackedPointer, e: PointerEvent): void;
-  onPanStart?(p: TrackedPointer, e: PointerEvent): void;
   onPanMove?(p: TrackedPointer, deltas: PanDeltas, e: PointerEvent): void;
   onPanEnd?(summary: PanSummary): void;
 
@@ -281,7 +279,7 @@ export class PointerGestureTracker {
       // click must not toggle overlays or consume the dismissal swallow.
       if (!this.dragSinceLastPress && this.pointers.size === 1) {
         const drift = Math.hypot(e.clientX - tracked.pressX, e.clientY - tracked.pressY);
-        if (drift > (this.config.dragThreshold ?? 5)) this.dragSinceLastPress = true;
+        if (drift > DRAG_THRESHOLD) this.dragSinceLastPress = true;
       }
       return;
     }
@@ -291,15 +289,12 @@ export class PointerGestureTracker {
 
     if (!this.panEngaged) {
       const fromStart = Math.hypot(e.clientX - this.panStartX, e.clientY - this.panStartY);
-      const threshold = this.config.dragThreshold ?? 5;
-      if (fromStart <= threshold) return;
+      if (fromStart <= DRAG_THRESHOLD) return;
       this.panEngaged = true;
       this.dragSinceLastPress = true;
-      if (this.config.clearSelectionOnPan ?? true) {
-        window.getSelection()?.removeAllRanges();
-      }
+      // A drag is never also a text selection — clear any partial one.
+      window.getSelection()?.removeAllRanges();
       if (this.config.capturePolicy === 'deferred') this.capture(e.pointerId);
-      this.config.onPanStart?.(tracked, e);
     }
 
     this.panLastX = e.clientX;
@@ -431,5 +426,55 @@ export class PointerGestureTracker {
   private onGestureEnd = (e: Event): void => {
     e.preventDefault();
     this.config.safariGestures?.end();
+  };
+}
+
+/**
+ * The standard wiring from tracker pinches (and Safari trackpad gestures)
+ * into a zoom controller — identical across all three reading surfaces, so
+ * it lives here once. The `x || width/2` fallback recenters gestures whose
+ * coordinates WebKit omitted (reported as 0).
+ */
+export function zoomGestureConfig(deps: {
+  beforeZoom(): void;
+  controller: {
+    readonly isActive: boolean;
+    pinchStart(points: { x: number; y: number }[]): void;
+    pinchMove(points: { x: number; y: number }[]): void;
+    pinchEnd(): void;
+    gestureStart(x: number, y: number): void;
+    gestureChange(scale: number, x: number, y: number): void;
+    gestureEnd(): void;
+  };
+  getViewport(): { width: number; height: number };
+}): Pick<
+  PointerTrackerConfig,
+  'onPinchStart' | 'onPinchMove' | 'onPinchEnd' | 'isPinchAlive' | 'safariGestures'
+> {
+  const { controller } = deps;
+  return {
+    onPinchStart: (pts) => {
+      deps.beforeZoom();
+      controller.pinchStart(pts);
+    },
+    onPinchMove: (pts) => controller.pinchMove(pts),
+    onPinchEnd: () => controller.pinchEnd(),
+    isPinchAlive: () => controller.isActive,
+    safariGestures: {
+      start: (x, y) => {
+        deps.beforeZoom();
+        controller.gestureStart(
+          x || deps.getViewport().width / 2,
+          y || deps.getViewport().height / 2
+        );
+      },
+      change: (scale, x, y) =>
+        controller.gestureChange(
+          scale,
+          x || deps.getViewport().width / 2,
+          y || deps.getViewport().height / 2
+        ),
+      end: () => controller.gestureEnd()
+    }
   };
 }

--- a/src/lib/reader/input/swipe.test.ts
+++ b/src/lib/reader/input/swipe.test.ts
@@ -5,6 +5,7 @@ function ctx(overrides: Partial<SwipeContext> = {}): SwipeContext {
   return {
     summary: {
       panned: true,
+      cancelled: false,
       startX: 500,
       startY: 400,
       endX: 500,
@@ -83,5 +84,17 @@ describe('classifySwipe', () => {
     expect(swipe(-600, 0, { canRevealRightAtStart: true })).toBe(null);
     // the opposite edge does not gate
     expect(swipe(600, 0, { canRevealRightAtStart: true })).toBe('left');
+  });
+});
+
+describe('classifySwipe — cancelled gestures', () => {
+  it('a cancelled pan never flips, however swipe-shaped it is', () => {
+    const base = ctx();
+    expect(
+      classifySwipe({
+        ...base,
+        summary: { ...base.summary, endX: base.summary.startX + 600, cancelled: true }
+      })
+    ).toBe(null);
   });
 });

--- a/src/lib/reader/input/swipe.test.ts
+++ b/src/lib/reader/input/swipe.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { classifySwipe, type SwipeContext } from './swipe';
+
+function ctx(overrides: Partial<SwipeContext> = {}): SwipeContext {
+  return {
+    summary: {
+      panned: true,
+      startX: 500,
+      startY: 400,
+      endX: 500,
+      endY: 400,
+      durationMs: 200,
+      pointerType: 'touch'
+    },
+    wasPinch: false,
+    viewport: { width: 1000, height: 800 },
+    thresholdPercent: 50,
+    canRevealLeftAtStart: false,
+    canRevealRightAtStart: false,
+    ...overrides
+  };
+}
+
+function swipe(dx: number, dy = 0, overrides: Partial<SwipeContext> = {}) {
+  const base = ctx(overrides);
+  return classifySwipe({
+    ...base,
+    summary: { ...base.summary, endX: base.summary.startX + dx, endY: base.summary.startY + dy }
+  });
+}
+
+describe('classifySwipe', () => {
+  it('rightward swipe past threshold flips toward the left page', () => {
+    expect(swipe(600)).toBe('left');
+  });
+
+  it('leftward swipe past threshold flips toward the right page', () => {
+    expect(swipe(-600)).toBe('right');
+  });
+
+  it('a swipe short of the threshold does not flip (50% of 1000px = 500px)', () => {
+    expect(swipe(450)).toBe(null);
+    expect(swipe(-450)).toBe(null);
+  });
+
+  it('threshold scales with the setting', () => {
+    expect(swipe(300, 0, { thresholdPercent: 25 })).toBe('left');
+  });
+
+  it('non-touch pointers never swipe', () => {
+    const base = ctx();
+    expect(
+      classifySwipe({
+        ...base,
+        summary: { ...base.summary, endX: base.summary.startX + 600, pointerType: 'mouse' }
+      })
+    ).toBe(null);
+  });
+
+  it('a gesture that pinched is not a swipe', () => {
+    expect(swipe(600, 0, { wasPinch: true })).toBe(null);
+  });
+
+  it('slow gestures (>=500ms) are pans, not swipes', () => {
+    const base = ctx();
+    expect(
+      classifySwipe({
+        ...base,
+        summary: { ...base.summary, endX: base.summary.startX + 600, durationMs: 500 }
+      })
+    ).toBe(null);
+  });
+
+  it('too much vertical travel disqualifies (min(200, 30% of height))', () => {
+    // height 800 → vertical threshold min(200, 240) = 200
+    expect(swipe(600, 250)).toBe(null);
+    expect(swipe(600, -250)).toBe(null);
+    expect(swipe(600, 150)).toBe('left');
+  });
+
+  it('edge gating (#186): hidden content in the swipe direction means pan, not flip', () => {
+    expect(swipe(600, 0, { canRevealLeftAtStart: true })).toBe(null);
+    expect(swipe(-600, 0, { canRevealRightAtStart: true })).toBe(null);
+    // the opposite edge does not gate
+    expect(swipe(600, 0, { canRevealRightAtStart: true })).toBe('left');
+  });
+});

--- a/src/lib/reader/input/swipe.ts
+++ b/src/lib/reader/input/swipe.ts
@@ -1,0 +1,52 @@
+/**
+ * Swipe-to-flip classification for paged mode — the pure decision extracted
+ * from Reader.svelte's window-level touch handlers.
+ *
+ * A page-flip swipe is a fast (<500ms), mostly-horizontal touch gesture
+ * crossing the user's distance threshold (swipeThreshold, % of viewport
+ * width). Two suppressions carry the contracts that matter:
+ *
+ * - **Edge gating (#186):** if pannable content was hidden in the swipe's
+ *   direction when the gesture BEGAN, the gesture is an intra-page pan and
+ *   must not flip — the user is dragging hidden content into view. The
+ *   edge state is sampled at press time, before the pan moves it.
+ * - **Pinch suppression:** a gesture that was ever a pinch (wasPinch, from
+ *   the pointer tracker) is zooming, and its tail movement must not flip
+ *   the page. Replaces the old 200ms lastMultiTouchTime debounce.
+ *
+ * Returns which side's page to flip to — 'left' for a rightward swipe
+ * (revealing the page to the left), 'right' for a leftward swipe — or null.
+ * RTL direction semantics are the caller's concern.
+ */
+
+import type { PanSummary } from './pointer-tracker';
+
+export interface SwipeContext {
+  summary: PanSummary;
+  /** PointerGestureTracker.wasPinch for this press sequence. */
+  wasPinch: boolean;
+  viewport: { width: number; height: number };
+  /** settings.swipeThreshold — required travel as a % of viewport width. */
+  thresholdPercent: number;
+  /** Camera edge state sampled when the gesture began. */
+  canRevealLeftAtStart: boolean;
+  canRevealRightAtStart: boolean;
+}
+
+export function classifySwipe(ctx: SwipeContext): 'left' | 'right' | null {
+  const { summary } = ctx;
+  if (summary.pointerType !== 'touch') return null;
+  if (ctx.wasPinch) return null;
+  if (summary.durationMs >= 500) return null;
+
+  const dy = summary.endY - summary.startY;
+  const verticalThreshold = Math.min(200, ctx.viewport.height * 0.3);
+  if (Math.abs(dy) >= verticalThreshold) return null;
+
+  const dx = summary.endX - summary.startX;
+  const threshold = (ctx.thresholdPercent / 100) * ctx.viewport.width;
+
+  if (dx > threshold && !ctx.canRevealLeftAtStart) return 'left';
+  if (dx < -threshold && !ctx.canRevealRightAtStart) return 'right';
+  return null;
+}

--- a/src/lib/reader/input/swipe.ts
+++ b/src/lib/reader/input/swipe.ts
@@ -35,6 +35,7 @@ export interface SwipeContext {
 
 export function classifySwipe(ctx: SwipeContext): 'left' | 'right' | null {
   const { summary } = ctx;
+  if (summary.cancelled) return null;
   if (summary.pointerType !== 'touch') return null;
   if (ctx.wasPinch) return null;
   if (summary.durationMs >= 500) return null;

--- a/src/lib/reader/input/tap.test.ts
+++ b/src/lib/reader/input/tap.test.ts
@@ -87,17 +87,6 @@ describe('TapDiscriminator (deferred commit — scroll readers)', () => {
     vi.advanceTimersByTime(1000);
     expect(onTap).not.toHaveBeenCalled();
   });
-
-  it('respects a custom window', () => {
-    const fast = new TapDiscriminator({ onTap, onDoubleTap, doubleTapDelayMs: 100 });
-    fast.tap(0, 0);
-    vi.advanceTimersByTime(150);
-    fast.tap(0, 0);
-    expect(onDoubleTap).not.toHaveBeenCalled(); // 150ms > 100ms window
-    vi.advanceTimersByTime(100);
-    expect(onTap).toHaveBeenCalledTimes(2);
-    fast.cancel();
-  });
 });
 
 describe("TapDiscriminator (immediate commit — paged mode's native-click feel)", () => {

--- a/src/lib/reader/input/tap.test.ts
+++ b/src/lib/reader/input/tap.test.ts
@@ -99,3 +99,64 @@ describe('TapDiscriminator (deferred commit — scroll readers)', () => {
     fast.cancel();
   });
 });
+
+describe("TapDiscriminator (immediate commit — paged mode's native-click feel)", () => {
+  let onTap: ReturnType<typeof vi.fn>;
+  let onDoubleTap: ReturnType<typeof vi.fn>;
+  let taps: TapDiscriminator;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    onTap = vi.fn();
+    onDoubleTap = vi.fn();
+    taps = new TapDiscriminator({ commitPolicy: 'immediate', onTap, onDoubleTap });
+  });
+
+  afterEach(() => {
+    taps.cancel();
+    vi.useRealTimers();
+  });
+
+  it('commits every tap instantly', () => {
+    taps.tap(100, 200);
+    expect(onTap).toHaveBeenCalledTimes(1);
+    expect(onTap).toHaveBeenCalledWith(100, 200);
+  });
+
+  it('a second tap within the window commits AND double-taps (native click/click/dblclick)', () => {
+    taps.tap(100, 200);
+    vi.advanceTimersByTime(150);
+    taps.tap(110, 205);
+    expect(onTap).toHaveBeenCalledTimes(2); // both taps committed — overlay toggles twice, net zero
+    expect(onDoubleTap).toHaveBeenCalledTimes(1);
+    expect(onDoubleTap).toHaveBeenCalledWith(110, 205);
+  });
+
+  it('slow second tap is just another single tap', () => {
+    taps.tap(100, 200);
+    vi.advanceTimersByTime(400);
+    taps.tap(100, 200);
+    expect(onTap).toHaveBeenCalledTimes(2);
+    expect(onDoubleTap).not.toHaveBeenCalled();
+  });
+
+  it('a third quick tap after a double-tap starts a fresh cycle', () => {
+    taps.tap(0, 0);
+    vi.advanceTimersByTime(100);
+    taps.tap(0, 0); // double
+    vi.advanceTimersByTime(100);
+    taps.tap(0, 0); // fresh first tap
+    expect(onDoubleTap).toHaveBeenCalledTimes(1);
+    expect(onTap).toHaveBeenCalledTimes(3);
+  });
+
+  it('swallows the post-text-box dismissal tap without committing or arming', () => {
+    taps.noteTextBoxInteraction();
+    taps.tap(100, 200);
+    expect(onTap).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(50);
+    taps.tap(100, 200); // fresh FIRST tap, not a double
+    expect(onTap).toHaveBeenCalledTimes(1);
+    expect(onDoubleTap).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/reader/input/tap.test.ts
+++ b/src/lib/reader/input/tap.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TapDiscriminator } from './tap';
+
+describe('TapDiscriminator (deferred commit — scroll readers)', () => {
+  let onTap: ReturnType<typeof vi.fn>;
+  let onDoubleTap: ReturnType<typeof vi.fn>;
+  let taps: TapDiscriminator;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    onTap = vi.fn();
+    onDoubleTap = vi.fn();
+    taps = new TapDiscriminator({ onTap, onDoubleTap });
+  });
+
+  afterEach(() => {
+    taps.cancel();
+    vi.useRealTimers();
+  });
+
+  it('commits a single tap only after the double-tap window closes', () => {
+    taps.tap(100, 200);
+    expect(onTap).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(299);
+    expect(onTap).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(onTap).toHaveBeenCalledTimes(1);
+    expect(onTap).toHaveBeenCalledWith(100, 200);
+    expect(onDoubleTap).not.toHaveBeenCalled();
+  });
+
+  it('two taps within the window fire onDoubleTap once and no onTap', () => {
+    taps.tap(100, 200);
+    vi.advanceTimersByTime(150);
+    taps.tap(110, 205);
+    expect(onDoubleTap).toHaveBeenCalledTimes(1);
+    expect(onDoubleTap).toHaveBeenCalledWith(110, 205);
+    vi.advanceTimersByTime(1000);
+    expect(onTap).not.toHaveBeenCalled();
+  });
+
+  it('two taps slower than the window are two single taps', () => {
+    taps.tap(100, 200);
+    vi.advanceTimersByTime(400);
+    taps.tap(300, 400);
+    vi.advanceTimersByTime(400);
+    expect(onTap).toHaveBeenCalledTimes(2);
+    expect(onDoubleTap).not.toHaveBeenCalled();
+  });
+
+  it('a tap right after a double-tap starts a fresh cycle', () => {
+    taps.tap(100, 200);
+    vi.advanceTimersByTime(100);
+    taps.tap(100, 200); // double
+    vi.advanceTimersByTime(100);
+    taps.tap(100, 200); // fresh first tap, not a second double
+    expect(onDoubleTap).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(300);
+    expect(onTap).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows exactly one tap after a text-box interaction', () => {
+    taps.noteTextBoxInteraction();
+    taps.tap(100, 200); // dismissal tap — swallowed
+    vi.advanceTimersByTime(1000);
+    expect(onTap).not.toHaveBeenCalled();
+    expect(onDoubleTap).not.toHaveBeenCalled();
+
+    taps.tap(100, 200);
+    vi.advanceTimersByTime(300);
+    expect(onTap).toHaveBeenCalledTimes(1);
+  });
+
+  it('the swallowed tap does not arm a double-tap', () => {
+    taps.noteTextBoxInteraction();
+    taps.tap(100, 200); // swallowed
+    vi.advanceTimersByTime(50);
+    taps.tap(100, 200); // must be a fresh FIRST tap
+    expect(onDoubleTap).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(300);
+    expect(onTap).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancel() drops a pending single tap', () => {
+    taps.tap(100, 200);
+    taps.cancel();
+    vi.advanceTimersByTime(1000);
+    expect(onTap).not.toHaveBeenCalled();
+  });
+
+  it('respects a custom window', () => {
+    const fast = new TapDiscriminator({ onTap, onDoubleTap, doubleTapDelayMs: 100 });
+    fast.tap(0, 0);
+    vi.advanceTimersByTime(150);
+    fast.tap(0, 0);
+    expect(onDoubleTap).not.toHaveBeenCalled(); // 150ms > 100ms window
+    vi.advanceTimersByTime(100);
+    expect(onTap).toHaveBeenCalledTimes(2);
+    fast.cancel();
+  });
+});

--- a/src/lib/reader/input/tap.test.ts
+++ b/src/lib/reader/input/tap.test.ts
@@ -149,14 +149,62 @@ describe("TapDiscriminator (immediate commit — paged mode's native-click feel)
     expect(onDoubleTap).toHaveBeenCalledTimes(1);
     expect(onTap).toHaveBeenCalledTimes(3);
   });
+});
 
-  it('swallows the post-text-box dismissal tap without committing or arming', () => {
-    taps.noteTextBoxInteraction();
-    taps.tap(100, 200);
-    expect(onTap).not.toHaveBeenCalled();
-    vi.advanceTimersByTime(50);
-    taps.tap(100, 200); // fresh FIRST tap, not a double
-    expect(onTap).toHaveBeenCalledTimes(1);
+describe('TapDiscriminator — adversarial review fixes', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('immediate: rejects distant second taps when maxDoubleTapDistancePx is set', () => {
+    const onTap = vi.fn();
+    const onDoubleTap = vi.fn();
+    const taps = new TapDiscriminator({
+      commitPolicy: 'immediate',
+      maxDoubleTapDistancePx: 40,
+      onTap,
+      onDoubleTap
+    });
+    taps.tap(100, 100);
+    vi.advanceTimersByTime(100);
+    taps.tap(600, 100); // far away — NOT a double-tap
     expect(onDoubleTap).not.toHaveBeenCalled();
+    expect(onTap).toHaveBeenCalledTimes(2);
+    // and the distant tap re-arms: a third tap near IT does double
+    vi.advanceTimersByTime(100);
+    taps.tap(610, 105);
+    expect(onDoubleTap).toHaveBeenCalledTimes(1);
+    taps.cancel();
+  });
+
+  it('immediate: the swallowed dismissal tap still arms a double-tap (post-textbox dbltap zooms)', () => {
+    const onTap = vi.fn();
+    const onDoubleTap = vi.fn();
+    const taps = new TapDiscriminator({ commitPolicy: 'immediate', onTap, onDoubleTap });
+    taps.noteTextBoxInteraction();
+    taps.tap(100, 100); // dismissal — no commit, but arms
+    expect(onTap).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    taps.tap(105, 100);
+    expect(onTap).toHaveBeenCalledTimes(1); // second tap commits (old: click2 toggled)
+    expect(onDoubleTap).toHaveBeenCalledTimes(1); // and zooms (old: native dblclick)
+    taps.cancel();
+  });
+
+  it('deferred: the swallowed dismissal tap does NOT arm (readers parity)', () => {
+    const onTap = vi.fn();
+    const onDoubleTap = vi.fn();
+    const taps = new TapDiscriminator({ onTap, onDoubleTap });
+    taps.noteTextBoxInteraction();
+    taps.tap(100, 100); // dismissal
+    vi.advanceTimersByTime(100);
+    taps.tap(105, 100); // fresh FIRST tap
+    expect(onDoubleTap).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(300);
+    expect(onTap).toHaveBeenCalledTimes(1);
+    taps.cancel();
   });
 });

--- a/src/lib/reader/input/tap.ts
+++ b/src/lib/reader/input/tap.ts
@@ -3,11 +3,18 @@
  * both scroll readers previously duplicated inline (lastTapTime +
  * setTimeout dances).
  *
- * Deferred commit: a single tap is held for the double-tap window and only
- * commits (onTap — overlay toggle) if no second tap lands; a second tap
- * within the window cancels it and fires onDoubleTap (zoom toggle) instead.
- * The cost is intentional: the overlay appears doubleTapDelayMs late so a
- * double-tap never flashes it.
+ * Two commit policies, matching the two surface families:
+ *
+ * - 'deferred' (scroll readers): a single tap is held for the double-tap
+ *   window and only commits (onTap — overlay toggle) if no second tap
+ *   lands; a second tap within the window cancels it and fires onDoubleTap
+ *   (zoom toggle) instead. The cost is intentional: the overlay appears
+ *   doubleTapDelayMs late so a double-tap never flashes it.
+ * - 'immediate' (paged): every tap commits instantly, and a second tap
+ *   within the window ALSO fires onDoubleTap. This reproduces the native
+ *   click/click/dblclick sequence paged mode was built on: the overlay
+ *   toggles on each click (twice for a double-tap — net zero) and the zoom
+ *   fires on the second, so there is no overlay latency.
  *
  * The caller reports only qualified taps — clicks already filtered by
  * target role ('page' only) and by the tracker's wasDrag. One exception is
@@ -18,6 +25,8 @@
  */
 
 export interface TapDiscriminatorConfig {
+  /** See module doc. Default 'deferred'. */
+  commitPolicy?: 'deferred' | 'immediate';
   /** Double-tap window in ms. */
   doubleTapDelayMs?: number;
   /** A lone tap, fired after the window closes. */
@@ -50,8 +59,20 @@ export class TapDiscriminator {
 
     const delay = this.config.doubleTapDelayMs ?? 300;
     const now = performance.now();
+    const isSecondTap = this.lastTapTime !== null && now - this.lastTapTime < delay;
 
-    if (this.lastTapTime !== null && now - this.lastTapTime < delay) {
+    if (this.config.commitPolicy === 'immediate') {
+      this.config.onTap?.(x, y);
+      if (isSecondTap) {
+        this.lastTapTime = null;
+        this.config.onDoubleTap?.(x, y);
+      } else {
+        this.lastTapTime = now;
+      }
+      return;
+    }
+
+    if (isSecondTap) {
       this.lastTapTime = null;
       this.clearPending();
       this.config.onDoubleTap?.(x, y);

--- a/src/lib/reader/input/tap.ts
+++ b/src/lib/reader/input/tap.ts
@@ -29,6 +29,12 @@ export interface TapDiscriminatorConfig {
   commitPolicy?: 'deferred' | 'immediate';
   /** Double-tap window in ms. */
   doubleTapDelayMs?: number;
+  /**
+   * Two taps further apart than this are two singles, not a double —
+   * restores the proximity gate native dblclick gave paged mode. Default:
+   * unlimited (the scroll readers never had one).
+   */
+  maxDoubleTapDistancePx?: number;
   /** A lone tap, fired after the window closes. */
   onTap?(x: number, y: number): void;
   /** Second tap within the window, at the second tap's position. */
@@ -38,6 +44,8 @@ export interface TapDiscriminatorConfig {
 export class TapDiscriminator {
   private config: TapDiscriminatorConfig;
   private lastTapTime: number | null = null;
+  private lastTapX = 0;
+  private lastTapY = 0;
   private pending: ReturnType<typeof setTimeout> | null = null;
   private swallowNext = false;
 
@@ -54,12 +62,24 @@ export class TapDiscriminator {
   tap(x: number, y: number): void {
     if (this.swallowNext) {
       this.swallowNext = false;
+      // Immediate mode arms anyway: in the old paged code the dismissal
+      // only consumed the toggle, so a double-tap right after a text-box
+      // interaction still zoomed (click2 toggled + native dblclick fired).
+      if (this.config.commitPolicy === 'immediate') {
+        this.lastTapTime = performance.now();
+        this.lastTapX = x;
+        this.lastTapY = y;
+      }
       return;
     }
 
     const delay = this.config.doubleTapDelayMs ?? 300;
+    const maxDist = this.config.maxDoubleTapDistancePx ?? Infinity;
     const now = performance.now();
-    const isSecondTap = this.lastTapTime !== null && now - this.lastTapTime < delay;
+    const isSecondTap =
+      this.lastTapTime !== null &&
+      now - this.lastTapTime < delay &&
+      Math.hypot(x - this.lastTapX, y - this.lastTapY) <= maxDist;
 
     if (this.config.commitPolicy === 'immediate') {
       this.config.onTap?.(x, y);
@@ -68,6 +88,8 @@ export class TapDiscriminator {
         this.config.onDoubleTap?.(x, y);
       } else {
         this.lastTapTime = now;
+        this.lastTapX = x;
+        this.lastTapY = y;
       }
       return;
     }
@@ -80,6 +102,8 @@ export class TapDiscriminator {
     }
 
     this.lastTapTime = now;
+    this.lastTapX = x;
+    this.lastTapY = y;
     this.clearPending();
     this.pending = setTimeout(() => {
       this.pending = null;

--- a/src/lib/reader/input/tap.ts
+++ b/src/lib/reader/input/tap.ts
@@ -1,0 +1,82 @@
+/**
+ * Tap vs double-tap discrimination for reader surfaces — the timing logic
+ * both scroll readers previously duplicated inline (lastTapTime +
+ * setTimeout dances).
+ *
+ * Deferred commit: a single tap is held for the double-tap window and only
+ * commits (onTap — overlay toggle) if no second tap lands; a second tap
+ * within the window cancels it and fires onDoubleTap (zoom toggle) instead.
+ * The cost is intentional: the overlay appears doubleTapDelayMs late so a
+ * double-tap never flashes it.
+ *
+ * The caller reports only qualified taps — clicks already filtered by
+ * target role ('page' only) and by the tracker's wasDrag. One exception is
+ * handled here because it spans events: after interacting with a text box,
+ * the first tap outside is a DISMISSAL (the box closes) and must not toggle
+ * anything. Surfaces call noteTextBoxInteraction() when a press lands on a
+ * text box; the next tap is swallowed.
+ */
+
+export interface TapDiscriminatorConfig {
+  /** Double-tap window in ms. */
+  doubleTapDelayMs?: number;
+  /** A lone tap, fired after the window closes. */
+  onTap?(x: number, y: number): void;
+  /** Second tap within the window, at the second tap's position. */
+  onDoubleTap?(x: number, y: number): void;
+}
+
+export class TapDiscriminator {
+  private config: TapDiscriminatorConfig;
+  private lastTapTime: number | null = null;
+  private pending: ReturnType<typeof setTimeout> | null = null;
+  private swallowNext = false;
+
+  constructor(config: TapDiscriminatorConfig) {
+    this.config = config;
+  }
+
+  /** A press landed on a text box — the next tap dismisses, not toggles. */
+  noteTextBoxInteraction(): void {
+    this.swallowNext = true;
+  }
+
+  /** Report a qualified tap at viewport coordinates. */
+  tap(x: number, y: number): void {
+    if (this.swallowNext) {
+      this.swallowNext = false;
+      return;
+    }
+
+    const delay = this.config.doubleTapDelayMs ?? 300;
+    const now = performance.now();
+
+    if (this.lastTapTime !== null && now - this.lastTapTime < delay) {
+      this.lastTapTime = null;
+      this.clearPending();
+      this.config.onDoubleTap?.(x, y);
+      return;
+    }
+
+    this.lastTapTime = now;
+    this.clearPending();
+    this.pending = setTimeout(() => {
+      this.pending = null;
+      this.config.onTap?.(x, y);
+    }, delay);
+  }
+
+  /** Drop any pending single tap (component teardown, page change). */
+  cancel(): void {
+    this.clearPending();
+    this.lastTapTime = null;
+    this.swallowNext = false;
+  }
+
+  private clearPending(): void {
+    if (this.pending !== null) {
+      clearTimeout(this.pending);
+      this.pending = null;
+    }
+  }
+}

--- a/src/lib/reader/input/tap.ts
+++ b/src/lib/reader/input/tap.ts
@@ -24,11 +24,12 @@
  * text box; the next tap is swallowed.
  */
 
+/** The double-tap window — shared by both commit policies. */
+const DOUBLE_TAP_DELAY_MS = 300;
+
 export interface TapDiscriminatorConfig {
   /** See module doc. Default 'deferred'. */
   commitPolicy?: 'deferred' | 'immediate';
-  /** Double-tap window in ms. */
-  doubleTapDelayMs?: number;
   /**
    * Two taps further apart than this are two singles, not a double —
    * restores the proximity gate native dblclick gave paged mode. Default:
@@ -73,7 +74,7 @@ export class TapDiscriminator {
       return;
     }
 
-    const delay = this.config.doubleTapDelayMs ?? 300;
+    const delay = DOUBLE_TAP_DELAY_MS;
     const maxDist = this.config.maxDoubleTapDistancePx ?? Infinity;
     const now = performance.now();
     const isSecondTap =

--- a/src/lib/reader/page-mode-detection.ts
+++ b/src/lib/reader/page-mode-detection.ts
@@ -11,39 +11,7 @@ export function isWideSpread(page: Page): boolean {
 }
 
 /**
- * Calculate the median width of all portrait-oriented pages.
- * This represents the "normal" page width for the volume.
- */
-export function calculateMedianPageWidth(pages: Page[]): number {
-  // Only consider portrait-oriented pages (typical manga pages)
-  const portraitWidths = pages.filter((p) => p.img_height > p.img_width).map((p) => p.img_width);
-
-  if (portraitWidths.length === 0) {
-    // Fallback: use all pages if no portrait pages
-    const allWidths = pages.map((p) => p.img_width);
-    if (allWidths.length === 0) return 0;
-    const sorted = [...allWidths].sort((a, b) => a - b);
-    const mid = Math.floor(sorted.length / 2);
-    return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
-  }
-
-  const sorted = [...portraitWidths].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
-}
-
-/**
- * Checks if a page width is close to the median (within 15% tolerance)
- */
-export function isNormalWidth(page: Page, medianWidth: number): boolean {
-  if (medianWidth === 0) return true;
-  const deviation = Math.abs(page.img_width - medianWidth) / medianWidth;
-  return deviation <= 0.15;
-}
-
-/**
  * Checks if two pages have similar widths (within 20% of each other)
- * @deprecated Use isNormalWidth with median instead for more robust detection
  */
 export function haveSimilarWidths(page1: Page | undefined, page2: Page | undefined): boolean {
   if (!page1 || !page2) return false;

--- a/src/lib/reader/page-nav.test.ts
+++ b/src/lib/reader/page-nav.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { calculateForwardTarget, calculateBackwardTarget, type PageNavContext } from './page-nav';
+import type { Page } from '$lib/types';
+
+const portrait = () => ({ img_width: 800, img_height: 1200 }) as Page;
+const wide = () => ({ img_width: 2000, img_height: 1200 }) as Page;
+
+function ctx(pages: Page[], overrides: Partial<PageNavContext> = {}): PageNavContext {
+  return { pages, mode: 'dual', hasCover: false, fallbackStep: 2, ...overrides };
+}
+
+describe('calculateForwardTarget', () => {
+  it('single mode advances one page', () => {
+    const pages = [portrait(), portrait(), portrait(), portrait()];
+    expect(calculateForwardTarget(1, ctx(pages, { mode: 'single' }))).toBe(2);
+  });
+
+  it('dual mode advances a full spread', () => {
+    const pages = [portrait(), portrait(), portrait(), portrait(), portrait(), portrait()];
+    expect(calculateForwardTarget(1, ctx(pages))).toBe(3);
+  });
+
+  it('cover page advances one to start spreads after it', () => {
+    const pages = [portrait(), portrait(), portrait(), portrait()];
+    expect(calculateForwardTarget(1, ctx(pages, { hasCover: true }))).toBe(2);
+  });
+
+  it('half-steps when the next spread would land mis-aligned on a wide page', () => {
+    // Dual view [1,2]; pages[idx+3] (page 4) is wide → +1 so the wide page aligns.
+    const pages = [portrait(), portrait(), portrait(), wide(), portrait(), portrait()];
+    expect(calculateForwardTarget(1, ctx(pages))).toBe(2);
+  });
+
+  it('a current wide spread advances normally (no half-step from a wide view)', () => {
+    const pages = [wide(), portrait(), portrait(), wide(), portrait(), portrait()];
+    // current view shows the wide page alone (auto/single detection is the
+    // caller's concern in dual mode the wide current page still advances +1
+    // because shouldShowSinglePage('dual') is false and currentIsWide blocks
+    // the half-step rule
+    expect(calculateForwardTarget(1, ctx(pages))).toBe(3);
+  });
+
+  it('falls back to the provided step when out of range', () => {
+    const pages = [portrait(), portrait()];
+    expect(calculateForwardTarget(5, ctx(pages, { fallbackStep: 1 }))).toBe(6);
+    expect(calculateForwardTarget(5, ctx(pages, { fallbackStep: 2 }))).toBe(7);
+    expect(calculateForwardTarget(1, ctx([], { fallbackStep: 2 }))).toBe(3);
+  });
+});
+
+describe('calculateBackwardTarget', () => {
+  it('from page 1 goes to 0 (volume-boundary sentinel)', () => {
+    const pages = [portrait(), portrait(), portrait()];
+    expect(calculateBackwardTarget(1, ctx(pages))).toBe(0);
+  });
+
+  it('dual mode steps back a full spread', () => {
+    const pages = [portrait(), portrait(), portrait(), portrait(), portrait(), portrait()];
+    expect(calculateBackwardTarget(5, ctx(pages))).toBe(3);
+  });
+
+  it('single mode steps back one page (target shows single)', () => {
+    const pages = [portrait(), portrait(), portrait(), portrait()];
+    expect(calculateBackwardTarget(3, ctx(pages, { mode: 'single' }))).toBe(2);
+  });
+
+  it('half-steps backward when the previous chunk’s further page is wide', () => {
+    // From dual view at page 4, pages[idx-2] (page 2) wide → -1.
+    const pages = [portrait(), wide(), portrait(), portrait(), portrait(), portrait()];
+    expect(calculateBackwardTarget(4, ctx(pages))).toBe(3);
+  });
+
+  it('steps back one when the target would display single (cover)', () => {
+    // Views with a cover: [1], [2,3], ... From page 2, a full -2 would skip
+    // past the cover; the single-display target makes it -1.
+    const pages = [portrait(), portrait(), portrait(), portrait()];
+    expect(calculateBackwardTarget(2, ctx(pages, { hasCover: true }))).toBe(1);
+  });
+
+  it('from page 2 without a cover returns 0 for changePage to clamp to 1', () => {
+    const pages = [portrait(), portrait(), portrait()];
+    expect(calculateBackwardTarget(2, ctx(pages))).toBe(0);
+  });
+});

--- a/src/lib/reader/page-nav.ts
+++ b/src/lib/reader/page-nav.ts
@@ -1,0 +1,122 @@
+/**
+ * Paged-mode navigation targets — where forward/backward actually lands.
+ *
+ * Not a simple ±1/±2: spread alignment makes this stateful-looking logic
+ * pure. The "half-step" rules keep wide spreads (double-page images)
+ * aligned with the dual view: when a full step would land a wide page in
+ * the second slot of a pair, step one page instead so the spread gets the
+ * whole view to itself. The same correction exists in both directions.
+ *
+ * Returned values may be out of range (0, or past the last page) — the
+ * caller (Reader.changePage) clamps and interprets edge overshoot as
+ * volume navigation.
+ */
+
+import type { Page } from '$lib/types';
+import type { PageViewMode } from '$lib/settings';
+import { isWideSpread, shouldShowSinglePage } from './page-mode-detection';
+
+export interface PageNavContext {
+  pages: Page[];
+  /** settings.singlePageView */
+  mode: PageViewMode;
+  /** Volume's hasCover — the first page displays alone. */
+  hasCover: boolean;
+  /** Step used when currentPage is out of range (Reader's navAmount). */
+  fallbackStep: number;
+}
+
+/**
+ * Target page when navigating forward. Half-steps (+1) when the current
+ * view is dual and the next spread's further page is a wide image.
+ */
+export function calculateForwardTarget(currentPage: number, ctx: PageNavContext): number {
+  const { pages, mode, hasCover } = ctx;
+  const currentIndex = currentPage - 1;
+
+  if (!pages || currentIndex < 0 || currentIndex >= pages.length) {
+    return currentPage + ctx.fallbackStep;
+  }
+
+  const currentPageData = pages[currentIndex];
+  const nextPageData = pages[currentIndex + 1];
+  const previousPageData = currentIndex > 0 ? pages[currentIndex - 1] : undefined;
+
+  const currentIsSingle = shouldShowSinglePage(
+    mode,
+    currentPageData,
+    nextPageData,
+    previousPageData,
+    currentIndex === 0,
+    hasCover
+  );
+
+  if (currentIsSingle) {
+    return currentPage + 1;
+  }
+
+  // Half-step correction for off-alignment spreads:
+  // Current dual view is [N, N+1], next spread is [N+2, N+3].
+  // The further page from current in forward direction is N+3.
+  const forwardLookaheadPage = pages[currentIndex + 3];
+  const lookaheadIsWide = forwardLookaheadPage !== undefined && isWideSpread(forwardLookaheadPage);
+
+  if (currentPageData && nextPageData && !isWideSpread(currentPageData) && lookaheadIsWide) {
+    return currentPage + 1;
+  }
+
+  return currentPage + 2;
+}
+
+/**
+ * Target page when navigating backward, accounting for single-page
+ * exceptions (covers, wide spreads) so the landing view stays aligned.
+ */
+export function calculateBackwardTarget(currentPage: number, ctx: PageNavContext): number {
+  const { pages, mode, hasCover } = ctx;
+  if (currentPage <= 1) return 0;
+
+  const currentIndex = currentPage - 1;
+  const currentPageData = pages?.[currentIndex];
+  const currentNextPageData = pages?.[currentIndex + 1];
+  const currentPreviousPageData = currentIndex > 0 ? pages?.[currentIndex - 1] : undefined;
+
+  const currentShouldBeSingle = shouldShowSinglePage(
+    mode,
+    currentPageData,
+    currentNextPageData,
+    currentPreviousPageData,
+    currentIndex === 0,
+    hasCover
+  );
+
+  // Mirror of forward half-step fix:
+  // when moving backward from a dual view, inspect the further page in the
+  // previous spread chunk (currentPage - 2). If that page is wide, half-step.
+  if (!currentShouldBeSingle) {
+    const previousSpreadFurtherPage = pages?.[currentIndex - 2];
+    if (previousSpreadFurtherPage && isWideSpread(previousSpreadFurtherPage)) {
+      return currentPage - 1;
+    }
+  }
+
+  const targetIndex = currentPage - 2;
+  if (targetIndex < 0) {
+    return currentPage - 1;
+  }
+
+  const targetPage = pages?.[targetIndex];
+  const targetNextPage = pages?.[targetIndex + 1];
+  const targetPreviousPage = targetIndex > 0 ? pages?.[targetIndex - 1] : undefined;
+
+  const targetShouldBeSingle = shouldShowSinglePage(
+    mode,
+    targetPage,
+    targetNextPage,
+    targetPreviousPage,
+    targetIndex === 0,
+    hasCover
+  );
+
+  return targetShouldBeSingle ? currentPage - 1 : currentPage - 2;
+}

--- a/src/lib/reader/page-nav.ts
+++ b/src/lib/reader/page-nav.ts
@@ -15,6 +15,31 @@
 import type { Page } from '$lib/types';
 import type { PageViewMode } from '$lib/settings';
 import { isWideSpread, shouldShowSinglePage } from './page-mode-detection';
+import { getCharCount } from '$lib/util/count-chars';
+
+/**
+ * Scroll readers' volume-boundary handling: navigating past either end
+ * exits to the adjacent volume (marking the current one complete when
+ * leaving forward). Returns true when the navigation was consumed.
+ */
+export function volumeEdgeNav(
+  pageIdx: number,
+  pages: Page[],
+  onPageChange: (page: number, charCount: number, isComplete: boolean) => void,
+  onVolumeNav: (direction: 'prev' | 'next') => void
+): boolean {
+  if (pageIdx >= pages.length) {
+    const { charCount } = getCharCount(pages, pages.length);
+    onPageChange(pages.length, charCount, true);
+    onVolumeNav('next');
+    return true;
+  }
+  if (pageIdx < 0) {
+    onVolumeNav('prev');
+    return true;
+  }
+  return false;
+}
 
 export interface PageNavContext {
   pages: Page[];

--- a/src/lib/reader/paged-camera.ts
+++ b/src/lib/reader/paged-camera.ts
@@ -71,14 +71,6 @@ export class PagedCamera {
     return this.base.scale * this.userZoom;
   }
 
-  get currentUserZoom(): number {
-    return this.userZoom;
-  }
-
-  get baseScale(): number {
-    return this.base.scale;
-  }
-
   private scaledSize(): Size {
     const c = this.content ?? { width: 0, height: 0 };
     const s = this.effectiveScale;

--- a/src/lib/reader/paged-zoom-session.ts
+++ b/src/lib/reader/paged-zoom-session.ts
@@ -72,7 +72,7 @@ export function createSessionState(): PagedZoomSessionState {
 }
 
 /** keepZoom and its legacy persisted aliases (localStorage / synced profiles). */
-export function isKeepZoomMode(mode: string): boolean {
+function isKeepZoomMode(mode: string): boolean {
   return mode === 'keepZoom' || mode === 'keepZoomStart' || mode === 'keepZoomTopCorner';
 }
 

--- a/src/lib/reader/paged-zoom.ts
+++ b/src/lib/reader/paged-zoom.ts
@@ -9,14 +9,8 @@
 import { writable } from 'svelte/store';
 
 export interface PagedZoomApi {
-  /** Window-level wheel delegate (zoom intent or smooth vertical pan). */
-  handleWheel(e: WheelEvent): void;
-  /** Contextual double-tap: 1 ↔ fit ↔ 2× (see paged-zoom-session). */
-  doubleTap(x: number, y: number): void;
   /** Arrow-key style smooth vertical pan (75% of the viewport). */
   scrollImage(direction: 'up' | 'down'): void;
-  /** Hidden-content edge state for swipe-to-flip gating (issue #186). */
-  edgeState(): { canRevealLeft: boolean; canRevealRight: boolean };
   /** QuickActions: show the whole page (fit-to-screen view, level 1). */
   zoomFitToScreen(): void;
 }

--- a/src/lib/reader/scroll-animator.ts
+++ b/src/lib/reader/scroll-animator.ts
@@ -50,7 +50,7 @@ export class ScrollAnimator {
   }
 
   /** Animate to absolute scroll position */
-  scrollTo(x: number, y: number): void {
+  private scrollTo(x: number, y: number): void {
     this.xAnim.setTarget(x);
     this.yAnim.setTarget(y);
   }
@@ -62,11 +62,6 @@ export class ScrollAnimator {
   }
 
   /** Jump immediately with no animation */
-  snapTo(x: number, y: number): void {
-    this.xAnim.snapTo(x);
-    this.yAnim.snapTo(y);
-  }
-
   /**
    * Stop any in-flight animation, leaving the scroll position as-is.
    * Used when a zoom gesture takes over scroll control — the next manual
@@ -142,10 +137,6 @@ export class ScrollAnimator {
       this.container.scrollLeft + pairCenterX - viewCenterX,
       this.container.scrollTop + pairCenterY - viewCenterY
     );
-  }
-
-  get isAnimating(): boolean {
-    return this.xAnim.isAnimating || this.yAnim.isAnimating;
   }
 
   destroy(): void {

--- a/src/lib/reader/zoom-controller.test.ts
+++ b/src/lib/reader/zoom-controller.test.ts
@@ -214,7 +214,7 @@ describe('ContinuousZoomController — pinch', () => {
     expect(c.currentZoom).toBeCloseTo(2.6, 6);
     expect(c.zoomTarget).toBe(3);
     expect(settled).toHaveBeenCalledTimes(1);
-    expect(settled).toHaveBeenCalledWith(2.6);
+    expect(settled).toHaveBeenCalledWith(2.6, 'gesture');
     expect(c.isActive).toBe(false);
   });
 
@@ -238,7 +238,7 @@ describe('ContinuousZoomController — pinch', () => {
     expect(c.currentZoom).toBe(1);
     expect(c.zoomTarget).toBe(1);
     expect(settled).toHaveBeenCalledTimes(1);
-    expect(settled).toHaveBeenCalledWith(1);
+    expect(settled).toHaveBeenCalledWith(1, 'gesture');
     expect(zoomed).toHaveBeenLastCalledWith(false);
   });
 
@@ -431,7 +431,7 @@ describe('ContinuousZoomController — interruption and lifecycle', () => {
     expect(c.currentZoom).toBe(1);
     expect(world.zoom).toBe(1);
     expect(settled).toHaveBeenCalledTimes(1);
-    expect(settled).toHaveBeenCalledWith(1);
+    expect(settled).toHaveBeenCalledWith(1, 'reset');
     expect(zoomed).toHaveBeenLastCalledWith(false);
   });
 
@@ -645,7 +645,7 @@ describe('ZoomController — snapToLevel (additive)', () => {
     expect(c.zoomTarget).toBe(2.5);
     expect(world.zoom).toBe(2.5);
     expect(settled).toHaveBeenCalledTimes(1);
-    expect(settled).toHaveBeenCalledWith(2.5);
+    expect(settled).toHaveBeenCalledWith(2.5, 'reset');
     // layout placement only — no anchor-driven scroll writes
     expect(world.scrollLeft).toBe(before.left);
     expect(world.scrollTop).toBe(before.top);
@@ -682,5 +682,52 @@ describe('ZoomController — snapToLevel anchor skip (regression pin)', () => {
     expect(world.scrollLeft).toBe(before.left);
     expect(world.scrollTop).toBe(before.top);
     expect(c.currentZoom).toBe(1.5);
+  });
+});
+
+describe('ZoomController — settle reasons', () => {
+  it('reports gesture on natural animated settle', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const c = makeController(world, { settled });
+    c.toggleZoom(300, 500);
+    pump();
+    expect(settled).toHaveBeenCalledWith(2, 'gesture');
+  });
+
+  it('reports interrupt by default from finishNow', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const c = makeController(world, { settled });
+    c.toggleZoom(300, 500);
+    pump(3);
+    c.finishNow();
+    expect(settled).toHaveBeenCalledWith(2, 'interrupt');
+  });
+
+  it('reports nav when the interrupt precedes a navigation', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const c = makeController(world, { settled });
+    c.toggleZoom(300, 500);
+    pump(3);
+    c.finishNow('nav');
+    expect(settled).toHaveBeenCalledWith(2, 'nav');
+  });
+
+  it('reports nav from a pinch interrupted for navigation', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const c = makeController(world, { settled });
+    c.pinchStart([
+      { x: 400, y: 400 },
+      { x: 600, y: 400 }
+    ]);
+    c.pinchMove([
+      { x: 300, y: 400 },
+      { x: 700, y: 400 }
+    ]);
+    c.finishNow('nav');
+    expect(settled).toHaveBeenCalledWith(2, 'nav');
   });
 });

--- a/src/lib/reader/zoom-controller.ts
+++ b/src/lib/reader/zoom-controller.ts
@@ -38,7 +38,7 @@ const SNAP_TO_ONE_BELOW = 1.05;
 /** Double-tap zoom-in target level. */
 const DOUBLE_TAP_ZOOM = 2;
 
-export const CONTINUOUS_ZOOM_LEVELS: readonly number[] = [1, 1.5, 2, 3];
+const CONTINUOUS_ZOOM_LEVELS: readonly number[] = [1, 1.5, 2, 3];
 
 /** Structural subset of HTMLElement the controller scrolls. */
 export interface ZoomContainer {
@@ -213,7 +213,11 @@ export class ContinuousZoomController {
     this.stepTo(next, { x: e.clientX, y: e.clientY });
   }
 
-  /** Step one level in `direction`, anchored at (x, y) or the viewport center. */
+  /**
+   * Step one level in `direction`, anchored at (x, y) or the viewport
+   * center. No production caller — this is the test seam (unit + e2e
+   * geometry suites) for stepping levels without the wheel accumulator.
+   */
   cycleZoom(direction: 1 | -1, anchorX?: number, anchorY?: number): void {
     const viewport = this.config.getViewport();
     const anchor = {
@@ -463,4 +467,3 @@ export class ContinuousZoomController {
  * drives paged mode too. The original export name remains for existing
  * callers.
  */
-export { ContinuousZoomController as ZoomController };

--- a/src/lib/reader/zoom-controller.ts
+++ b/src/lib/reader/zoom-controller.ts
@@ -52,6 +52,24 @@ export interface ZoomAnchorTarget {
   getBoundingClientRect(): RectLike;
 }
 
+/**
+ * Why a settle happened. Components decide per reason whether to re-detect
+ * pages and report progress — replacing the suppressSettleReport boolean
+ * that callers had to toggle around synchronous calls (and which silently
+ * depended on Animator.snapTo firing onSettle synchronously).
+ *
+ * - 'gesture'   — a zoom gesture finished naturally (animation settled,
+ *                 pinch released). Geometry is final: report progress.
+ * - 'interrupt' — a competing input finished the zoom early (wheel scroll,
+ *                 new drag). Geometry is final: report progress.
+ * - 'nav'       — finished because a navigation is about to move the view.
+ *                 Do NOT report: the nav supersedes it.
+ * - 'reset'     — instant reset/snap with no anchor correction; the scroll
+ *                 offset is stale against the new layout. Do NOT report or
+ *                 detect: the caller re-anchors next.
+ */
+export type SettleReason = 'gesture' | 'interrupt' | 'nav' | 'reset';
+
 export interface ZoomWheelEventLike {
   deltaY: number;
   deltaMode: number;
@@ -102,9 +120,10 @@ export interface ZoomControllerConfig {
   onZoomedChange?(zoomed: boolean): void;
   /**
    * A gesture finished (animation settled, pinch released, finishNow, reset).
-   * Components re-run page detection and report progress here.
+   * Components re-run page detection and report progress here, gated by the
+   * reason — see SettleReason.
    */
-  onSettled?(zoom: number): void;
+  onSettled?(zoom: number, reason: SettleReason): void;
 }
 
 /** The continuous readers' surface: native scroll container + layout hook. */
@@ -153,7 +172,7 @@ export class ContinuousZoomController {
     this.animator = new Animator(1, (zoom) => this.frameStep(zoom), {
       factor: 0.25,
       epsilon: 0.005,
-      onSettle: () => this.settle()
+      onSettle: () => this.settle('gesture')
     });
   }
 
@@ -272,7 +291,7 @@ export class ContinuousZoomController {
       return;
     }
     this.target = nearestZoomLevel(this.levels, zoom);
-    this.settle();
+    this.settle('gesture');
   }
 
   // Safari desktop trackpad pinch (proprietary gesture events).
@@ -318,16 +337,16 @@ export class ContinuousZoomController {
    * Call before competing scroll intents (keyboard nav, manual page change,
    * scroll-intent wheel, new drag) so they act on settled geometry.
    */
-  finishNow(): void {
+  finishNow(reason: 'interrupt' | 'nav' = 'interrupt'): void {
     if (this.pinching) {
       this.pinching = false;
       this.target = nearestZoomLevel(this.levels, this.animator.current);
-      this.settle();
+      this.settle(reason);
       return;
     }
     if (this.animator.isAnimating) {
       this.animator.snapTo(this.target);
-      this.settle();
+      this.settle(reason);
     }
   }
 
@@ -351,7 +370,7 @@ export class ContinuousZoomController {
     this.target = level;
     this.anchorEl = null; // skip anchor correction; layout placement only
     this.animator.snapTo(level);
-    this.settle();
+    this.settle('reset');
   }
 
   destroy(): void {
@@ -432,10 +451,10 @@ export class ContinuousZoomController {
   }
 
   /** Shared settle: bookkeeping + component hooks. Runs exactly once per gesture. */
-  private settle(): void {
+  private settle(reason: SettleReason): void {
     const zoom = this.animator.current;
     this.config.onZoomedChange?.(zoom > 1 + ZOOM_EPS);
-    this.config.onSettled?.(zoom);
+    this.config.onSettled?.(zoom, reason);
   }
 }
 

--- a/src/lib/reader/zoom-layout.ts
+++ b/src/lib/reader/zoom-layout.ts
@@ -75,7 +75,7 @@ export function applyVerticalZoomLayout(
 }
 
 /** `flex-start` when the strip's visual height exceeds the container, else `center`. */
-export function horizontalAlignment(visualHeight: number, containerHeight: number): string {
+function horizontalAlignment(visualHeight: number, containerHeight: number): string {
   return visualHeight > containerHeight + 1 ? 'flex-start' : 'center';
 }
 


### PR DESCRIPTION
## Why

The v1.7.x zoom rework sessions showed that the zoom core (controller, camera, math) is solid, but every bug clustered at the input seams: three divergent ~80-line pointer machines, the `.textBox` contract enforced by accident in two places, ~8 coordination booleans, an interrupt ritual repeated at ~20 sites — plus a **live pointer-map leak in both scroll readers** (a release landing on an overlay left a phantom pointer, and the next press misread as a pinch).

## What

Eight commits, each independently reviewable:

1. **Settle reasons** — `onSettled(zoom, reason)` (`gesture | interrupt | nav | reset`) replaces the `suppressSettleReport` flag dances; progress reporting is gated on reason.
2. **Gesture-target roles** — `gestureTargetRole()` (`textbox | interactive | page`) is THE statement of the `.textBox` input-routing contract (Anki double-tap, Yomitan/Migaku selection); `keyboardShouldIgnore()` unifies the keyboard guards that had drifted apart.
3. **PointerGestureTracker** — one pointer state machine for all three surfaces. Window-level `pointerup`/`pointercancel` makes pointer cleanup structural (**fixes the live leak**). Capture timing, pan suppression, and survivor handoff are named config; pinch always wins, re-baselines on pointer-set changes, and resurrects when a base re-application clears controller state mid-gesture.
4. **TapDiscriminator** — tap vs double-tap with two commit policies: deferred 300 ms (scroll readers, unchanged) and immediate (paged — reproduces the native click/click/dblclick feel, no overlay latency). Absorbs `textBoxWasActive`.
5. **MotionGate** — `beforeZoom / beforeManualPan / beforeAnimatedScroll / beforeNav` choke points per surface replace the scattered `finishNow()/stop()/stopPan()` ritual.
6. **Paged input ownership** — wheel, swipe-to-flip, and taps move from Reader (window-level handlers + store round-trips) into PagedViewport; Reader supplies `onPageFlip`/`onOverlayToggle` and keeps only keyboard. The swipe classifier is extracted pure (`input/swipe.ts`); `tracker.wasPinch` replaces the 200 ms multi-touch debounce. Page-nav spread-alignment math extracted to `page-nav.ts`.
7. **`docs/INPUT-CONTRACTS.md`** — the map: architecture, per-surface policy matrix, and the contracts that must not break. CLAUDE.md points there.
8. **Adversarial-review fixes** — a 22-agent review of the branch found six real edge cases (pan→pinch upgrade could fire a swipe flip; `pointercancel` could classify as a swipe; right-click on a text box lost its dismissal arming; survivor-pan eligibility; selection-drag click consuming the dismissal; double-tap proximity gate lost). All fixed with regression tests.

## Deliberate behavior deltas

- Paged double-tap window is now the shared 300 ms + 40 px proximity (was the OS dblclick interval).
- Background taps between the page and gutter buttons toggle the overlay (previously a dead zone) — matches the continuous readers.
- A drag press now stops a running scroll animation; scroll readers gained pinch resurrection.
- Swipes must start on the reader surface (previously window-wide, including over HUD overlays).

## Verification

- 643 unit tests (90 new across the input modules + page-nav), `svelte-check` clean, 11 Playwright e2e green.
- A 15-scenario real-app pass with trusted input (Playwright + CDP touch): ctrl+wheel/pinch/double-tap zoom, mouse and **single-finger touch pan** (the v1.7.1 regression area), Anki double-tap guard on text boxes, dismissal swallowing, instant paged overlay toggle, edge-gated swipe both directions (#186), keyboard nav through the motion gate — in both paged and continuous modes. 15/15.

## Known accepted gaps

- A non-primary mouse button can still join a pinch count (pre-existing behavior on develop, unchanged).
- The old 200 ms post-pinch swipe debounce is gone; a genuinely fresh single-finger flick right after a pinch can flip — `wasPinch` covers everything within the same press sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)