### PR TITLE
fix(reader): un-pin Keep Zoom / Original Size; add Fill screen zoom mode

### DIFF
--- a/e2e/zoom.spec.ts
+++ b/e2e/zoom.spec.ts
@@ -574,6 +574,58 @@ test('paged keepZoom: effective scale survives a content swap (spread)', async (
   expect(r.effectiveAfter).toBeCloseTo(r.effectiveBefore, 3);
 });
 
+test('paged fillScreen: tall page fills the width and pans to the bottom; small pages center', async ({
+  page
+}) => {
+  await setupPagedWorld(page, { rtl: true, mode: 'zoomFillScreen' });
+  const r = await page.evaluate(async () => {
+    const z = (window as any).__paged;
+    // 1400x2000 page: taller than the viewport aspect → width must fill.
+    const rect0 = z.pageEl.getBoundingClientRect();
+    const widthFills = Math.abs(rect0.width - innerWidth) < 1.5;
+    const startsAtTop = Math.abs(rect0.top) < 1.5;
+
+    // The overflowing height is pannable all the way to the bottom edge.
+    z.camera.adjustView(0, rect0.height * 2); // grossly past the end — clamps
+    const rect1 = z.pageEl.getBoundingClientRect();
+    const bottomReachable = Math.abs(rect1.bottom - innerHeight) < 1.5;
+
+    // A page smaller than the viewport centers — never welded to the corner
+    // (the keepZoom/original top-pin bug class).
+    z.pageEl.style.width = '400px';
+    z.pageEl.style.height = '300px';
+    z.applyBase({ width: 400, height: 300 });
+    z.controller.snapToLevel(z.session.pagedLevels(z.state.baseScale, z.state.fitScale)[0]);
+    const rect2 = z.pageEl.getBoundingClientRect();
+    const centeredX = Math.abs(rect2.left - (innerWidth - rect2.width) / 2) < 1.5;
+    return { widthFills, startsAtTop, bottomReachable, centeredX, w: rect2.width };
+  });
+  expect(r.widthFills).toBe(true);
+  expect(r.startsAtTop).toBe(true);
+  expect(r.bottomReachable).toBe(true);
+  expect(r.centeredX).toBe(true);
+});
+
+test('paged zoomOriginal: a page smaller than the viewport centers and zooming out never pins it', async ({
+  page
+}) => {
+  await setupPagedWorld(page, { rtl: true, mode: 'zoomOriginal' });
+  const r = await page.evaluate(async () => {
+    const z = (window as any).__paged;
+    // Swap in a page smaller than the viewport at 1:1.
+    z.pageEl.style.width = '600px';
+    z.pageEl.style.height = '500px';
+    z.applyBase({ width: 600, height: 500 });
+    const rect = z.pageEl.getBoundingClientRect();
+    return {
+      cx: rect.left + rect.width / 2,
+      cy: rect.top + rect.height / 2
+    };
+  });
+  expect(r.cx).toBeCloseTo(1920 / 2, 0);
+  expect(r.cy).toBeCloseTo(1080 / 2, 0);
+});
+
 test('vertical fit-to-screen: side margins are not pannable while zoomed', async ({ page }) => {
   // Narrow fixed-size pages (560px in a 1920px viewport): at 2x the scaled
   // content (1120px) still fits, so there must be NO horizontal scroll range

--- a/src/lib/components/Reader/HorizontalScrollReader.svelte
+++ b/src/lib/components/Reader/HorizontalScrollReader.svelte
@@ -59,14 +59,11 @@
     if (zoomMode === 'zoomOriginal') {
       return { width: page.img_width, height: page.img_height };
     }
-    if (zoomMode === 'zoomFillScreen' || (zoomMode as string) === 'zoomFitToWidth') {
-      // Fill the non-limiting axis (legacy fit-to-width lands here): tall
-      // pages fill the viewport width and overflow vertically; wide spreads
-      // fall back to the height fit below (max picks it).
-      const scale = Math.max(viewportWidth / page.img_width, viewportHeight / page.img_height);
-      return { width: page.img_width * scale, height: page.img_height * scale };
-    }
-    // zoomFitToScreen / default: fit to height
+    // zoomFitToScreen, zoomFillScreen, and legacy zoomFitToWidth all fill the
+    // height here: the strip axis (width) always overflows in horizontal
+    // mode, so filling the screen means filling the CROSS axis. This is
+    // exactly the layout legacy fit-to-width users were missing when
+    // "match orientation" rotated them into horizontal mode.
     const scale = viewportHeight / page.img_height;
     return { width: page.img_width * scale, height: viewportHeight };
   }

--- a/src/lib/components/Reader/HorizontalScrollReader.svelte
+++ b/src/lib/components/Reader/HorizontalScrollReader.svelte
@@ -59,9 +59,12 @@
     if (zoomMode === 'zoomOriginal') {
       return { width: page.img_width, height: page.img_height };
     }
-    if (zoomMode === 'zoomFitToWidth') {
-      const scale = viewportWidth / page.img_width;
-      return { width: viewportWidth, height: page.img_height * scale };
+    if (zoomMode === 'zoomFillScreen' || (zoomMode as string) === 'zoomFitToWidth') {
+      // Fill the non-limiting axis (legacy fit-to-width lands here): tall
+      // pages fill the viewport width and overflow vertically; wide spreads
+      // fall back to the height fit below (max picks it).
+      const scale = Math.max(viewportWidth / page.img_width, viewportHeight / page.img_height);
+      return { width: page.img_width * scale, height: page.img_height * scale };
     }
     // zoomFitToScreen / default: fit to height
     const scale = viewportHeight / page.img_height;

--- a/src/lib/components/Reader/QuickActions.svelte
+++ b/src/lib/components/Reader/QuickActions.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { toggleFullScreen } from '$lib/util/fullscreen';
   import { pagedZoom } from '$lib/reader/paged-zoom';
-  import { settings, volumes } from '$lib/settings';
+  import { settings, volumes, updateSetting } from '$lib/settings';
   import {
     ArrowLeftOutline,
     ArrowRightOutline,
@@ -49,7 +49,14 @@
   let open = $state(false);
 
   function handleZoom() {
-    $pagedZoom?.zoomFitToScreen();
+    if ($pagedZoom) {
+      // Paged mode: transient whole-page view (the mode setting is untouched).
+      $pagedZoom.zoomFitToScreen();
+    } else {
+      // Continuous mode has no transient equivalent — pages lay out from the
+      // mode setting, so "fit" means switching it (the Z-key path).
+      updateSetting('continuousZoomDefault', 'zoomFitToScreen');
+    }
     open = false;
   }
 

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -976,19 +976,19 @@
     const currentMode = $settings.continuousZoomDefault;
     let nextMode: ContinuousZoomMode;
 
-    // Rotate through: fitToWidth -> fitToScreen -> original -> fitToWidth
-    if (currentMode === 'zoomFitToWidth') {
+    // Rotate through: fillScreen -> fitToScreen -> original -> fillScreen
+    if (currentMode === 'zoomFillScreen') {
       nextMode = 'zoomFitToScreen';
     } else if (currentMode === 'zoomFitToScreen') {
       nextMode = 'zoomOriginal';
     } else {
-      nextMode = 'zoomFitToWidth';
+      nextMode = 'zoomFillScreen';
     }
 
     updateSetting('continuousZoomDefault', nextMode);
 
     const labels: Record<ContinuousZoomMode, string> = {
-      zoomFitToWidth: 'Fit to Width',
+      zoomFillScreen: 'Fill Screen',
       zoomFitToScreen: 'Fit to Screen',
       zoomOriginal: 'Original Size'
     };

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -1014,10 +1014,12 @@
     const currentMode = $settings.zoomDefault;
     let nextMode: typeof currentMode;
 
-    // Rotate through: fitToScreen -> fitToWidth -> original -> keepZoom -> fitToScreen
+    // Rotate: fitToScreen -> fitToWidth -> fillScreen -> original -> keepZoom -> fitToScreen
     if (currentMode === 'zoomFitToScreen') {
       nextMode = 'zoomFitToWidth';
     } else if (currentMode === 'zoomFitToWidth') {
+      nextMode = 'zoomFillScreen';
+    } else if (currentMode === 'zoomFillScreen') {
       nextMode = 'zoomOriginal';
     } else if (currentMode === 'zoomOriginal') {
       nextMode = 'keepZoom';
@@ -1031,6 +1033,7 @@
     const labels = {
       zoomFitToScreen: 'Fit to Screen',
       zoomFitToWidth: 'Fit to Width',
+      zoomFillScreen: 'Fill Screen',
       zoomOriginal: 'Original Size',
       keepZoom: 'Keep Zoom'
     };

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -346,11 +346,19 @@
     // Prevent scrollbars from appearing when in reader mode
     document.documentElement.style.overflow = 'hidden';
 
+    // The settings panel's "Offset spreads" button signals through this
+    // event (it has no access to reader internals). The old PixiJS reader
+    // was the listener; since its removal the button had dispatched into
+    // the void.
+    const onOffsetSpreads = () => offsetSpreads();
+    window.addEventListener('offset-spreads', onOffsetSpreads);
+
     return () => {
       // Stop activity tracker when component unmounts
       activityTracker.stop();
       // Restore overflow when leaving reader
       document.documentElement.style.overflow = '';
+      window.removeEventListener('offset-spreads', onOffsetSpreads);
     };
   });
 
@@ -949,13 +957,9 @@
   }
 
   function offsetSpreads() {
-    if ($settings.continuousScroll) {
-      // In continuous mode, ContinuousScrollReader handles it via custom event
-      window.dispatchEvent(new CustomEvent('offset-spreads'));
-    } else if (volume) {
-      // In paged mode, toggle hasCover to shift spread pairing
-      toggleHasCover(volume.volume_uuid);
-    }
+    // Shift spread pairing by toggling hasCover — the paged viewport and the
+    // horizontal scroll reader both derive their pairing from it.
+    if (volume) toggleHasCover(volume.volume_uuid);
     showNotification('Spreads Offset', 'offset-spreads');
   }
 

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -314,13 +314,15 @@
           showNotification(newVal ? 'Dividers On' : 'Dividers Off', 'page-dividers');
         }
         return;
-      case 'KeyT':
-        updateSetting('alwaysShowOCR', !$settings.alwaysShowOCR);
+      case 'KeyT': {
+        const next = !$settings.alwaysShowOCR;
+        updateSetting('alwaysShowOCR', next);
         showNotification(
-          $settings.alwaysShowOCR ? 'Always Show OCR: Off' : 'Always Show OCR: On',
+          next ? 'Always Show OCR: On' : 'Always Show OCR: Off',
           'always-show-ocr-toggle'
         );
         return;
+      }
       case 'KeyV':
         toggleContinuousScroll();
         return;
@@ -898,11 +900,11 @@
     }, 2000);
   }
 
-  // Shared toggle for the Manual/Scheduled display filters (night, invert, B&W).
-  // When the schedule owns the filter we only notify; otherwise we flip the
-  // manual boolean. This reproduces the original inline KeyI/KeyN handlers
-  // exactly, including reading $settings right after updateSetting for the
-  // On/Off label — keep this order and pattern; do not "simplify" it.
+  // Shared toggle for the Manual/Scheduled display filters (night, invert,
+  // B&W). When the schedule owns the filter we only notify; otherwise flip
+  // the manual boolean and announce the state we just wrote. (The old code
+  // re-read $settings after updateSetting expecting a stale value — the read
+  // is synchronous, so every toast announced the OPPOSITE state.)
   function toggleScheduledFilter(
     settingKey: 'nightMode' | 'invertColors' | 'grayscale',
     scheduleKey: ScheduleSettingKey,
@@ -912,11 +914,9 @@
     if ($settings[scheduleKey].enabled) {
       showNotification(`${label} is on automatic schedule`, `${notifPrefix}-scheduled`);
     } else {
-      updateSetting(settingKey, !$settings[settingKey]);
-      showNotification(
-        $settings[settingKey] ? `${label} Off` : `${label} On`,
-        `${notifPrefix}-toggle`
-      );
+      const next = !$settings[settingKey];
+      updateSetting(settingKey, next);
+      showNotification(next ? `${label} On` : `${label} Off`, `${notifPrefix}-toggle`);
     }
   }
 

--- a/src/lib/components/Reader/VerticalScrollReader.svelte
+++ b/src/lib/components/Reader/VerticalScrollReader.svelte
@@ -71,15 +71,15 @@
         height: `${page.img_height * scale}px`
       };
     }
-    // zoomFillScreen (default; legacy persisted zoomFitToWidth lands here) —
-    // fill the non-limiting axis: tall pages fill the viewport width exactly
-    // as fit-to-width did; wide spreads fill the height and overflow
-    // horizontally (pannable, centered by mx-auto).
-    const scale = Math.max(viewportWidth / page.img_width, viewportHeight / page.img_height);
+    // zoomFillScreen (default; legacy persisted zoomFitToWidth lands here).
+    // The strip axis always overflows in continuous mode, so filling the
+    // screen means filling the CROSS axis — the width here. In horizontal
+    // mode the same setting fills the height, which is what makes it safe
+    // under "match orientation" rotation (fit-to-width was not).
     return {
-      width: `${page.img_width * scale}px`,
-      maxWidth: `${page.img_width * scale}px`,
-      height: `${page.img_height * scale}px`
+      width: '100%',
+      maxWidth: '',
+      height: 'auto'
     };
   }
 
@@ -106,10 +106,7 @@
         const scale = Math.min(viewportWidth / page.img_width, viewportHeight / page.img_height);
         width = page.img_width * scale;
       } else {
-        // zoomFillScreen
-        width =
-          page.img_width *
-          Math.max(viewportWidth / page.img_width, viewportHeight / page.img_height);
+        width = viewportWidth; // zoomFillScreen — fills the cross axis
       }
       if (width > max) max = width;
     }

--- a/src/lib/components/Reader/VerticalScrollReader.svelte
+++ b/src/lib/components/Reader/VerticalScrollReader.svelte
@@ -71,11 +71,15 @@
         height: `${page.img_height * scale}px`
       };
     }
-    // zoomFitToWidth (default) — always fill viewport width, upscale if needed
+    // zoomFillScreen (default; legacy persisted zoomFitToWidth lands here) —
+    // fill the non-limiting axis: tall pages fill the viewport width exactly
+    // as fit-to-width did; wide spreads fill the height and overflow
+    // horizontally (pannable, centered by mx-auto).
+    const scale = Math.max(viewportWidth / page.img_width, viewportHeight / page.img_height);
     return {
-      width: '100%',
-      maxWidth: '',
-      height: 'auto'
+      width: `${page.img_width * scale}px`,
+      maxWidth: `${page.img_width * scale}px`,
+      height: `${page.img_height * scale}px`
     };
   }
 
@@ -102,7 +106,10 @@
         const scale = Math.min(viewportWidth / page.img_width, viewportHeight / page.img_height);
         width = page.img_width * scale;
       } else {
-        width = viewportWidth; // zoomFitToWidth
+        // zoomFillScreen
+        width =
+          page.img_width *
+          Math.max(viewportWidth / page.img_width, viewportHeight / page.img_height);
       }
       if (width > max) max = width;
     }

--- a/src/lib/components/Settings/Reader/ReaderSelects.svelte
+++ b/src/lib/components/Settings/Reader/ReaderSelects.svelte
@@ -13,6 +13,7 @@
   let zoomModes = [
     { value: 'zoomFitToScreen', name: 'Fit to screen' },
     { value: 'zoomFitToWidth', name: 'Fit to width' },
+    { value: 'zoomFillScreen', name: 'Fill screen' },
     { value: 'zoomOriginal', name: 'Original size' },
     { value: 'keepZoom', name: 'Keep zoom' }
   ];

--- a/src/lib/components/Settings/Reader/ReaderSelects.svelte
+++ b/src/lib/components/Settings/Reader/ReaderSelects.svelte
@@ -19,7 +19,7 @@
   ];
 
   let continuousZoomModes = [
-    { value: 'zoomFitToWidth', name: 'Fit to width' },
+    { value: 'zoomFillScreen', name: 'Fill screen' },
     { value: 'zoomFitToScreen', name: 'Fit to screen' },
     { value: 'zoomOriginal', name: 'Original size (1:1)' }
   ];

--- a/src/lib/reader/paged-camera.test.ts
+++ b/src/lib/reader/paged-camera.test.ts
@@ -65,8 +65,9 @@ describe('PagedCamera — base application', () => {
     const { camera } = makeCamera();
     camera.applyBase(tall, baseTransform('keepZoom', tall, viewport, true));
     camera.setUserZoom(2);
-    // RTL keepZoom: end-aligned X — at 2x (1260 wide, fits) lock stays flush right
-    expect(camera.translate.x).toBeCloseTo(1600 - 700 * 0.9 * 2, 4);
+    // At 2x the 1260px width still fits the 1600 viewport — fitting axes
+    // center (the old end-aligned lock welded the page to the right edge).
+    expect(camera.translate.x).toBeCloseTo((1600 - 700 * 0.9 * 2) / 2, 4);
     expect(camera.effectiveScale).toBeCloseTo(1.8, 6);
   });
 });
@@ -185,5 +186,58 @@ describe('PagedCamera — projectCentered (double-tap target)', () => {
     const p = camera.projectCentered({ x: 800, y: 20 }, 2);
     expect(p.x).toBeCloseTo(800, 4);
     expect(p.y).toBeCloseTo(450, 4);
+  });
+});
+
+describe('PagedCamera — fitting axes center (top-pin bug)', () => {
+  it('zoomOriginal: a page smaller than the viewport sits centered, not at the top corner', () => {
+    const { camera } = makeCamera();
+    const small = { width: 700, height: 800 };
+    camera.applyBase(small, baseTransform('zoomOriginal', small, viewport, true));
+    expect(camera.translate.x).toBeCloseTo((1600 - 700) / 2, 4);
+    expect(camera.translate.y).toBeCloseTo((900 - 800) / 2, 4);
+  });
+
+  it('keepZoom: zooming below an axis fit re-centers that axis instead of pinning it', () => {
+    const { camera } = makeCamera();
+    camera.applyBase(tall, baseTransform('keepZoom', tall, viewport, true));
+    // base 0.9 → scaled 630x900; zoom to 0.8 → 504x720, both axes fit
+    camera.setUserZoom(0.8);
+    expect(camera.translate.x).toBeCloseTo((1600 - 700 * 0.9 * 0.8) / 2, 4);
+    expect(camera.translate.y).toBeCloseTo((900 - 1000 * 0.9 * 0.8) / 2, 4);
+  });
+
+  it('zoomOriginal: an overflowing page still starts reading at the top and pans freely', () => {
+    const { camera } = makeCamera();
+    const big = { width: 2000, height: 2800 };
+    camera.applyBase(big, baseTransform('zoomOriginal', big, viewport, true));
+    expect(camera.translate.y).toBe(0); // reading start
+    expect(camera.translate.x).toBe(1600 - 2000); // RTL right edge visible
+    camera.adjustView(0, 500); // pan down
+    expect(camera.translate.y).toBe(-500); // NOT snapped back to the top
+  });
+});
+
+describe('PagedCamera — fillScreen mode', () => {
+  it('tall page: width fills exactly, height overflows from the top', () => {
+    const { camera } = makeCamera();
+    camera.applyBase(tall, baseTransform('zoomFillScreen', tall, viewport, true));
+    const scale = 1600 / 700;
+    expect(camera.effectiveScale).toBeCloseTo(scale, 6);
+    expect(camera.translate.x).toBeCloseTo(0, 4);
+    expect(camera.translate.y).toBe(0);
+    camera.adjustView(0, 300);
+    expect(camera.translate.y).toBe(-300); // overflowing height is pannable
+  });
+
+  it('wide spread: height fills exactly, width overflows at the RTL reading corner', () => {
+    const { camera } = makeCamera();
+    const wide = { width: 3200, height: 900 };
+    camera.applyBase(wide, baseTransform('zoomFillScreen', wide, viewport, true));
+    expect(camera.effectiveScale).toBeCloseTo(1, 6);
+    expect(camera.translate.x).toBe(1600 - 3200);
+    expect(camera.translate.y).toBeCloseTo(0, 4);
+    camera.adjustView(-400, 0);
+    expect(camera.translate.x).toBe(1600 - 3200 + 400);
   });
 });

--- a/src/lib/reader/paged-camera.ts
+++ b/src/lib/reader/paged-camera.ts
@@ -8,15 +8,15 @@
  *
  * Invariant: clamping runs after EVERY mutation (scale-only writes shrink
  * the bounds before any correction arrives, and anchorless paths never call
- * correctView at all). Axes where the scaled content fits lock to the mode's
- * alignment recomputed from the current scaled size. Clamping is gated by
+ * correctView at all). Axes where the scaled content fits center at the
+ * current scaled size. Clamping is gated by
  * the user's bounds/mobile settings — disabled means free panning, exactly
  * like the old keepInBounds no-op.
  */
 
 import { Animator } from './animator';
 import {
-  alignPosition,
+  basePosition,
   clampTranslate,
   panEdgeState,
   type BaseLayout,
@@ -89,13 +89,13 @@ export class PagedCamera {
     this.place();
   }
 
-  /** Re-place the view at the base alignment for the current user zoom. */
+  /** Re-place the view at the base placement for the current user zoom. */
   place(): void {
     this.stopPan();
     const scaled = this.scaledSize();
     const viewport = this.config.getViewport();
-    this.tx = alignPosition(this.base.alignX, scaled.width, viewport.width);
-    this.ty = alignPosition(this.base.alignY, scaled.height, viewport.height);
+    this.tx = basePosition(this.base.alignX, scaled.width, viewport.width);
+    this.ty = basePosition(this.base.alignY, scaled.height, viewport.height);
     this.clampAndRender(true);
     // A freshly placed page is at rest — settle so the alignment position is
     // device-pixel rounded (#65 applies before any gesture too).
@@ -182,9 +182,7 @@ export class PagedCamera {
       x: viewport.width / 2 - c.x * sNext,
       y: viewport.height / 2 - c.y * sNext
     };
-    const t = this.config.isClampingEnabled()
-      ? clampTranslate(want, scaled, viewport, { x: this.base.alignX, y: this.base.alignY })
-      : want;
+    const t = this.config.isClampingEnabled() ? clampTranslate(want, scaled, viewport) : want;
     return { x: c.x * sNext + t.x, y: c.y * sNext + t.y };
   }
 
@@ -207,10 +205,7 @@ export class PagedCamera {
 
   private clamped(translate: Translate): Translate {
     if (!this.config.isClampingEnabled() || !this.content) return translate;
-    return clampTranslate(translate, this.scaledSize(), this.config.getViewport(), {
-      x: this.base.alignX,
-      y: this.base.alignY
-    });
+    return clampTranslate(translate, this.scaledSize(), this.config.getViewport());
   }
 
   private clampAndRender(resyncPan: boolean): void {

--- a/src/lib/reader/paged-zoom-layout.test.ts
+++ b/src/lib/reader/paged-zoom-layout.test.ts
@@ -34,27 +34,39 @@ describe('baseTransform', () => {
     expect(t.alignY).toBe('start');
   });
 
-  it('original is 1:1 at the reading-start corner (RTL → right)', () => {
+  it('original is 1:1; fitting axes center, overflowing axes start at the top', () => {
+    // tall: width (700) fits the 1600 viewport → centered, never pinned to
+    // the corner; height (1000) overflows the 900 viewport → reading start.
     const t = baseTransform('zoomOriginal', tall, viewport, true);
     expect(t.scale).toBe(1);
-    expect(t.x).toBe(1600 - 700);
+    expect(t.x).toBe((1600 - 700) / 2);
     expect(t.y).toBe(0);
     expect(t.alignX).toBe('end');
     expect(t.alignY).toBe('start');
   });
 
-  it('original is 1:1 at the left corner in LTR', () => {
-    const t = baseTransform('zoomOriginal', tall, viewport, false);
-    expect(t.scale).toBe(1);
-    expect(t.x).toBe(0);
-    expect(t.alignX).toBe('start');
+  it('original: an overflowing width starts at the reading corner (RTL → right edge)', () => {
+    const wide = { width: 2400, height: 800 };
+    const rtl = baseTransform('zoomOriginal', wide, viewport, true);
+    expect(rtl.x).toBe(1600 - 2400); // right edge of the spread visible
+    const ltr = baseTransform('zoomOriginal', wide, viewport, false);
+    expect(ltr.x).toBe(0); // left edge visible
+    // height fits → centered, not pinned to the top
+    expect(rtl.y).toBe((900 - 800) / 2);
   });
 
-  it('keepZoom uses a fit-to-screen base scale at the reading-start corner', () => {
+  it('original: a page smaller than the viewport centers on both axes', () => {
+    const small = { width: 700, height: 800 };
+    const t = baseTransform('zoomOriginal', small, viewport, true);
+    expect(t.x).toBe((1600 - 700) / 2);
+    expect(t.y).toBe((900 - 800) / 2);
+  });
+
+  it('keepZoom uses a fit-to-screen base scale; fitting width centers', () => {
     const t = baseTransform('keepZoom', tall, viewport, true);
     expect(t.scale).toBeCloseTo(0.9, 6);
-    expect(t.x).toBeCloseTo(1600 - 700 * 0.9, 6);
-    expect(t.y).toBe(0);
+    expect(t.x).toBeCloseTo((1600 - 700 * 0.9) / 2, 6);
+    expect(t.y).toBe(0); // height fits exactly — center == top
   });
 
   it('treats legacy keepZoom aliases like keepZoom', () => {
@@ -63,6 +75,33 @@ describe('baseTransform', () => {
     const k = baseTransform('keepZoom', tall, viewport, true);
     expect(a).toEqual(k);
     expect(b).toEqual(k);
+  });
+
+  it('fillScreen on a tall page fills the width and overflows the height, top-aligned', () => {
+    const t = baseTransform('zoomFillScreen', tall, viewport, true);
+    expect(t.scale).toBeCloseTo(1600 / 700, 6); // max(1600/700, 900/1000)
+    expect(t.x).toBeCloseTo(0, 6); // width fills exactly
+    expect(t.y).toBe(0); // overflowing height starts at the top
+    expect(t.alignY).toBe('start');
+  });
+
+  it('fillScreen on a wide spread fills the height and overflows the width at the reading corner', () => {
+    const wide = { width: 3200, height: 900 };
+    const rtl = baseTransform('zoomFillScreen', wide, viewport, true);
+    expect(rtl.scale).toBeCloseTo(1, 6); // max(0.5, 1)
+    expect(rtl.y).toBeCloseTo(0, 6); // height fills exactly
+    expect(rtl.x).toBe(1600 - 3200); // RTL reading start — right edge visible
+    const ltr = baseTransform('zoomFillScreen', wide, viewport, false);
+    expect(ltr.x).toBe(0);
+  });
+
+  it('fillScreen matches fit-to-screen when aspects match', () => {
+    const matching = { width: 3200, height: 1800 };
+    const fill = baseTransform('zoomFillScreen', matching, viewport, true);
+    const fit = baseTransform('zoomFitToScreen', matching, viewport, true);
+    expect(fill.scale).toBeCloseTo(fit.scale, 6);
+    expect(fill.x).toBeCloseTo(fit.x, 6);
+    expect(fill.y).toBeCloseTo(fit.y, 6);
   });
 
   it('guards zero-size content', () => {
@@ -82,38 +121,30 @@ describe('alignPosition', () => {
 });
 
 describe('clampTranslate', () => {
-  const align = { x: 'center', y: 'start' } as const;
-
-  it('locks a fitting axis to the alignment recomputed from the CURRENT scaled size', () => {
+  it('centers a fitting axis at the CURRENT scaled size', () => {
     // fitToScreen tall page zoomed to 1.5x: width 1134 still fits 1600 —
     // the lock must center the *scaled* width, not reuse the level-1 position.
-    const clamped = clampTranslate({ x: -400, y: -500 }, { width: 1134, height: 1350 }, viewport, {
-      x: 'center',
-      y: 'center'
-    });
+    const clamped = clampTranslate({ x: -400, y: -500 }, { width: 1134, height: 1350 }, viewport);
     expect(clamped.x).toBeCloseTo((1600 - 1134) / 2, 6);
     expect(clamped.y).toBe(-450); // overflowing axis clamps to [900-1350, 0]
   });
 
-  it('keeps an end-aligned fitting axis flush to the edge at any zoom (RTL original)', () => {
-    // RTL zoomOriginal, 500px page at 1.5x = 750: must lock to 1600-750,
-    // keeping the right edge at the viewport edge — never past it.
-    const clamped = clampTranslate({ x: 1100, y: 0 }, { width: 750, height: 900 }, viewport, {
-      x: 'end',
-      y: 'start'
-    });
-    expect(clamped.x).toBe(1600 - 750);
-    expect(clamped.y).toBe(0);
+  it('centers fitting axes in every mode — a fitting page can never pin to an edge', () => {
+    // The old behavior locked fitting axes to the mode alignment, welding
+    // zoomOriginal/keepZoom pages to the top corner (the reported bug).
+    const clamped = clampTranslate({ x: 1100, y: 700 }, { width: 750, height: 600 }, viewport);
+    expect(clamped.x).toBe((1600 - 750) / 2);
+    expect(clamped.y).toBe((900 - 600) / 2);
   });
 
   it('clamps an overflowing axis so content edges never pass viewport edges', () => {
     const scaled = { width: 3200, height: 1800 };
-    expect(clampTranslate({ x: 50, y: 10 }, scaled, viewport, align)).toEqual({ x: 0, y: 0 });
-    expect(clampTranslate({ x: -2000, y: -1000 }, scaled, viewport, align)).toEqual({
+    expect(clampTranslate({ x: 50, y: 10 }, scaled, viewport)).toEqual({ x: 0, y: 0 });
+    expect(clampTranslate({ x: -2000, y: -1000 }, scaled, viewport)).toEqual({
       x: 1600 - 3200,
       y: 900 - 1800
     });
-    expect(clampTranslate({ x: -800, y: -400 }, scaled, viewport, align)).toEqual({
+    expect(clampTranslate({ x: -800, y: -400 }, scaled, viewport)).toEqual({
       x: -800,
       y: -400
     });
@@ -123,8 +154,7 @@ describe('clampTranslate', () => {
     const clamped = clampTranslate(
       { x: NaN, y: Infinity },
       { width: 3200, height: 1800 },
-      viewport,
-      align
+      viewport
     );
     expect(Number.isFinite(clamped.x)).toBe(true);
     expect(Number.isFinite(clamped.y)).toBe(true);

--- a/src/lib/reader/paged-zoom-layout.ts
+++ b/src/lib/reader/paged-zoom-layout.ts
@@ -7,10 +7,12 @@
  * scale and the camera clamps panning so content edges never drift past the
  * viewport edges (replacing the old panzoom keepInBounds()).
  *
- * Axes where the scaled content fits inside the viewport lock to the mode's
- * ALIGNMENT RULE recomputed from the current scaled size — never to the
- * level-1 position, which would mis-place every zoomed frame where an axis
- * still fits (and, end-aligned, push content past the viewport edge).
+ * Per-axis placement: an axis where the scaled content FITS the viewport is
+ * always centered (recomputed from the current scaled size — never the
+ * level-1 position); an axis that OVERFLOWS starts at the mode's alignment
+ * rule, i.e. the reading start (top, or the RTL/LTR corner). The alignment
+ * never locks fitting axes to an edge — that welded zoomOriginal/keepZoom
+ * pages to the top corner.
  *
  * The e2e suite imports this module through the Vite dev server and drives
  * the real functions — keep it free of Svelte and component state.
@@ -37,6 +39,7 @@ export interface BaseLayout extends Translate {
 export type PagedZoomMode =
   | 'zoomFitToScreen'
   | 'zoomFitToWidth'
+  | 'zoomFillScreen'
   | 'zoomOriginal'
   | 'keepZoom'
   // Legacy persisted aliases (localStorage / synced profiles) — keepZoom.
@@ -54,15 +57,28 @@ export function alignPosition(align: Align, scaled: number, viewport: number): n
 }
 
 /**
+ * Placement of one axis: centered when the scaled content fits, at the
+ * mode's reading-start rule when it overflows.
+ */
+export function basePosition(align: Align, scaled: number, viewport: number): number {
+  if (scaled <= viewport + EDGE_EPSILON) return (viewport - scaled) / 2;
+  return alignPosition(align, scaled, viewport);
+}
+
+/**
  * The mode's fitted layout for the displayed content: base scale, the level-1
  * position, and the per-axis alignment rules that fitting axes lock to at any
  * user zoom.
  *
  * - fit-to-screen: limiting-axis fit, centered both axes
- * - fit-to-width: fill viewport width, top-aligned
- * - original: 1:1 at the reading-start corner (right in RTL), top-aligned
- * - keepZoom (+legacy aliases): fit-to-screen scale at the reading-start
- *   corner — the preserved effective scale multiplies this base across pages
+ * - fit-to-width: fill viewport width; an overflowing height starts at the top
+ * - fill-screen: fill the non-limiting axis — tall pages fit the width, wide
+ *   spreads fit the height; the overflowing axis starts at the reading corner
+ * - original: 1:1; overflowing axes start at the reading corner (right in RTL)
+ * - keepZoom (+legacy aliases): fit-to-screen base scale, reading-corner
+ *   overflow — the preserved effective scale multiplies this base across pages
+ *
+ * Alignment rules place OVERFLOWING axes only; fitting axes always center.
  *
  * Accepts arbitrary strings because zoom modes are persisted in localStorage
  * and synced profiles that may carry values from other app versions; unknown
@@ -91,6 +107,11 @@ export function baseTransform(
       alignX = 'center';
       alignY = 'start';
       break;
+    case 'zoomFillScreen':
+      scale = Math.max(viewport.width / content.width, viewport.height / content.height);
+      alignX = corner;
+      alignY = 'start';
+      break;
     case 'zoomOriginal':
       scale = 1;
       alignX = corner;
@@ -115,32 +136,33 @@ export function baseTransform(
     scale,
     alignX,
     alignY,
-    x: alignPosition(alignX, content.width * scale, viewport.width),
-    y: alignPosition(alignY, content.height * scale, viewport.height)
+    x: basePosition(alignX, content.width * scale, viewport.width),
+    y: basePosition(alignY, content.height * scale, viewport.height)
   };
 }
 
 /**
  * Clamp a translate so content edges never pass viewport edges. Axes where
- * the scaled content fits lock to their alignment position at the current
- * scaled size. Non-finite inputs collapse into bounds — a NaN write would
- * teleport the camera.
+ * the scaled content fits center at the current scaled size — they are not
+ * pannable, and centering (rather than the mode's reading-start rule) is
+ * what keeps zoomOriginal/keepZoom pages from welding to the top corner.
+ * Non-finite inputs collapse into bounds — a NaN write would teleport the
+ * camera.
  */
 export function clampTranslate(
   translate: Translate,
   scaledContent: Size,
-  viewport: Size,
-  align: { x: Align; y: Align }
+  viewport: Size
 ): Translate {
-  const clampAxis = (value: number, scaled: number, view: number, rule: Align): number => {
-    if (scaled <= view + EDGE_EPSILON) return alignPosition(rule, scaled, view);
-    const v = Number.isFinite(value) ? value : alignPosition(rule, scaled, view);
+  const clampAxis = (value: number, scaled: number, view: number): number => {
+    if (scaled <= view + EDGE_EPSILON) return (view - scaled) / 2;
+    const v = Number.isFinite(value) ? value : 0;
     return Math.max(view - scaled, Math.min(0, v));
   };
 
   return {
-    x: clampAxis(translate.x, scaledContent.width, viewport.width, align.x),
-    y: clampAxis(translate.y, scaledContent.height, viewport.height, align.y)
+    x: clampAxis(translate.x, scaledContent.width, viewport.width),
+    y: clampAxis(translate.y, scaledContent.height, viewport.height)
   };
 }
 

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -28,7 +28,7 @@ export type ZoomModes =
   | 'keepZoom';
 
 // Continuous scroll mode only supports the basic zoom modes (no keep zoom variants)
-export type ContinuousZoomMode = 'zoomFitToScreen' | 'zoomFitToWidth' | 'zoomOriginal';
+export type ContinuousZoomMode = 'zoomFitToScreen' | 'zoomFillScreen' | 'zoomOriginal';
 
 export type ScrollMode = 'vertical' | 'horizontal' | 'auto' | 'continuous';
 
@@ -494,6 +494,12 @@ export function migrateProfiles(profiles: Profiles): Profiles {
         base: 'dark',
         background: profile.backgroundColor
       };
+    }
+
+    // Legacy: continuous fit-to-width was replaced by fill-screen (identical
+    // for tall pages; wide spreads now fit the height instead of shrinking).
+    if ((migratedProfile.continuousZoomDefault as string) === 'zoomFitToWidth') {
+      migratedProfile.continuousZoomDefault = 'zoomFillScreen';
     }
 
     // Add timestamp if missing

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -20,7 +20,12 @@ export type FontSize =
   | '48'
   | '60';
 
-export type ZoomModes = 'zoomFitToScreen' | 'zoomFitToWidth' | 'zoomOriginal' | 'keepZoom';
+export type ZoomModes =
+  | 'zoomFitToScreen'
+  | 'zoomFitToWidth'
+  | 'zoomFillScreen'
+  | 'zoomOriginal'
+  | 'keepZoom';
 
 // Continuous scroll mode only supports the basic zoom modes (no keep zoom variants)
 export type ContinuousZoomMode = 'zoomFitToScreen' | 'zoomFitToWidth' | 'zoomOriginal';

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -496,8 +496,9 @@ export function migrateProfiles(profiles: Profiles): Profiles {
       };
     }
 
-    // Legacy: continuous fit-to-width was replaced by fill-screen (identical
-    // for tall pages; wide spreads now fit the height instead of shrinking).
+    // Legacy: continuous fit-to-width was replaced by fill-screen, which
+    // fills the cross axis of the scroll direction — identical in vertical
+    // mode, but correct (height-fill) when rotation lands in horizontal.
     if ((migratedProfile.continuousZoomDefault as string) === 'zoomFitToWidth') {
       migratedProfile.continuousZoomDefault = 'zoomFillScreen';
     }


### PR DESCRIPTION
## Bug fix: pages welded to the top corner in Keep Zoom / Original Size

The paged mode's alignment rule served two roles: base placement on page turns AND the clamp lock for axes where the scaled content fits the viewport. Keep Zoom and Original Size use `start`/reading-corner alignment, so any fitting axis was hard-locked to the top corner — pages smaller than the viewport (or zoomed below an axis fit) were pinned there and could not be panned or centered.

Fix: **fitting axes always center** (exactly the behavior Fit to Screen already had), recomputed from the current scaled size. The mode alignment now only places **overflowing** axes, which keeps the reading-start semantics intact: top of the page first, RTL/LTR reading corner first. `clampTranslate` drops its `align` parameter entirely — centering is universal, not a mode choice.

## New mode: Fill screen

`zoomFillScreen` fills the non-limiting axis and overflows the other (`scale = max(fitWidth, fitHeight)`):
- pages/spreads **taller** than the viewport → fit to width, pan vertically from the top
- pages/spreads **wider** than the viewport → fit to height, pan from the reading corner

Wired through settings (`ZoomModes`), the zoom dropdown ("Fill screen", after "Fit to width"), and the Z-key rotation. The dynamic level ladder's fit-floor and double-tap escape-to-fit work unchanged — double-tap still drops to the whole-page view.

## Verification

- 651 unit tests (15 new: layout centering + fillScreen cases, camera top-pin regressions), svelte-check clean
- 13 e2e (2 new: fillScreen fill/pan/center behavior; zoomOriginal small-page centering)
- 10-scenario real-app pass with trusted input: keepZoom centering at fit and pan-stick when zoomed, Original Size reading-start + free pan, Fill screen width-fill / bottom-edge clamp / double-tap-to-fit, and the full Z-key rotation cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)