### PR TITLE
feat(reader): restore inertial panning to paged mode

### DIFF
--- a/src/lib/components/Reader/PagedViewport.svelte
+++ b/src/lib/components/Reader/PagedViewport.svelte
@@ -212,20 +212,35 @@
     onPress: () => {
       motion.beforeManualPan();
       edgeAtPress = camera.edgeState();
+      // Track the drag for an inertial fling on release.
+      camera.kineticStart();
     },
     onPanMove: (_p, d) => camera.adjustView(-d.dx, -d.dy),
     onPanEnd: (s) => {
-      if (s.panned) camera.settle();
-      if (!$settings.mobile) return;
-      const side = classifySwipe({
-        summary: s,
-        wasPinch: tracker.wasPinch,
-        viewport: { width: viewportWidth, height: viewportHeight },
-        thresholdPercent: $settings.swipeThreshold,
-        canRevealLeftAtStart: edgeAtPress.canRevealLeft,
-        canRevealRightAtStart: edgeAtPress.canRevealRight
-      });
-      if (side) onPageFlip?.(side);
+      const side =
+        $settings.mobile && !s.cancelled
+          ? classifySwipe({
+              summary: s,
+              wasPinch: tracker.wasPinch,
+              viewport: { width: viewportWidth, height: viewportHeight },
+              thresholdPercent: $settings.swipeThreshold,
+              canRevealLeftAtStart: edgeAtPress.canRevealLeft,
+              canRevealRightAtStart: edgeAtPress.canRevealRight
+            })
+          : null;
+      if (side) {
+        // The gesture flipped the page — the new page re-applies its base,
+        // so drop any momentum rather than flinging the outgoing page.
+        camera.stopPan();
+        onPageFlip?.(side);
+      } else if (s.cancelled) {
+        // OS-cancelled gesture: drop the momentum and settle in place.
+        camera.stopPan();
+        camera.settle();
+      } else {
+        // Normal release: glide with inertia (or settle if too slow).
+        camera.kineticStop();
+      }
     },
     // The finger remaining after a pinch keeps panning (the old panzoom
     // pinch→drag handoff) — safe here because deltas are incremental.

--- a/src/lib/reader/animator.ts
+++ b/src/lib/reader/animator.ts
@@ -23,6 +23,11 @@ export function setInstantAnimations(instant: boolean): void {
   instantMode = instant;
 }
 
+/** Whether reader animations are in instant mode (e-ink "disable animations"). */
+export function areAnimationsInstant(): boolean {
+  return instantMode;
+}
+
 export class Animator {
   current: number;
   target: number;

--- a/src/lib/reader/kinetic.test.ts
+++ b/src/lib/reader/kinetic.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createKinetic } from './kinetic';
+
+/**
+ * Drives the kinetic tracker deterministically: a manual rAF queue and a
+ * manual clock, so we can step the track loop and the decay loop frame by
+ * frame the way panzoom's kinetic.js ran on real rAF + Date.now.
+ */
+function harness() {
+  let clock = 0;
+  const queue: Array<(t?: number) => void> = [];
+  const raf = (cb: (t?: number) => void) => {
+    queue.push(cb);
+    return queue.length;
+  };
+  const caf = (id: number) => {
+    queue[id - 1] = () => {};
+  };
+  const now = () => clock;
+  let point = { x: 0, y: 0 };
+  const scrolled: Array<{ x: number; y: number }> = [];
+  const k = createKinetic(
+    () => point,
+    (x, y) => {
+      // Mirror the real consumer: a scroll moves the surface, so getPoint()
+      // reflects it on the next frame (the camera sets tx/ty here).
+      point = { x, y };
+      scrolled.push({ x, y });
+    },
+    { requestAnimationFrame: raf, cancelAnimationFrame: caf, now }
+  );
+  // Run exactly the callbacks queued right now (one "frame"), advancing the
+  // clock first, the way the browser would before firing rAF callbacks.
+  function frame(dtMs = 16) {
+    clock += dtMs;
+    const batch = queue.splice(0);
+    for (const cb of batch) cb(clock);
+  }
+  return {
+    k,
+    frame,
+    scrolled,
+    setPoint: (x: number, y: number) => (point = { x, y }),
+    get clock() {
+      return clock;
+    }
+  };
+}
+
+describe('createKinetic', () => {
+  it('does not fling when the surface was held still before release (below minVelocity)', () => {
+    const h = harness();
+    const onDone = vi.fn();
+    h.setPoint(100, 100); // resting offset before the gesture
+    h.k.start();
+    // pressed and held: the offset never changes, so velocity stays ~0
+    for (let i = 0; i < 5; i++) {
+      h.setPoint(100, 100);
+      h.frame();
+    }
+    h.k.stop(onDone);
+    expect(h.scrolled.length).toBe(0); // no glide
+    expect(onDone).toHaveBeenCalledTimes(1); // settles immediately, no autoScroll
+  });
+
+  it('flings past the release point and decays to a stop, then signals done', () => {
+    const h = harness();
+    const onDone = vi.fn();
+    h.k.start();
+    // fast drag: 40px/frame to the right for 5 frames → release at x=200
+    for (let i = 1; i <= 5; i++) {
+      h.setPoint(i * 40, 0);
+      h.frame();
+    }
+    const releaseX = 200;
+    h.k.stop(onDone);
+
+    let maxX = releaseX;
+    for (let i = 0; i < 200 && onDone.mock.calls.length === 0; i++) {
+      h.frame();
+      if (h.scrolled.length) maxX = Math.max(maxX, h.scrolled[h.scrolled.length - 1].x);
+    }
+    // glided forward past the release point
+    expect(maxX).toBeGreaterThan(releaseX + 10);
+    // and came to rest (done fired)
+    expect(onDone).toHaveBeenCalledTimes(1);
+    // monotonic decay: each glide step moves less than (or equal to) the prior
+    const steps = h.scrolled.map((s) => s.x);
+    for (let i = 2; i < steps.length; i++) {
+      expect(steps[i] - steps[i - 1]).toBeLessThanOrEqual(steps[i - 1] - steps[i - 2] + 1e-6);
+    }
+  });
+
+  it('flings on both axes independently', () => {
+    const h = harness();
+    h.k.start();
+    for (let i = 1; i <= 5; i++) {
+      h.setPoint(i * 30, i * -50);
+      h.frame();
+    }
+    h.k.stop();
+    h.frame();
+    expect(h.scrolled.length).toBeGreaterThan(0);
+    const last = h.scrolled[h.scrolled.length - 1];
+    expect(last.x).toBeGreaterThan(150); // glided right
+    expect(last.y).toBeLessThan(-250); // glided up
+  });
+
+  it('cancel() stops an in-flight glide and fires no further scrolls', () => {
+    const h = harness();
+    const onDone = vi.fn();
+    h.k.start();
+    for (let i = 1; i <= 5; i++) {
+      h.setPoint(i * 40, 0);
+      h.frame();
+    }
+    h.k.stop(onDone);
+    h.frame(); // one glide frame
+    const countAfterOne = h.scrolled.length;
+    h.k.cancel();
+    h.frame();
+    h.frame();
+    expect(h.scrolled.length).toBe(countAfterOne); // no more scrolls
+    expect(onDone).not.toHaveBeenCalled(); // cancel is not a natural finish
+  });
+
+  it('a fresh start() resets accumulated velocity (no carryover fling)', () => {
+    const h = harness();
+    h.k.start();
+    for (let i = 1; i <= 5; i++) {
+      h.setPoint(i * 40, 0);
+      h.frame();
+    }
+    // new gesture begins without releasing the old one
+    h.k.start();
+    h.setPoint(200, 0); // held still relative to the restart
+    h.frame();
+    h.setPoint(200, 0);
+    h.frame();
+    const onDone = vi.fn();
+    h.k.stop(onDone);
+    h.frame();
+    expect(h.scrolled.length).toBe(0); // stale velocity did not carry over
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createKinetic — clamp early-out', () => {
+  it('stops the glide promptly when the consumer pins it at a bound', () => {
+    let clock = 0;
+    const queue: Array<(t?: number) => void> = [];
+    const raf = (cb: (t?: number) => void) => {
+      queue.push(cb);
+      return queue.length;
+    };
+    const caf = (id: number) => {
+      queue[id - 1] = () => {};
+    };
+    let point = { x: 0, y: 0 };
+    const BOUND = 100; // the consumer refuses to scroll past x=100
+    const scrolled: number[] = [];
+    const k = createKinetic(
+      () => point,
+      (x) => {
+        const cx = Math.min(BOUND, x); // clamp like the camera does
+        point = { x: cx, y: 0 };
+        scrolled.push(cx);
+      },
+      { requestAnimationFrame: raf, cancelAnimationFrame: caf, now: () => clock }
+    );
+    function frame(dt = 16) {
+      clock += dt;
+      const batch = queue.splice(0);
+      for (const cb of batch) cb(clock);
+    }
+    k.start();
+    // hard fast fling to the right — would project well past the bound
+    for (let i = 1; i <= 5; i++) {
+      point = { x: i * 40, y: 0 };
+      frame();
+    }
+    point = { x: 100, y: 0 }; // already sitting at the bound on release
+    const onDone = vi.fn();
+    k.stop(onDone);
+    let frames = 0;
+    for (let i = 0; i < 200 && onDone.mock.calls.length === 0; i++) {
+      frame();
+      frames++;
+    }
+    expect(onDone).toHaveBeenCalledTimes(1);
+    // pinned at the bound, it must finish in a handful of frames, not the
+    // full ~150-frame (~2.5s) decay
+    expect(frames).toBeLessThan(10);
+    // never reported a position past the bound
+    expect(Math.max(...scrolled)).toBeLessThanOrEqual(BOUND);
+  });
+
+  it('a diagonal fling keeps gliding on the free axis after one axis pins', () => {
+    let clock = 0;
+    const queue: Array<(t?: number) => void> = [];
+    const raf = (cb: (t?: number) => void) => {
+      queue.push(cb);
+      return queue.length;
+    };
+    const caf = (id: number) => {
+      queue[id - 1] = () => {};
+    };
+    let point = { x: 0, y: 0 };
+    const X_BOUND = 60;
+    const seen: Array<{ x: number; y: number }> = [];
+    const k = createKinetic(
+      () => point,
+      (x, y) => {
+        point = { x: Math.min(X_BOUND, x), y };
+        seen.push({ ...point });
+      },
+      { requestAnimationFrame: raf, cancelAnimationFrame: caf, now: () => clock }
+    );
+    function frame(dt = 16) {
+      clock += dt;
+      const batch = queue.splice(0);
+      for (const cb of batch) cb(clock);
+    }
+    k.start();
+    for (let i = 1; i <= 5; i++) {
+      point = { x: i * 40, y: i * 40 };
+      frame();
+    }
+    point = { x: 60, y: 200 }; // x already at bound, y free
+    k.stop();
+    for (let i = 0; i < 200 && queue.length; i++) frame();
+    // y kept gliding past the release value even though x was pinned
+    expect(seen[seen.length - 1].y).toBeGreaterThan(220);
+    expect(Math.max(...seen.map((s) => s.x))).toBeLessThanOrEqual(X_BOUND);
+  });
+});

--- a/src/lib/reader/kinetic.ts
+++ b/src/lib/reader/kinetic.ts
@@ -1,0 +1,197 @@
+/**
+ * Kinetic ("inertial") panning — the momentum glide that follows a drag
+ * release, restored from the `panzoom` library (v9.4.3) we removed in the
+ * 1.7.0 paged-zoom rebuild. This is a faithful port of panzoom's kinetic.js,
+ * so paged-mode flings feel exactly as they did before: the same Apple-style
+ * exponential decay (amplitude 0.25 × velocity, time constant 342 ms,
+ * minimum launch velocity 5).
+ *
+ * Like the original, it polls the SURFACE OFFSET (not the pointer) on its own
+ * rAF "track" loop while a gesture is in progress, accumulating a smoothed
+ * velocity. On `stop()` it launches a decaying "autoScroll" glide toward a
+ * projected target. The consumer supplies getPoint()/scroll() over whatever
+ * coordinate space it owns (here, the paged camera's translate).
+ *
+ * rAF/clock are injectable so the glide is deterministically testable.
+ */
+
+export interface KineticPoint {
+  x: number;
+  y: number;
+}
+
+export interface KineticControls {
+  /** Begin tracking the surface offset (call at gesture start). */
+  start(): void;
+  /** Release: launch the momentum glide (or settle now if too slow). */
+  stop(onDone?: () => void): void;
+  /** Abort tracking and any glide immediately (no onDone). */
+  cancel(): void;
+}
+
+export interface KineticOptions {
+  minVelocity?: number;
+  amplitude?: number;
+  timeConstant?: number;
+  requestAnimationFrame?: (cb: (t?: number) => void) => number;
+  cancelAnimationFrame?: (id: number) => void;
+  now?: () => number;
+}
+
+export function createKinetic(
+  getPoint: () => KineticPoint,
+  scroll: (x: number, y: number) => void,
+  options: KineticOptions = {}
+): KineticControls {
+  const minVelocity = options.minVelocity ?? 5;
+  const amplitude = options.amplitude ?? 0.25;
+  const timeConstant = options.timeConstant ?? 342;
+  const raf = options.requestAnimationFrame ?? ((cb) => requestAnimationFrame(cb));
+  const caf = options.cancelAnimationFrame ?? ((id) => cancelAnimationFrame(id));
+  const now = options.now ?? (() => performance.now());
+
+  let lastPoint: KineticPoint = { x: 0, y: 0 };
+  let timestamp = 0;
+  let vx = 0;
+  let vy = 0;
+  let ax = 0;
+  let ay = 0;
+  let targetX = 0;
+  let targetY = 0;
+  // Last position the glide actually reached (post-clamp) — used to detect a
+  // pin against a bound and finish early.
+  let lastScroll: KineticPoint = { x: 0, y: 0 };
+  let ticker: number | null = null;
+  let rafId: number | null = null;
+  let done: (() => void) | null = null;
+
+  function track(): void {
+    const t = now();
+    const elapsed = t - timestamp;
+    timestamp = t;
+
+    const current = getPoint();
+    const dx = current.x - lastPoint.x;
+    const dy = current.y - lastPoint.y;
+    lastPoint = current;
+
+    const dt = 1000 / (1 + elapsed);
+    // exponential moving average of velocity (px per normalized frame)
+    vx = 0.8 * dx * dt + 0.2 * vx;
+    vy = 0.8 * dy * dt + 0.2 * vy;
+
+    ticker = raf(track);
+  }
+
+  function autoScroll(): void {
+    const elapsed = now() - timestamp;
+    let moving = false;
+    let dx = 0;
+    let dy = 0;
+
+    if (ax) {
+      dx = -ax * Math.exp(-elapsed / timeConstant);
+      if (dx > 0.5 || dx < -0.5) moving = true;
+      else {
+        dx = 0;
+        ax = 0;
+      }
+    }
+    if (ay) {
+      dy = -ay * Math.exp(-elapsed / timeConstant);
+      if (dy > 0.5 || dy < -0.5) moving = true;
+      else {
+        dy = 0;
+        ay = 0;
+      }
+    }
+
+    if (moving) {
+      scroll(targetX + dx, targetY + dy);
+      // The consumer clamps each frame, so a fling into a hard bound pins the
+      // offset while the unclamped decay still claims movement. Without this
+      // check the loop would spin the full ~2.5s decay writing an identical
+      // transform every frame. Finish once every still-decaying axis is pinned
+      // (a free axis keeps gliding — a diagonal fling into one wall continues
+      // along the other).
+      const after = getPoint();
+      const pinnedX = !ax || Math.abs(after.x - lastScroll.x) < 0.01;
+      const pinnedY = !ay || Math.abs(after.y - lastScroll.y) < 0.01;
+      lastScroll = after;
+      if (pinnedX && pinnedY) {
+        rafId = null;
+        const onDone = done;
+        done = null;
+        onDone?.();
+        return;
+      }
+      rafId = raf(autoScroll);
+    } else {
+      rafId = null;
+      const onDone = done;
+      done = null;
+      onDone?.();
+    }
+  }
+
+  function start(): void {
+    cancel();
+    lastPoint = getPoint();
+    ax = ay = vx = vy = 0;
+    timestamp = now();
+    ticker = raf(track);
+  }
+
+  function stop(onDone?: () => void): void {
+    if (ticker !== null) {
+      caf(ticker);
+      ticker = null;
+    }
+    if (rafId !== null) {
+      caf(rafId);
+      rafId = null;
+    }
+    done = onDone ?? null;
+
+    const current = getPoint();
+    targetX = current.x;
+    targetY = current.y;
+    lastScroll = current;
+    timestamp = now();
+    ax = ay = 0;
+
+    if (vx < -minVelocity || vx > minVelocity) {
+      ax = amplitude * vx;
+      targetX += ax;
+    }
+    if (vy < -minVelocity || vy > minVelocity) {
+      ay = amplitude * vy;
+      targetY += ay;
+    }
+
+    if (ax || ay) {
+      rafId = raf(autoScroll);
+    } else {
+      // Too slow to fling — settle now (one fewer frame than the original,
+      // which bounced through a no-op autoScroll tick).
+      const onDoneNow = done;
+      done = null;
+      onDoneNow?.();
+    }
+  }
+
+  function cancel(): void {
+    if (ticker !== null) {
+      caf(ticker);
+      ticker = null;
+    }
+    if (rafId !== null) {
+      caf(rafId);
+      rafId = null;
+    }
+    done = null;
+    vx = vy = ax = ay = 0;
+  }
+
+  return { start, stop, cancel };
+}

--- a/src/lib/reader/paged-camera.test.ts
+++ b/src/lib/reader/paged-camera.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PagedCamera } from './paged-camera';
 import { baseTransform } from './paged-zoom-layout';
+import { setInstantAnimations } from './animator';
 
 const viewport = { width: 1600, height: 900 };
 
@@ -19,26 +20,37 @@ function makeCamera(opts?: { clamp?: boolean; dpr?: number }) {
   return { camera, wrapper };
 }
 
-/** Deterministic rAF pump for the pan Animators. */
-let rafQueue: FrameRequestCallback[] = [];
+/**
+ * Deterministic rAF pump for the pan Animators and the kinetic glide. Uses an
+ * id→callback map so cancelAnimationFrame actually removes a pending frame —
+ * the kinetic tracker cancels its poll loop on release, and a no-op caf would
+ * let the stale loop keep stamping the shared timestamp and freeze the glide.
+ */
+let rafMap = new Map<number, FrameRequestCallback>();
+let rafSeq = 0;
 let clock = 0;
 
 function pump(frames = 80, dt = 16.67) {
-  for (let i = 0; i < frames && rafQueue.length > 0; i++) {
+  for (let i = 0; i < frames && rafMap.size > 0; i++) {
     clock += dt;
-    const cbs = rafQueue.splice(0);
-    for (const cb of cbs) cb(clock);
+    const batch = [...rafMap];
+    rafMap.clear();
+    for (const [, cb] of batch) cb(clock);
   }
 }
 
 beforeEach(() => {
-  rafQueue = [];
+  rafMap = new Map();
+  rafSeq = 0;
   clock = 0;
   vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
-    rafQueue.push(cb);
-    return rafQueue.length;
+    const id = ++rafSeq;
+    rafMap.set(id, cb);
+    return id;
   });
-  vi.stubGlobal('cancelAnimationFrame', () => {});
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+    rafMap.delete(id);
+  });
   vi.spyOn(performance, 'now').mockImplementation(() => clock);
 });
 
@@ -239,5 +251,87 @@ describe('PagedCamera — fillScreen mode', () => {
     expect(camera.translate.y).toBeCloseTo(0, 4);
     camera.adjustView(-400, 0);
     expect(camera.translate.x).toBe(1600 - 3200 + 400);
+  });
+});
+
+describe('PagedCamera — inertial fling (kinetic)', () => {
+  // A big overflowing page so there's room to glide and a bound to hit.
+  const big = { width: 4000, height: 3000 };
+
+  function drag(camera: PagedCamera, stepX: number, stepY: number, frames: number) {
+    camera.kineticStart();
+    pump(1); // let the track loop arm
+    for (let i = 0; i < frames; i++) {
+      camera.adjustView(stepX, stepY); // pointer-space delta → content moves
+      pump(1); // a track sample for this frame
+    }
+  }
+
+  it('glides past the release point after a fast drag, then settles', () => {
+    const { camera } = makeCamera();
+    camera.applyBase(big, baseTransform('zoomOriginal', big, viewport, true));
+    // start centered-ish then drag up-left fast (content moves up/left)
+    const releaseY = camera.translate.y;
+    drag(camera, 0, 60, 6); // adjustView(0,60) → ty -= 60 each frame (content up)
+    const atRelease = camera.translate.y;
+    camera.kineticStop();
+    pump(120);
+    // glided further in the drag direction (ty decreased past release)
+    expect(camera.translate.y).toBeLessThan(atRelease);
+    expect(atRelease).toBeLessThan(releaseY);
+    // came to rest within bounds (ty in [view-scaled, 0])
+    expect(camera.translate.y).toBeGreaterThanOrEqual(900 - 3000 - 1);
+    expect(camera.translate.y).toBeLessThanOrEqual(0 + 1);
+  });
+
+  it('a fling never escapes the clamp bounds', () => {
+    const { camera } = makeCamera();
+    camera.applyBase(big, baseTransform('zoomOriginal', big, viewport, true));
+    drag(camera, 0, 600, 6); // huge upward velocity → would overshoot the bottom edge
+    camera.kineticStop();
+    pump(300);
+    // clamped to the bottom edge, not flung past it
+    expect(camera.translate.y).toBeGreaterThanOrEqual(900 - 3000 - 1);
+  });
+
+  it('does not fling when animations are instant (e-ink); just settles', () => {
+    setInstantAnimations(true);
+    try {
+      const { camera } = makeCamera();
+      camera.applyBase(big, baseTransform('zoomOriginal', big, viewport, true));
+      drag(camera, 0, 60, 6);
+      const atRelease = camera.translate.y;
+      camera.kineticStop();
+      pump(120);
+      expect(camera.translate.y).toBe(atRelease); // no glide
+    } finally {
+      setInstantAnimations(false);
+    }
+  });
+
+  it('an explicit panBy (wheel/keyboard scroll) cancels an in-flight glide', () => {
+    const { camera } = makeCamera();
+    camera.applyBase(big, baseTransform('zoomOriginal', big, viewport, true));
+    drag(camera, 0, 60, 6);
+    camera.kineticStop();
+    pump(2); // glide a couple frames (fling still has momentum)
+    const mid = camera.translate.y;
+    camera.panBy(0, -100); // wheel scroll up arrives mid-fling
+    pump(120); // run the panBy animation to completion
+    // The view lands at the panBy target (mid - 100), proving the fling was
+    // cancelled — had it kept gliding it would be far more negative than that.
+    expect(camera.translate.y).toBeCloseTo(mid - 100, 0);
+  });
+
+  it('stopPan cancels an in-flight glide (a new press wins)', () => {
+    const { camera } = makeCamera();
+    camera.applyBase(big, baseTransform('zoomOriginal', big, viewport, true));
+    drag(camera, 0, 60, 6);
+    camera.kineticStop();
+    pump(2); // glide a couple frames
+    const mid = camera.translate.y;
+    camera.stopPan(); // new gesture interrupts
+    pump(60);
+    expect(camera.translate.y).toBe(mid); // frozen where the glide was cut
   });
 });

--- a/src/lib/reader/paged-camera.ts
+++ b/src/lib/reader/paged-camera.ts
@@ -14,7 +14,8 @@
  * like the old keepInBounds no-op.
  */
 
-import { Animator } from './animator';
+import { Animator, areAnimationsInstant } from './animator';
+import { createKinetic, type KineticControls } from './kinetic';
 import {
   basePosition,
   clampTranslate,
@@ -42,6 +43,7 @@ export class PagedCamera {
   private ty = 0;
   private panX: Animator;
   private panY: Animator;
+  private kinetic: KineticControls;
 
   constructor(config: PagedCameraConfig) {
     this.config = config;
@@ -61,6 +63,40 @@ export class PagedCamera {
       },
       { factor: 0.22, epsilon: 0.5, onSettle: () => this.settle() }
     );
+    // Inertial panning (restored from panzoom's kinetic.js). It polls the
+    // live translate during a drag and, on release, glides it with momentum.
+    this.kinetic = createKinetic(
+      () => ({ x: this.tx, y: this.ty }),
+      (x, y) => {
+        const c = this.clamped({ x, y });
+        this.tx = c.x;
+        this.ty = c.y;
+        this.syncPan();
+        this.render();
+      }
+    );
+  }
+
+  /** Begin tracking for an inertial fling (call when a drag starts). */
+  kineticStart(): void {
+    if (areAnimationsInstant()) return;
+    this.kinetic.start();
+  }
+
+  /**
+   * Release a drag: glide with momentum if it was fast enough, otherwise
+   * settle. Animations-off (e-ink) skips the glide entirely.
+   */
+  kineticStop(): void {
+    if (areAnimationsInstant()) {
+      // If 'disable animations' flipped on mid-drag, the track() poll loop is
+      // still armed from kineticStart(); cancel it so it doesn't reschedule
+      // itself forever (this branch never reaches kinetic.stop()).
+      this.kinetic.cancel();
+      this.settle();
+      return;
+    }
+    this.kinetic.stop(() => this.settle());
   }
 
   get translate(): Translate {
@@ -121,15 +157,20 @@ export class PagedCamera {
 
   /** Smoothly pan by a delta (arrow keys, wheel-pan). Targets are clamped. */
   panBy(dx: number, dy: number): void {
+    // An explicit animated pan (wheel/keyboard) supersedes inertial momentum;
+    // cancel the glide so the two don't fight over the translate. (The pan
+    // animators are left running so successive wheel pans still chain.)
+    this.kinetic.cancel();
     const target = this.clamped({ x: this.panX.target + dx, y: this.panY.target + dy });
     this.panX.setTarget(target.x);
     this.panY.setTarget(target.y);
   }
 
-  /** Stop pan animations, keeping the current position. */
+  /** Stop pan animations and any inertial glide, keeping the current position. */
   stopPan(): void {
     this.panX.stop();
     this.panY.stop();
+    this.kinetic.cancel();
     this.syncPan();
   }
 
@@ -201,6 +242,7 @@ export class PagedCamera {
   destroy(): void {
     this.panX.destroy();
     this.panY.destroy();
+    this.kinetic.cancel();
   }
 
   private clamped(translate: Translate): Translate {


### PR DESCRIPTION
## What

Paged mode lost its drag-release **momentum** in the 1.7.0 panzoom→PagedCamera rebuild — releasing a pan stopped dead. This restores it.

The fling is a faithful port of the `panzoom` library's `kinetic.js` (the exact code we removed) into `src/lib/reader/kinetic.ts` — same Apple-style exponential decay (`amplitude 0.25`, `timeConstant 342ms`, `minVelocity 5`), so it feels as it did before 1.7.0. It polls the camera's translate on its own rAF loop during a drag and, on release, glides toward a projected target. **The pointer tracker is unchanged** (the kinetic samples the camera offset, not the pointer).

## Wiring (PagedCamera)

- `kineticStart()` on press — skipped when "Disable animations" (e-ink) is on.
- `kineticStop()` on release — glides if fast enough, else settles; settle still device-pixel-rounds (#65).
- `stopPan()`, `panBy()`, and `destroy()` cancel the glide, so a new press, a pinch/wheel zoom, an explicit wheel/keyboard pan, or component teardown supersedes momentum cleanly (no two animators fighting the transform).
- The glide clamps to bounds each frame and **finishes early once pinned at an edge** — flinging into a page boundary no longer spins rAF for the full ~2.5s decay writing an identical transform.
- `PagedViewport`: a swipe-to-flip or an OS-cancelled gesture drops the momentum; a normal release flings. Mouse drags fling too, as before.

## Verification

- 721 unit tests — `kinetic.test.ts` (velocity accumulation, decay, minVelocity, cancel, clamp early-out, diagonal pin) and `paged-camera.test.ts` fling cases (glide past release, clamp never escaped, e-ink skip, `stopPan`/`panBy` cancel). The camera test harness gained a functional `cancelAnimationFrame` so the kinetic's poll loop tears down deterministically.
- Real-app pass (Playwright, trusted input): a fast drag keeps gliding ~160px after release then rests; a slow release does **not** glide; "Disable animations" skips the glide; bounds hold.
- Adversarial review run; its findings (a track-loop leak if you toggle e-ink mid-drag; the pinned-at-bound rAF spin) are fixed here with tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)