### PR TITLE
fix(ci): prettier-format PagedViewport.svelte (fix develop lint)

### DIFF
--- a/src/lib/components/Reader/PagedViewport.svelte
+++ b/src/lib/components/Reader/PagedViewport.svelte
@@ -140,8 +140,10 @@
     }
     e.preventDefault();
     motion.beforeAnimatedScroll();
-    camera.panBy(-normalizeWheelDelta(e.deltaX, e.deltaMode),
-      -normalizeWheelDelta(e.deltaY, e.deltaMode));
+    camera.panBy(
+      -normalizeWheelDelta(e.deltaX, e.deltaMode),
+      -normalizeWheelDelta(e.deltaY, e.deltaMode)
+    );
   }
 
   function doubleTap(x: number, y: number) {


### PR DESCRIPTION
PR #238 merged an unformatted `src/lib/components/Reader/PagedViewport.svelte`, turning develop's CI Lint red (and every subsequent PR inherits it). This is just `prettier --write` on that one file — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)