### PR TITLE
fix(ci): grant PR-guard write perms, run CI on develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   lint:
@@ -98,7 +98,8 @@ jobs:
   release-check:
     name: Release Check
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # Only relevant for release PRs (develop -> main); skip on PRs into develop.
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pr-target-guard.yml
+++ b/.github/workflows/pr-target-guard.yml
@@ -4,11 +4,16 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize]
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
-  # Block any PR to main that doesn't come from develop
+  # Block any PR to main that doesn't come from develop (non-fork branches only;
+  # forks are handled by redirect-forks below to avoid a duplicate message).
   require-develop-to-main:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref != 'develop'
+    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref != 'develop' && !github.event.pull_request.head.repo.fork
     steps:
       - name: Block non-develop PRs to main
         run: |


### PR DESCRIPTION
## What went wrong (PR #235)

PR #235 (a fork PR targeting \`main\`) should have been auto-closed with a redirect comment by **PR Target Guard**, but the workflow run **failed**:

\`\`\`
GraphQL: Resource not accessible by integration (addComment)
\`\`\`

The token was read-only (`Contents/Metadata/Packages: read`) — the workflow declared no `permissions:` block, so both `gh pr comment` and `gh pr close --comment` were denied. The targeting logic was correct; it just couldn't act.

## Changes

**`pr-target-guard.yml`**
- Add `permissions: pull-requests: write` (+ `contents: read`) so the guard can comment/close.
- Exclude forks from `require-develop-to-main` (`!head.repo.fork`) so a fork PR to \`main\` gets a single redirect-and-close instead of both a comment and a close-comment.

**`ci.yml`**
- Run CI on \`develop\` too (push + pull_request). Previously CI only ran on \`main\`, so internal PRs into \`develop\` got no lint/test/build until release time.
- Scope `release-check` to `base_ref == 'main'` so it doesn't misfire on feature PRs into \`develop\`.

## Note

`pr-target-guard.yml` runs from the **base** commit under `pull_request_target`, so this fix only takes effect once it reaches \`main\`. It will not retroactively act on #235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)