### PR TITLE
Release v1.7.4 (develop → main)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,15 @@ jobs:
         id: release_notes
         run: |
           VERSION="${{ steps.version_check.outputs.current_version }}"
-          # Extract content between this version header and the next version header
-          NOTES=$(awk "/^## $VERSION/,/^## \[?[0-9]/" CHANGELOG.md | head -n -1 | tail -n +2)
+          # Print the body between this version's header and the next version header,
+          # excluding both headers. Handles both "## 1.2.3" and "## [1.2.3]" styles.
+          # (The old awk range failed because its end pattern also matched the start
+          # header, collapsing the range to a single line — release notes were empty.)
+          NOTES=$(awk -v ver="$VERSION" '
+            $0 ~ "^## \\[?" ver "([^0-9]|$)" { collecting = 1; next }
+            collecting && /^## \[?[0-9]/ { exit }
+            collecting { print }
+          ' CHANGELOG.md)
           # Use a delimiter for multiline output
           echo "notes<<EOF" >> $GITHUB_OUTPUT
           echo "$NOTES" >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.7.4] - 2026-06-30
+
+### Added
+
+- Horizontal panning with wheel and touchpad (thanks @binaryBrandon)
+- MEGA two-factor authentication (2FA) login
+- Uploaded covers now show thumbnails in MEGA
+
+### Changed
+
+- MEGA support no longer held together with hope and duct tape
+- Faster MEGA downloads
+
 ## [1.7.3] - 2026-06-14
 
 ### Fixed

--- a/docs/superpowers/plans/2026-06-29-mega-session-auth.md
+++ b/docs/superpowers/plans/2026-06-29-mega-session-auth.md
@@ -1,0 +1,1536 @@
+# MEGA Session-Token Auth, 2FA & Worker Hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace MEGA's plaintext email/password storage with a reused, revocable session token (megajs `toJSON`/`fromJSON`), add two-step 2FA login, and replace the worker share-link download hack and upload-worker password with lightweight session-based file access.
+
+**Architecture:** The main-thread `MegaProvider` persists a sanitized `Storage.toJSON()` blob (`sid` + master key, no password) under `localStorage['mega_session']`, restores it with `Storage.fromJSON()` + `reload()`, maps the `EMFAREQUIRED` error to a `MFA_REQUIRED` `ProviderError`, and detects `ESID` to drive a needs-attention reconnect. Upload workers receive the session blob (`fromJSON` + `reload`) instead of a password; download workers (Phase 2) receive `{ sid, nodeId, fileKey }` and build a `File` that downloads the owned node directly — no share link, no master key in the download worker.
+
+**Tech Stack:** SvelteKit 5, TypeScript, megajs ^1.3.9 (browser ESM build), Vitest (jsdom), Dexie.
+
+## Global Constraints
+
+- **megajs resolution:** `import { Storage, File } from 'megajs'` resolves to `dist/main.browser-es.mjs` in Vite (main thread + workers). All API facts below are verified against that build.
+- **Security invariant (post-Phase-1):** No plaintext MEGA password is ever persisted in `localStorage` or sent to a worker. The only persisted secret is `localStorage['mega_session']` = `JSON.stringify(sanitizeSessionBlob(storage.toJSON()))` — it contains `sid` + the account master `key`. **Never `console.log` this blob or its `key`.**
+- **megajs API contracts (verified):**
+  - `new Storage(options, cb?)` — `options.autoload` (default true) gates the file-tree fetch; `options.autologin` (default true) gates login; `options.secondFactorCode` → the `us` command's `mfa` field. The `cb` fires after login completes (after tree load when `autoload:true`).
+  - `storage.toJSON()` → `{ key, sid, name, user, options }` (`options` still contains `email` and, if set, `secondFactorCode`).
+  - `Storage.fromJSON(json)` rebuilds an authenticated Storage with **no network call**, forcing `autoload:false`+`autologin:false`, and sets `storage.aes`/`storage.sid`/`storage.api.sid`. It leaves `storage.status === 'closed'` and `storage.files === {}` (no tree) until you call `reload`.
+  - `await storage.reload(true)` issues `{a:'f',c:1}` and populates `storage.root` + `storage.files`. `storage.root.mkdir()` / `folder.upload()` are `MutableFile` methods that do **not** check `storage.status`, so they work after `fromJSON`+`reload`.
+  - A `File` built as `new File({ downloadId, key, api })` with `file.nodeId` set downloads the owned node via `{a:'g', n:nodeId}`, authorized by `api.sid`. `formatKey(string)` base64url-decodes (`d64`) into a real megajs Buffer, so transport the per-file key as MEGA base64url (`encodeMegaKey`).
+  - Error strings: `EMFAREQUIRED (-26): Multi-Factor Authentication Required`; `ESID (-15): Invalid or expired user session, please relogin`. No numeric `.code` — match the message.
+- **Testing:** Vitest jsdom. Single file run: `npx vitest run <path>`. `localStorage` is auto-mocked by `src/test-setup.ts` (Map-backed; call `localStorage.clear()` in `beforeEach`). Mock `$app/environment` with `vi.mock('$app/environment', () => ({ browser: true }))` and megajs with `vi.mock('megajs', ...)`.
+- **Type-check:** `npm run check`. **Lint:** `npm run lint`.
+- **Worktree setup:** This worktree (`feat/mega-session-auth`) has **no `node_modules`**. Run `npm install` once before any test/check command.
+- **Commits:** Commit after each task. Do **not** push (active development). End commit messages with the project's `Co-Authored-By` trailer.
+- **Phasing:** Phase 1 (Tasks 1–7) = token auth + 2FA + migration + upload worker; independently shippable. Phase 2 (Tasks 8–10) = download workers + remove share links.
+
+---
+
+## Phase 1 — Token auth, 2FA, migration, upload worker
+
+### Task 1: Pure session helpers (`mega-session.ts`)
+
+**Files:**
+
+- Create: `src/lib/util/sync/providers/mega/mega-session.ts`
+- Test: `src/lib/util/sync/providers/mega/mega-session.test.ts`
+
+**Interfaces:**
+
+- Produces:
+  - `interface MegaSessionBlob { key: string; sid: string; name?: string; user?: string; options?: Record<string, any> }`
+  - `isMfaRequiredError(error: unknown): boolean`
+  - `isSessionExpiredError(error: unknown): boolean`
+  - `isAuthRejectionError(error: unknown): boolean`
+  - `sanitizeSessionBlob(blob: any): MegaSessionBlob`
+  - `encodeMegaKey(key: Uint8Array): string`
+
+- [ ] **Step 1: Run `npm install` in the worktree (one-time prerequisite)**
+
+Run: `npm install`
+Expected: completes; `node_modules/megajs` present.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/lib/util/sync/providers/mega/mega-session.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  isMfaRequiredError,
+  isSessionExpiredError,
+  isAuthRejectionError,
+  sanitizeSessionBlob,
+  encodeMegaKey
+} from './mega-session';
+
+describe('mega-session error classifiers', () => {
+  it('detects 2FA-required from the EMFAREQUIRED message', () => {
+    expect(
+      isMfaRequiredError(new Error('EMFAREQUIRED (-26): Multi-Factor Authentication Required'))
+    ).toBe(true);
+    expect(isMfaRequiredError(new Error('wrong password'))).toBe(false);
+  });
+
+  it('detects expired session from the ESID message', () => {
+    expect(
+      isSessionExpiredError(
+        new Error('ESID (-15): Invalid or expired user session, please relogin')
+      )
+    ).toBe(true);
+    expect(isSessionExpiredError(new Error('EAGAIN congestion'))).toBe(false);
+  });
+
+  it('detects genuine auth rejection but not transient errors', () => {
+    expect(isAuthRejectionError(new Error('wrong password'))).toBe(true);
+    expect(isAuthRejectionError(new Error('ENOENT'))).toBe(true);
+    expect(isAuthRejectionError(new Error('network timeout'))).toBe(false);
+  });
+});
+
+describe('sanitizeSessionBlob', () => {
+  it('keeps sid/key/user/name and strips password + secondFactorCode from options', () => {
+    const blob = sanitizeSessionBlob({
+      key: 'KEY',
+      sid: 'SID',
+      name: 'n',
+      user: 'u',
+      options: { email: 'a@b.c', password: 'p', secondFactorCode: '123456', autoload: true }
+    });
+    expect(blob).toEqual({
+      key: 'KEY',
+      sid: 'SID',
+      name: 'n',
+      user: 'u',
+      options: { email: 'a@b.c', autoload: true }
+    });
+    expect(blob.options).not.toHaveProperty('password');
+    expect(blob.options).not.toHaveProperty('secondFactorCode');
+  });
+});
+
+describe('encodeMegaKey', () => {
+  it('produces URL-safe base64 without padding (matches megajs e64)', () => {
+    // btoa('\xff\xff\xff') === '////'  -> '____'
+    expect(encodeMegaKey(new Uint8Array([255, 255, 255]))).toBe('____');
+    // btoa('\x00') === 'AA==' -> strip padding -> 'AA'
+    expect(encodeMegaKey(new Uint8Array([0]))).toBe('AA');
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npx vitest run src/lib/util/sync/providers/mega/mega-session.test.ts`
+Expected: FAIL — cannot resolve `./mega-session`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `src/lib/util/sync/providers/mega/mega-session.ts`:
+
+```ts
+/**
+ * Pure helpers for MEGA session-token auth: error classification, session-blob
+ * sanitization, and per-file key encoding for worker transport.
+ *
+ * No side effects, no DOM, no megajs imports — safe to unit test in isolation.
+ */
+
+/** Sanitized megajs `Storage.toJSON()` blob persisted under localStorage['mega_session']. */
+export interface MegaSessionBlob {
+  /** Account master key (base64url) — sensitive. */
+  key: string;
+  /** Session id. */
+  sid: string;
+  name?: string;
+  user?: string;
+  /** megajs options minus password/secondFactorCode. */
+  options?: Record<string, any>;
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** MEGA signals "2FA code required" only via the EMFAREQUIRED (-26) error message. */
+export function isMfaRequiredError(error: unknown): boolean {
+  return /EMFAREQUIRED|Multi-Factor|-26/i.test(messageOf(error));
+}
+
+/** MEGA signals an invalid/expired session via ESID (-15). */
+export function isSessionExpiredError(error: unknown): boolean {
+  return /ESID|-15|expired user session|please relogin/i.test(messageOf(error));
+}
+
+/** Genuine credential rejection (wrong email/password) vs transient/network errors. */
+export function isAuthRejectionError(error: unknown): boolean {
+  return /ENOENT|incorrect|invalid|authentication failed|wrong password/i.test(messageOf(error));
+}
+
+/** Strip single-use / sensitive fields from a `toJSON()` blob before persisting. */
+export function sanitizeSessionBlob(blob: any): MegaSessionBlob {
+  const options = { ...(blob?.options ?? {}) };
+  delete options.password;
+  delete options.secondFactorCode;
+  return { key: blob.key, sid: blob.sid, name: blob.name, user: blob.user, options };
+}
+
+/**
+ * Encode a raw MEGA key buffer to MEGA's base64url ("e64") form so a worker's
+ * `formatKey` (d64) reconstructs the identical megajs Buffer.
+ */
+export function encodeMegaKey(key: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < key.length; i++) binary += String.fromCharCode(key[i]);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run src/lib/util/sync/providers/mega/mega-session.test.ts`
+Expected: PASS (3 describe blocks, all green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/util/sync/providers/mega/mega-session.ts src/lib/util/sync/providers/mega/mega-session.test.ts
+git commit -m "feat(mega): add pure session-token helpers (error classifiers, blob sanitizer, key encoder)"
+```
+
+---
+
+### Task 2: Session-aware `login()` with 2FA + `persistSession()`
+
+**Files:**
+
+- Modify: `src/lib/util/sync/providers/mega/mega-provider.ts` (`MegaCredentials` 16-19; `STORAGE_KEYS` 21-25; imports 10-14; class fields 143-153; `login()` 195-249; `waitForReady()` 302-326 — remove)
+- Test: `src/lib/util/sync/providers/mega/mega-provider.test.ts` (new)
+
+**Interfaces:**
+
+- Consumes (Task 1): `sanitizeSessionBlob`, `isMfaRequiredError`.
+- Produces: `login({ email, password, secondFactorCode? })` persists `mega_session` and removes legacy keys on success; throws `ProviderError` with `code === 'MFA_REQUIRED'` when 2FA is needed. New private fields `needsReconnect: boolean`, `reconnectEmail: string | null`. New `STORAGE_KEYS.SESSION = 'mega_session'`. New `private persistSession(): void`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/util/sync/providers/mega/mega-provider.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('./mega-cache', () => ({ megaCache: { fetch: vi.fn() } }));
+vi.mock('../../cache-manager', () => ({
+  cacheManager: { clearAll: vi.fn(), registerCache: vi.fn() }
+}));
+
+// Controllable megajs Storage mock.
+const storageState = vi.hoisted(() => ({
+  // What the next `new Storage(opts, cb)` should do.
+  loginError: null as Error | null,
+  lastOptions: null as any,
+  toJSON: () => ({
+    key: 'MASTERKEY',
+    sid: 'SID123',
+    name: 'n',
+    user: 'u',
+    options: { email: 'a@b.c', password: 'secret', secondFactorCode: '123456', autoload: true }
+  }),
+  files: { f1: { name: 'mokuro-reader', directory: true } } as Record<string, any>
+}));
+
+vi.mock('megajs', () => {
+  class MockStorage {
+    files: Record<string, any>;
+    sid = 'SID123';
+    constructor(options: any, cb?: (e: Error | null) => void) {
+      storageState.lastOptions = options;
+      this.files = storageState.files;
+      // Defer cb so the caller's `const s = new Storage(...)` is assigned first.
+      if (cb) queueMicrotask(() => cb(storageState.loginError));
+    }
+    toJSON() {
+      return storageState.toJSON();
+    }
+    getAccountInfo() {
+      return Promise.resolve({ spaceUsed: 0, spaceTotal: 100 });
+    }
+    static fromJSON = vi.fn();
+  }
+  return { Storage: MockStorage, File: vi.fn() };
+});
+
+import { MegaProvider } from './mega-provider';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  storageState.loginError = null;
+  storageState.files = { f1: { name: 'mokuro-reader', directory: true } };
+});
+
+describe('MegaProvider.login()', () => {
+  it('persists a sanitized session blob and removes legacy password on success', async () => {
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    await provider.login({ email: 'a@b.c', password: 'secret' });
+
+    expect(provider.isAuthenticated()).toBe(true);
+    const raw = localStorage.getItem('mega_session');
+    expect(raw).toBeTruthy();
+    const blob = JSON.parse(raw!);
+    expect(blob.sid).toBe('SID123');
+    expect(blob.key).toBe('MASTERKEY');
+    expect(blob.options).not.toHaveProperty('password');
+    expect(blob.options).not.toHaveProperty('secondFactorCode');
+    expect(localStorage.getItem('mega_password')).toBeNull();
+    expect(localStorage.getItem('active_cloud_provider')).toBe('mega');
+  });
+
+  it('forwards secondFactorCode to the Storage constructor', async () => {
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    await provider.login({ email: 'a@b.c', password: 'secret', secondFactorCode: '654321' });
+
+    expect(storageState.lastOptions.secondFactorCode).toBe('654321');
+  });
+
+  it('maps EMFAREQUIRED to a MFA_REQUIRED ProviderError', async () => {
+    storageState.loginError = new Error('EMFAREQUIRED (-26): Multi-Factor Authentication Required');
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    await expect(provider.login({ email: 'a@b.c', password: 'secret' })).rejects.toMatchObject({
+      code: 'MFA_REQUIRED'
+    });
+    expect(provider.isAuthenticated()).toBe(false);
+    expect(localStorage.getItem('mega_session')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/lib/util/sync/providers/mega/mega-provider.test.ts`
+Expected: FAIL — `login` still stores `mega_email`/`mega_password`, no `mega_session`, no `MFA_REQUIRED` mapping.
+
+- [ ] **Step 3: Add imports + STORAGE_KEYS.SESSION + MegaCredentials field + class fields**
+
+In `src/lib/util/sync/providers/mega/mega-provider.ts`, update the import of provider-detection (line 13) to also keep existing, and add the session-helper import after line 14:
+
+```ts
+import {
+  isMfaRequiredError,
+  isSessionExpiredError,
+  isAuthRejectionError,
+  sanitizeSessionBlob,
+  encodeMegaKey,
+  type MegaSessionBlob
+} from './mega-session';
+```
+
+Replace the `MegaCredentials` interface (16-19):
+
+```ts
+interface MegaCredentials {
+  email: string;
+  password: string;
+  /** One-time TOTP code for 2FA-enabled accounts. Never persisted. */
+  secondFactorCode?: string;
+}
+```
+
+Replace `STORAGE_KEYS` (21-25):
+
+```ts
+const STORAGE_KEYS = {
+  /** Sanitized Storage.toJSON() blob (sid + master key). The only persisted secret. */
+  SESSION: 'mega_session',
+  // Legacy keys — read for migration, removed on first successful login.
+  EMAIL: 'mega_email',
+  PASSWORD: 'mega_password',
+  FOLDER_PATH: 'mega_folder_path'
+};
+```
+
+Add two private fields alongside the existing ones (after line 144 `private mokuroFolder: any = null;`):
+
+```ts
+  private needsReconnect = false;
+  private reconnectEmail: string | null = null;
+```
+
+- [ ] **Step 4: Replace `login()` (195-249) and delete `waitForReady()` (302-326)**
+
+Replace the whole `login()` method body with:
+
+```ts
+  async login(credentials?: ProviderCredentials): Promise<void> {
+    if (!credentials || !credentials.email || !credentials.password) {
+      throw new ProviderError('Email and password are required', 'mega', 'INVALID_CREDENTIALS');
+    }
+
+    const { email, password, secondFactorCode } = credentials as MegaCredentials;
+
+    try {
+      // Dynamically import megajs to reduce initial bundle size
+      const { Storage } = await import('megajs');
+
+      // Fresh interactive login. The constructor cb fires after the tree loads
+      // (autoload:true), so the Storage is ready once this promise resolves.
+      const storage: any = await new Promise((resolve, reject) => {
+        const s = new Storage(
+          { email, password, secondFactorCode, autoload: true } as any,
+          (error: Error | null) => (error ? reject(error) : resolve(s))
+        );
+      });
+
+      this.storage = storage;
+      await this.ensureMokuroFolder();
+      this.persistSession();
+      this.needsReconnect = false;
+      this.reconnectEmail = email;
+      setActiveProviderKey('mega');
+      console.log('✅ MEGA login successful');
+    } catch (error) {
+      this.storage = null;
+      this.mokuroFolder = null;
+
+      if (isMfaRequiredError(error)) {
+        throw new ProviderError(
+          'MEGA requires a two-factor authentication code',
+          'mega',
+          'MFA_REQUIRED',
+          false
+        );
+      }
+
+      throw new ProviderError(
+        `MEGA login failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        'mega',
+        'LOGIN_FAILED',
+        true
+      );
+    }
+  }
+
+  /** Persist the current session as a sanitized toJSON() blob; drop legacy keys. */
+  private persistSession(): void {
+    if (!browser || !this.storage) return;
+    const blob: MegaSessionBlob = sanitizeSessionBlob(this.storage.toJSON());
+    localStorage.setItem(STORAGE_KEYS.SESSION, JSON.stringify(blob));
+    localStorage.removeItem(STORAGE_KEYS.EMAIL);
+    localStorage.removeItem(STORAGE_KEYS.PASSWORD);
+  }
+```
+
+Delete the now-unused `waitForReady()` method (originally lines 302-326). Confirm no other caller: `grep -n waitForReady src/lib/util/sync/providers/mega/mega-provider.ts` returns nothing after deletion.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run src/lib/util/sync/providers/mega/mega-provider.test.ts`
+Expected: PASS (3 tests in `login()`).
+
+- [ ] **Step 6: Type-check + commit**
+
+Run: `npm run check` (expect no new errors in mega-provider.ts).
+
+```bash
+git add src/lib/util/sync/providers/mega/mega-provider.ts src/lib/util/sync/providers/mega/mega-provider.test.ts
+git commit -m "feat(mega): session-token login with 2FA support and password-free persistence"
+```
+
+---
+
+### Task 3: `restoreSession()`, migration, and `reinitialize()` via session
+
+**Files:**
+
+- Modify: `src/lib/util/sync/providers/mega/mega-provider.ts` (`loadPersistedCredentials()` 266-300 → rewrite as `restorePersistedSession()`; constructor 155-161; `reinitialize()` 332-368)
+- Test: `src/lib/util/sync/providers/mega/mega-provider.test.ts` (extend)
+
+**Interfaces:**
+
+- Consumes (Task 1): `isSessionExpiredError`, `isAuthRejectionError`, `isMfaRequiredError`. (Task 2): `login()`, `persistSession`.
+- Produces: `private restoreSession(blob: MegaSessionBlob): Promise<void>` (fromJSON + reload); `restorePersistedSession(): Promise<void>` (session-first, legacy migration fallback); `reinitialize()` refreshes via a fresh `fromJSON` of the stored session (no password, no re-login). Constructor calls `restorePersistedSession()`.
+
+- [ ] **Step 1: Write the failing tests (append to mega-provider.test.ts)**
+
+Add a `fromJSON` impl to the megajs mock by replacing the `static fromJSON = vi.fn();` line with a working stub that returns a ready-ish storage, and append these tests:
+
+In the `vi.mock('megajs', ...)` block, replace `static fromJSON = vi.fn();` with:
+
+```ts
+    static fromJSON = vi.fn((json: any) => {
+      const s = new MockStorage({ autologin: false, autoload: false } as any);
+      s.sid = json.sid;
+      (s as any).reload = vi.fn(async () => {
+        if (storageState.reloadError) throw storageState.reloadError;
+      });
+      return s;
+    });
+```
+
+Add `reloadError` to `storageState` hoisted object: `reloadError: null as Error | null,` and reset it in `beforeEach` (`storageState.reloadError = null;`). Also give `MockStorage` a default `reload`: add `reload = vi.fn(async () => {});` as an instance field.
+
+Append:
+
+```ts
+describe('MegaProvider session restore + migration', () => {
+  it('migrates legacy email/password to a session blob on load', async () => {
+    localStorage.setItem('mega_email', 'a@b.c');
+    localStorage.setItem('mega_password', 'secret');
+
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    expect(provider.isAuthenticated()).toBe(true);
+    expect(localStorage.getItem('mega_session')).toBeTruthy();
+    expect(localStorage.getItem('mega_password')).toBeNull();
+  });
+
+  it('restores from an existing session blob without re-login', async () => {
+    localStorage.setItem(
+      'mega_session',
+      JSON.stringify({ key: 'MASTERKEY', sid: 'SID123', name: 'n', user: 'u', options: {} })
+    );
+
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    expect(provider.isAuthenticated()).toBe(true);
+    const { Storage } = (await import('megajs')) as any;
+    expect(Storage.fromJSON).toHaveBeenCalledOnce();
+  });
+
+  it('flags needs-attention when the stored session is expired (ESID)', async () => {
+    storageState.reloadError = new Error(
+      'ESID (-15): Invalid or expired user session, please relogin'
+    );
+    localStorage.setItem(
+      'mega_session',
+      JSON.stringify({
+        key: 'MASTERKEY',
+        sid: 'DEAD',
+        name: 'n',
+        user: 'u',
+        options: { email: 'a@b.c' }
+      })
+    );
+
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    expect(provider.isAuthenticated()).toBe(false);
+    expect(provider.getStatus().needsAttention).toBe(true);
+    expect(localStorage.getItem('mega_session')).toBeNull();
+  });
+});
+```
+
+> Note: the ESID test asserts `getStatus().needsAttention` — that wiring lands in Task 4. If executing strictly task-by-task, expect this single assertion to fail until Task 4 and the rest to pass; mark it `it.todo` until Task 4, or implement Task 4's `getStatus`/`markSessionExpired` together with this task. (Subagent-driven execution: keep them in the same task pair.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/lib/util/sync/providers/mega/mega-provider.test.ts`
+Expected: FAIL — no `restoreSession`/migration; `fromJSON` not called.
+
+- [ ] **Step 3: Implement `restoreSession()` + `restorePersistedSession()`**
+
+Replace `loadPersistedCredentials()` (266-300) with:
+
+```ts
+  /** Rebuild an authenticated Storage from a saved session blob (no password, no login round-trip). */
+  private async restoreSession(blob: MegaSessionBlob): Promise<void> {
+    const { Storage } = await import('megajs');
+    const storage: any = Storage.fromJSON(blob);
+    // fromJSON does no network and loads no tree; reload populates root + files.
+    // A dead session throws ESID here.
+    await storage.reload(true);
+    this.storage = storage;
+    this.mokuroFolder = null;
+    await this.ensureMokuroFolder();
+    this.needsReconnect = false;
+    this.reconnectEmail = (blob.options && (blob.options as any).email) || this.reconnectEmail;
+    setActiveProviderKey('mega');
+  }
+
+  /** Restore on app load: session blob first, then one-time legacy email/password migration. */
+  async restorePersistedSession(): Promise<void> {
+    if (!browser) return;
+
+    const sessionRaw = localStorage.getItem(STORAGE_KEYS.SESSION);
+    if (sessionRaw) {
+      try {
+        await this.restoreSession(JSON.parse(sessionRaw) as MegaSessionBlob);
+        console.log('Restored MEGA session from stored token');
+      } catch (error) {
+        if (isSessionExpiredError(error) || isAuthRejectionError(error)) {
+          console.error('Stored MEGA session invalid; reconnect required');
+          this.markSessionExpired();
+        } else {
+          console.warn('Failed to restore MEGA session (temporary error), will retry:', error);
+        }
+      }
+      return;
+    }
+
+    // Legacy migration: log in with stored email/password, which persists a session blob
+    // and removes the password (see login()/persistSession()).
+    const email = localStorage.getItem(STORAGE_KEYS.EMAIL);
+    const password = localStorage.getItem(STORAGE_KEYS.PASSWORD);
+    if (email && password) {
+      try {
+        await this.login({ email, password });
+        console.log('Migrated MEGA legacy credentials to session token');
+      } catch (error) {
+        if (isMfaRequiredError(error)) {
+          // Account enabled 2FA after the password was stored — cannot migrate silently.
+          this.reconnectEmail = email;
+          this.markSessionExpired();
+        } else if (isAuthRejectionError(error)) {
+          this.reconnectEmail = email;
+          this.markSessionExpired();
+        } else {
+          console.warn('MEGA migration deferred (temporary error), keeping legacy creds:', error);
+        }
+      }
+    }
+  }
+```
+
+Update the constructor (155-161) to call the renamed method:
+
+```ts
+  constructor() {
+    if (browser) {
+      this.initPromise = this.restorePersistedSession();
+    } else {
+      this.initPromise = Promise.resolve();
+    }
+  }
+```
+
+- [ ] **Step 4: Rewrite `reinitialize()` (332-368) to refresh via the stored session**
+
+```ts
+  /**
+   * Refresh the file-tree cache by rebuilding the session from the stored token.
+   * No password and no re-login round-trip — fromJSON + reload only.
+   */
+  private async reinitialize(): Promise<void> {
+    if (!browser) return;
+
+    const sessionRaw = localStorage.getItem(STORAGE_KEYS.SESSION);
+    if (!sessionRaw) {
+      console.warn('Cannot reinitialize MEGA: no stored session');
+      return;
+    }
+
+    const oldStorage = this.storage;
+    try {
+      const { Storage } = await import('megajs');
+      const storage: any = Storage.fromJSON(JSON.parse(sessionRaw));
+      await storage.reload(true);
+      this.storage = storage;
+      this.mokuroFolder = null;
+      // Release the previous session's keepalive/sc listeners.
+      if (oldStorage && typeof oldStorage.close === 'function') {
+        try {
+          await oldStorage.close();
+        } catch {
+          /* best effort */
+        }
+      }
+      console.log('✅ MEGA cache reinitialized from session token');
+    } catch (error) {
+      if (isSessionExpiredError(error)) {
+        this.markSessionExpired();
+        return;
+      }
+      // Transient error: keep the existing (stale) storage so we don't appear logged out.
+      this.storage = oldStorage;
+      console.warn('Continuing with potentially stale MEGA cache:', error);
+    }
+  }
+```
+
+- [ ] **Step 5: Run tests (with Task 4 implemented, or the ESID test marked todo)**
+
+Run: `npx vitest run src/lib/util/sync/providers/mega/mega-provider.test.ts`
+Expected: PASS for migration + restore; the ESID/needs-attention assertion passes once Task 4 lands.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/util/sync/providers/mega/mega-provider.ts src/lib/util/sync/providers/mega/mega-provider.test.ts
+git commit -m "feat(mega): restore + migrate via session token; refresh cache without re-login"
+```
+
+---
+
+### Task 4: `markSessionExpired()`, needs-attention `getStatus()`, `getLastUsername()`
+
+**Files:**
+
+- Modify: `src/lib/util/sync/providers/mega/mega-provider.ts` (`getStatus()` 175-193; add `markSessionExpired()`, `getLastUsername()`)
+- Test: `src/lib/util/sync/providers/mega/mega-provider.test.ts` (the ESID test from Task 3 now asserts this)
+
+**Interfaces:**
+
+- Produces: `private markSessionExpired(): void` (clears `mega_session`, captures email for prefill, sets `needsReconnect`); `getStatus()` returns `needsAttention: this.needsReconnect`; `getLastUsername(): string | null` returns the reconnect email.
+
+- [ ] **Step 1: Tests already written in Task 3 (ESID → needsAttention). Add a getLastUsername test.**
+
+Append:
+
+```ts
+describe('MegaProvider needs-attention', () => {
+  it('exposes the stored email via getLastUsername after session expiry', async () => {
+    storageState.reloadError = new Error('ESID (-15): please relogin');
+    localStorage.setItem(
+      'mega_session',
+      JSON.stringify({ key: 'K', sid: 'DEAD', options: { email: 'me@host.dev' } })
+    );
+    const provider = new MegaProvider();
+    await provider.whenReady();
+    expect(provider.getLastUsername()).toBe('me@host.dev');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/lib/util/sync/providers/mega/mega-provider.test.ts`
+Expected: FAIL — `markSessionExpired`/`getLastUsername` not defined; `needsAttention` always false.
+
+- [ ] **Step 3: Add `markSessionExpired()` and `getLastUsername()`; update `getStatus()`**
+
+Add methods (place near `getStatus`):
+
+```ts
+  /** Drop the stored session and flag the UI to prompt for reconnect (password never stored). */
+  private markSessionExpired(): void {
+    // Capture email for reconnect pre-fill before clearing.
+    if (browser && !this.reconnectEmail) {
+      const sessionRaw = localStorage.getItem(STORAGE_KEYS.SESSION);
+      if (sessionRaw) {
+        try {
+          this.reconnectEmail = JSON.parse(sessionRaw)?.options?.email ?? null;
+        } catch {
+          /* ignore */
+        }
+      }
+      this.reconnectEmail = this.reconnectEmail ?? localStorage.getItem(STORAGE_KEYS.EMAIL);
+    }
+
+    this.storage = null;
+    this.mokuroFolder = null;
+    this.needsReconnect = true;
+
+    if (browser) {
+      localStorage.removeItem(STORAGE_KEYS.SESSION);
+      // Keep active_cloud_provider so the UI still shows MEGA in a needs-attention state.
+    }
+  }
+
+  /** Email captured for reconnect pre-fill (mirrors WebDAV's getLastUsername). */
+  getLastUsername(): string | null {
+    if (this.reconnectEmail) return this.reconnectEmail;
+    if (!browser) return null;
+    const sessionRaw = localStorage.getItem(STORAGE_KEYS.SESSION);
+    if (sessionRaw) {
+      try {
+        return JSON.parse(sessionRaw)?.options?.email ?? null;
+      } catch {
+        return null;
+      }
+    }
+    return localStorage.getItem(STORAGE_KEYS.EMAIL);
+  }
+```
+
+Replace `getStatus()` (175-193) with:
+
+```ts
+  getStatus(): ProviderStatus {
+    const hasSession = !!(browser && localStorage.getItem(STORAGE_KEYS.SESSION));
+    const hasLegacy = !!(
+      browser &&
+      localStorage.getItem(STORAGE_KEYS.EMAIL) &&
+      localStorage.getItem(STORAGE_KEYS.PASSWORD)
+    );
+    const isConnected = this.isAuthenticated();
+
+    return {
+      isAuthenticated: isConnected,
+      hasStoredCredentials: hasSession || hasLegacy,
+      needsAttention: this.needsReconnect,
+      statusMessage: isConnected
+        ? 'Connected to MEGA'
+        : this.needsReconnect
+          ? 'MEGA session expired — please reconnect'
+          : hasSession || hasLegacy
+            ? 'Configured (not connected)'
+            : 'Not configured'
+    };
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/util/sync/providers/mega/mega-provider.test.ts`
+Expected: PASS (including the Task 3 ESID test and getLastUsername).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/util/sync/providers/mega/mega-provider.ts src/lib/util/sync/providers/mega/mega-provider.test.ts
+git commit -m "feat(mega): needs-attention state on session expiry with reconnect email prefill"
+```
+
+---
+
+### Task 5: `logout()` + detection + manager key hygiene for `mega_session`
+
+**Files:**
+
+- Modify: `src/lib/util/sync/providers/mega/mega-provider.ts` (`logout()` 251-264)
+- Modify: `src/lib/util/sync/provider-detection.ts` (`detectProviderFromCredentials()` 53-58)
+- Modify: `src/lib/util/sync/provider-manager.ts` (logout key removal 197-199)
+- Test: `src/lib/util/sync/providers/mega/mega-provider.test.ts`; `src/lib/util/sync/provider-detection.test.ts` (new)
+
+**Interfaces:**
+
+- Produces: `logout()` clears `mega_session` + legacy keys + reconnect flags; `detectProviderFromCredentials()` recognizes `mega_session` OR legacy pair.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `mega-provider.test.ts`:
+
+```ts
+describe('MegaProvider.logout()', () => {
+  it('clears session, legacy keys, and needs-attention flag', async () => {
+    localStorage.setItem('mega_session', JSON.stringify({ key: 'K', sid: 'S', options: {} }));
+    localStorage.setItem('mega_email', 'a@b.c');
+    localStorage.setItem('mega_password', 'p');
+    localStorage.setItem('active_cloud_provider', 'mega');
+
+    const provider = new MegaProvider();
+    await provider.whenReady();
+    await provider.logout();
+
+    expect(localStorage.getItem('mega_session')).toBeNull();
+    expect(localStorage.getItem('mega_email')).toBeNull();
+    expect(localStorage.getItem('mega_password')).toBeNull();
+    expect(localStorage.getItem('active_cloud_provider')).toBeNull();
+    expect(provider.getStatus().needsAttention).toBe(false);
+    expect(provider.isAuthenticated()).toBe(false);
+  });
+});
+```
+
+Create `src/lib/util/sync/provider-detection.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('$lib/util/sync/providers/google-drive/constants', () => ({
+  GOOGLE_DRIVE_CONFIG: {
+    STORAGE_KEYS: { HAS_AUTHENTICATED: 'gdrive_has_authenticated', TOKEN: 'gdrive_token' }
+  }
+}));
+
+import { getConfiguredProviderType } from './provider-detection';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('provider detection (MEGA)', () => {
+  it('detects MEGA from a session blob (new key)', () => {
+    localStorage.setItem('mega_session', JSON.stringify({ sid: 'S', key: 'K' }));
+    expect(getConfiguredProviderType()).toBe('mega');
+  });
+
+  it('still detects MEGA from legacy email/password (pre-migration)', () => {
+    localStorage.setItem('mega_email', 'a@b.c');
+    localStorage.setItem('mega_password', 'p');
+    expect(getConfiguredProviderType()).toBe('mega');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/lib/util/sync/providers/mega/mega-provider.test.ts src/lib/util/sync/provider-detection.test.ts`
+Expected: FAIL — logout doesn't clear `mega_session`; detection ignores `mega_session`.
+
+- [ ] **Step 3: Update `logout()`**
+
+Replace `logout()` (251-264):
+
+```ts
+  async logout(): Promise<void> {
+    this.storage = null;
+    this.mokuroFolder = null;
+    this.needsReconnect = false;
+    this.reconnectEmail = null;
+
+    if (browser) {
+      localStorage.removeItem(STORAGE_KEYS.SESSION);
+      localStorage.removeItem(STORAGE_KEYS.EMAIL);
+      localStorage.removeItem(STORAGE_KEYS.PASSWORD);
+      localStorage.removeItem(STORAGE_KEYS.FOLDER_PATH);
+    }
+
+    clearActiveProviderKey();
+    console.log('MEGA logged out');
+  }
+```
+
+- [ ] **Step 4: Update `detectProviderFromCredentials()` (provider-detection.ts 53-58)**
+
+Replace the MEGA block:
+
+```ts
+// Check MEGA credentials (new session token or legacy email/password)
+const megaSession = localStorage.getItem('mega_session');
+const megaEmail = localStorage.getItem('mega_email');
+const megaPassword = localStorage.getItem('mega_password');
+if (megaSession || (megaEmail && megaPassword)) {
+  return 'mega';
+}
+```
+
+- [ ] **Step 5: Update `provider-manager.ts` logout key removal (197-199)**
+
+Add `mega_session` removal alongside the existing MEGA keys:
+
+```ts
+localStorage.removeItem('mega_session');
+localStorage.removeItem('mega_email');
+localStorage.removeItem('mega_password');
+localStorage.removeItem('mega_folder_path');
+```
+
+- [ ] **Step 6: Run tests + commit**
+
+Run: `npx vitest run src/lib/util/sync/providers/mega/mega-provider.test.ts src/lib/util/sync/provider-detection.test.ts`
+Expected: PASS.
+
+```bash
+git add src/lib/util/sync/providers/mega/mega-provider.ts src/lib/util/sync/provider-detection.ts src/lib/util/sync/provider-detection.test.ts src/lib/util/sync/provider-manager.ts
+git commit -m "feat(mega): clear mega_session on logout and detect it for provider restore"
+```
+
+---
+
+### Task 6: Upload worker uses the session blob (no password)
+
+**Files:**
+
+- Modify: `src/lib/util/sync/providers/mega/mega-provider.ts` (`getWorkerUploadCredentials()` 1197-1202)
+- Modify: `src/lib/util/sync/core/providers/mega-core.ts` (`getUploadStorage` 22-50; `uploadFile` 98-101)
+- Test: `src/lib/util/sync/providers/mega/mega-provider.test.ts`
+
+**Interfaces:**
+
+- Consumes: `localStorage['mega_session']`.
+- Produces: `getWorkerUploadCredentials()` returns `{ megaSession: string }`; worker `getUploadStorage(session)` builds via `Storage.fromJSON(JSON.parse(session))` + `reload(true)`, cached by `sid`.
+
+- [ ] **Step 1: Write failing test (provider side)**
+
+Append to `mega-provider.test.ts`:
+
+```ts
+describe('MegaProvider.getWorkerUploadCredentials()', () => {
+  it('returns the session blob, never a password', async () => {
+    const sessionRaw = JSON.stringify({ key: 'K', sid: 'S', options: { email: 'a@b.c' } });
+    localStorage.setItem('mega_session', sessionRaw);
+
+    const provider = new MegaProvider();
+    await provider.whenReady();
+    const creds = await provider.getWorkerUploadCredentials();
+
+    expect(creds).toEqual({ megaSession: sessionRaw });
+    expect(creds).not.toHaveProperty('megaPassword');
+    expect(creds).not.toHaveProperty('megaEmail');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/lib/util/sync/providers/mega/mega-provider.test.ts`
+Expected: FAIL — returns `{ megaEmail, megaPassword }`.
+
+- [ ] **Step 3: Update `getWorkerUploadCredentials()` (1197-1202)**
+
+```ts
+  async getWorkerUploadCredentials(): Promise<Record<string, any>> {
+    if (!browser) return {};
+    const session = localStorage.getItem(STORAGE_KEYS.SESSION);
+    return { megaSession: session };
+  }
+```
+
+- [ ] **Step 4: Update the worker core (`mega-core.ts`)**
+
+Replace `getUploadStorage()` (22-50) so it rebuilds from a session blob (no email/password). The cache key becomes the session's `sid`:
+
+```ts
+async function getUploadStorage(session: string): Promise<Storage> {
+  const parsed = JSON.parse(session);
+  const sessionKey: string = parsed.sid;
+
+  if (uploadStoragePromise && uploadSessionKey === sessionKey) {
+    return await uploadStoragePromise;
+  }
+
+  if (uploadStoragePromise && uploadSessionKey !== sessionKey) {
+    await resetUploadStorage();
+  }
+
+  uploadSessionKey = sessionKey;
+  const pendingSession = (async () => {
+    const storage = Storage.fromJSON(parsed) as any;
+    // fromJSON loads no tree; reload populates storage.root for folder navigation/upload.
+    await storage.reload(true);
+    return storage as Storage;
+  })();
+  uploadStoragePromise = pendingSession;
+
+  try {
+    return await pendingSession;
+  } catch (error) {
+    if (uploadStoragePromise === pendingSession) {
+      uploadStoragePromise = null;
+      uploadSessionKey = null;
+    }
+    throw error;
+  }
+}
+```
+
+Replace the credential reads in `uploadFile()` (99-101):
+
+```ts
+  async uploadFile({ seriesTitle, filename, blob, credentials, onProgress }): Promise<string> {
+    const session = requireCredentialString(credentials, 'megaSession', 'MEGA session');
+    const storage = await getUploadStorage(session);
+```
+
+(Leave the rest of `uploadFile` unchanged — `storage.root.children` / `storage.root.mkdir` / `folder.upload` work after `reload`.)
+
+- [ ] **Step 5: Run provider test + type-check**
+
+Run: `npx vitest run src/lib/util/sync/providers/mega/mega-provider.test.ts`
+Expected: PASS.
+Run: `npm run check`
+Expected: no new errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/util/sync/providers/mega/mega-provider.ts src/lib/util/sync/core/providers/mega-core.ts
+git commit -m "feat(mega): upload worker authenticates via session blob instead of password"
+```
+
+---
+
+### Task 7: 2FA two-step UI + needs-attention reconnect (`CloudView.svelte`)
+
+**Files:**
+
+- Modify: `src/lib/views/CloudView.svelte` (MEGA state 99-101; `handleMegaLogin` 370-400; `handleLogout` 412-415; `onMount` prefill 326-337; MEGA form 648-674)
+
+**Interfaces:**
+
+- Consumes (Task 2/4): `megaProvider.login({ email, password, secondFactorCode })` throws `ProviderError` with `code === 'MFA_REQUIRED'`; `megaProvider.getLastUsername?.()`.
+
+This task is UI; verify by manual run (no Vitest component test required — keep parity with the existing untested CloudView handlers). Steps below are edits, then a manual verification step.
+
+- [ ] **Step 1: Add MEGA 2FA/reconnect state (after line 101)**
+
+```svelte
+let megaTwoFactorCode = $state(''); let megaNeeds2fa = $state(false); let megaNeedsReLogin =
+$state(false);
+```
+
+- [ ] **Step 2: Update `handleMegaLogin()` (370-400) for the two-step flow**
+
+```svelte
+  async function handleMegaLogin() {
+    megaLoading = true;
+    try {
+      const megaProvider = await providerManager.getOrLoadProvider('mega');
+      await megaProvider.login({
+        email: megaEmail,
+        password: megaPassword,
+        secondFactorCode: megaNeeds2fa ? megaTwoFactorCode : undefined
+      });
+
+      await providerManager.setCurrentProvider(megaProvider);
+
+      showSnackbar('Connected to MEGA - loading cloud data...');
+      await unifiedCloudManager.fetchAllCloudVolumes();
+
+      providerManager.updateStatus();
+      showSnackbar('MEGA connected');
+
+      // Clear form + 2FA/reconnect state
+      megaEmail = '';
+      megaPassword = '';
+      megaTwoFactorCode = '';
+      megaNeeds2fa = false;
+      megaNeedsReLogin = false;
+
+      await handlePostLogin();
+    } catch (error) {
+      if (error && (error as { code?: string }).code === 'MFA_REQUIRED') {
+        // Reveal the 2FA field and keep email/password so the user just adds the code.
+        megaNeeds2fa = true;
+        showSnackbar('Enter your MEGA two-factor authentication code');
+      } else {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        showSnackbar(message);
+      }
+    } finally {
+      megaLoading = false;
+    }
+  }
+```
+
+- [ ] **Step 3: Reset 2FA state on logout (412-415)**
+
+```svelte
+    if (provider === 'mega') {
+      megaEmail = '';
+      megaPassword = '';
+      megaTwoFactorCode = '';
+      megaNeeds2fa = false;
+      megaNeedsReLogin = false;
+      showSnackbar('Logged out of MEGA');
+    } else if (provider === 'webdav') {
+```
+
+- [ ] **Step 4: Prefill email + reconnect banner in `onMount` (extend the block at 326-337)**
+
+After the WebDAV prefill block, add MEGA prefill:
+
+```svelte
+    // Pre-fill MEGA email + reconnect banner from last session (needs-attention)
+    try {
+      const megaProviderInstance = await providerManager.getOrLoadProvider('mega');
+      const lastEmail = megaProviderInstance.getLastUsername?.();
+      if (!megaEmail && lastEmail) megaEmail = lastEmail;
+      if (megaProviderInstance.getStatus().needsAttention) {
+        megaNeedsReLogin = true;
+        const megaForm = document.getElementById('mega-login-form');
+        if (megaForm) megaForm.classList.remove('hidden');
+      }
+    } catch {
+      // Provider not loadable, ignore
+    }
+```
+
+- [ ] **Step 5: Add the 2FA field + reconnect banner to the MEGA form (648-674)**
+
+Replace the `<div id="mega-login-form" ...>` block contents:
+
+```svelte
+<div id="mega-login-form" class="hidden pr-4 pb-4 pl-12">
+  {#if megaNeedsReLogin}
+    <p class="mb-3 text-sm text-amber-400">
+      Your MEGA session expired — sign in again to reconnect.
+    </p>
+  {/if}
+  <form
+    onsubmit={(e) => {
+      e.preventDefault();
+      handleMegaLogin();
+    }}
+    class="flex flex-col gap-3"
+  >
+    <input
+      type="email"
+      bind:value={megaEmail}
+      placeholder="Email"
+      required
+      class="rounded-lg border border-gray-600 bg-gray-700 p-2.5 text-sm text-white"
+    />
+    <input
+      type="password"
+      bind:value={megaPassword}
+      placeholder="Password"
+      required
+      class="rounded-lg border border-gray-600 bg-gray-700 p-2.5 text-sm text-white"
+    />
+    {#if megaNeeds2fa}
+      <input
+        type="text"
+        inputmode="numeric"
+        autocomplete="one-time-code"
+        bind:value={megaTwoFactorCode}
+        placeholder="6-digit 2FA code"
+        class="rounded-lg border border-amber-600 bg-gray-700 p-2.5 text-sm text-white"
+      />
+    {/if}
+    <Button type="submit" disabled={megaLoading} color="blue" size="sm">
+      {megaLoading ? 'Connecting...' : megaNeeds2fa ? 'Verify & Connect' : 'Connect to MEGA'}
+    </Button>
+  </form>
+</div>
+```
+
+- [ ] **Step 6: Type-check, lint, manual verify**
+
+Run: `npm run check` and `npm run lint` — expect no new errors.
+Run: `npm run dev`, open the cloud view:
+
+- Non-2FA account: email+password connects; reload the page → still connected with **no** `mega_password` in `localStorage` and a `mega_session` present (DevTools → Application → Local Storage).
+- 2FA account: email+password → "Enter your 2FA code" → field appears → code → connects.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/views/CloudView.svelte
+git commit -m "feat(mega): two-step 2FA login UI and session-expiry reconnect prompt"
+```
+
+- [ ] **Step 8: Full Phase 1 regression**
+
+Run: `npx vitest run` (whole suite) and `npm run check`.
+Expected: all pass; no regressions in other providers.
+
+---
+
+## Phase 2 — Download workers without share links
+
+### Task 8: `getWorkerDownloadCredentials()` → `{ sid, nodeId, fileKey }`; remove share-link machinery
+
+**Files:**
+
+- Modify: `src/lib/util/sync/providers/mega/mega-provider.ts` (`supportsWorkerDownload` comment 139; remove fields 146-148; remove `createShareLink` 1011-1061, `deleteShareLink` 1067-1110, `cleanupWorkerDownload` 1223-1233; rewrite `getWorkerDownloadCredentials` 1209-1221)
+- Test: `src/lib/util/sync/providers/mega/mega-provider.test.ts`
+
+**Interfaces:**
+
+- Consumes (Task 1): `encodeMegaKey`. Existing `getNodeById()` (439-442).
+- Produces: `getWorkerDownloadCredentials(fileId)` returns `{ sid: string, nodeId: string, fileKey: string }`. `createShareLink`/`deleteShareLink`/`cleanupWorkerDownload` removed (download-queue guards on their presence).
+
+- [ ] **Step 1: Write failing test**
+
+Append to `mega-provider.test.ts`:
+
+```ts
+describe('MegaProvider.getWorkerDownloadCredentials() (Phase 2)', () => {
+  it('returns sid + nodeId + encoded per-file key, never a share link or master key', async () => {
+    localStorage.setItem('mega_session', JSON.stringify({ key: 'K', sid: 'SID123', options: {} }));
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    // Seed the restored storage's tree with a target node.
+    (provider as any).storage = {
+      sid: 'SID123',
+      files: {
+        node1: { nodeId: 'node1', directory: false, key: new Uint8Array([255, 255, 255]) }
+      }
+    };
+
+    const creds = await provider.getWorkerDownloadCredentials('node1');
+    expect(creds).toEqual({ sid: 'SID123', nodeId: 'node1', fileKey: '____' });
+    expect(creds).not.toHaveProperty('megaShareUrl');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/lib/util/sync/providers/mega/mega-provider.test.ts`
+Expected: FAIL — still returns `{ megaShareUrl }`.
+
+- [ ] **Step 3: Rewrite `getWorkerDownloadCredentials()` (1209-1221)**
+
+```ts
+  async getWorkerDownloadCredentials(fileId: string): Promise<Record<string, any>> {
+    if (!this.isAuthenticated()) {
+      throw new ProviderError('Not authenticated', 'mega', 'NOT_AUTHENTICATED', true);
+    }
+    const node = this.getNodeById(fileId);
+    if (!node || !node.key) {
+      throw new ProviderError(
+        `MEGA node not found or missing key: ${fileId}`,
+        'mega',
+        'NODE_NOT_FOUND',
+        false,
+        true
+      );
+    }
+    // sid authorizes the owned-node download; the per-file key decrypts it.
+    // The download worker never receives the account master key.
+    return {
+      sid: this.storage.sid,
+      nodeId: node.nodeId,
+      fileKey: encodeMegaKey(node.key as Uint8Array)
+    };
+  }
+```
+
+- [ ] **Step 4: Remove the now-dead share-link machinery**
+
+Delete: the `createShareLink()` method (1011-1061), `deleteShareLink()` (1067-1110), and `cleanupWorkerDownload()` (1223-1233). Delete the three fields (146-148): `workerShareLinksToCleanup`, `workerShareLinkMutex`, `WORKER_SHARE_LINK_THROTTLE_MS`. Update the `supportsWorkerDownload` comment (139):
+
+```ts
+  readonly supportsWorkerDownload = true; // Workers download owned nodes via sid + per-file key
+```
+
+Verify nothing else references the removed symbols:
+`grep -n "createShareLink\|deleteShareLink\|cleanupWorkerDownload\|workerShareLink\|WORKER_SHARE_LINK" src/lib/util/sync/providers/mega/mega-provider.ts` → no matches.
+
+- [ ] **Step 5: Run tests + type-check**
+
+Run: `npx vitest run src/lib/util/sync/providers/mega/mega-provider.test.ts`
+Expected: PASS.
+Run: `npm run check`
+Expected: no new errors (download-queue's `cleanupWorkerDownload?` guard tolerates the method's absence).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/util/sync/providers/mega/mega-provider.ts src/lib/util/sync/providers/mega/mega-provider.test.ts
+git commit -m "feat(mega): worker download credentials use sid + per-file key; drop share links"
+```
+
+---
+
+### Task 9: Worker download via owned-node `File` (`mega-core.ts`)
+
+**Files:**
+
+- Modify: `src/lib/util/sync/core/providers/mega-core.ts` (`downloadFile` 53-96; add `getDownloadApi` helper)
+- Test: `src/lib/util/sync/core/providers/mega-core.test.ts` (new)
+
+**Interfaces:**
+
+- Consumes: credentials `{ sid, nodeId, fileKey }` from Task 8.
+- Produces: `downloadFile` builds `new File({ downloadId: nodeId, key: fileKey, api })` with `file.nodeId = nodeId` and streams `downloadBuffer`/`download`.
+
+- [ ] **Step 1: Write failing test (mock megajs File + a sid-bearing api)**
+
+Create `src/lib/util/sync/core/providers/mega-core.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'events';
+
+const state = vi.hoisted(() => ({
+  lastFileOpts: null as any,
+  fileNodeIdAfterConstruct: null as any,
+  chunks: [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5])]
+}));
+
+vi.mock('megajs', () => {
+  class MockStorage {
+    api: any = { sid: null };
+    constructor(_opts: any) {}
+  }
+  class MockFile extends EventEmitter {
+    nodeId: any = null;
+    constructor(opts: any) {
+      super();
+      state.lastFileOpts = opts;
+    }
+    download() {
+      state.fileNodeIdAfterConstruct = this.nodeId;
+      const stream = new EventEmitter() as any;
+      queueMicrotask(() => {
+        let loaded = 0;
+        for (const c of state.chunks) {
+          loaded += c.length;
+          stream.emit('data', c);
+          stream.emit('progress', { bytesLoaded: loaded, bytesTotal: 5 });
+        }
+        stream.emit('end');
+      });
+      return stream;
+    }
+  }
+  return { Storage: MockStorage, File: MockFile };
+});
+
+import { megaCore } from './mega-core';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.lastFileOpts = null;
+  state.fileNodeIdAfterConstruct = null;
+});
+
+describe('megaCore.downloadFile() (Phase 2)', () => {
+  it('builds an owned-node File (downloadId+key+api) and forces file.nodeId', async () => {
+    const onProgress = vi.fn();
+    const buf = await megaCore.downloadFile({
+      fileId: 'node1',
+      credentials: { sid: 'SID123', nodeId: 'node1', fileKey: '____' },
+      onProgress
+    } as any);
+
+    expect(state.lastFileOpts.downloadId).toBe('node1');
+    expect(state.lastFileOpts.key).toBe('____');
+    expect(state.lastFileOpts.api.sid).toBe('SID123');
+    expect(state.fileNodeIdAfterConstruct).toBe('node1'); // owned-node path forced
+    expect(new Uint8Array(buf)).toEqual(new Uint8Array([1, 2, 3, 4, 5]));
+    expect(onProgress).toHaveBeenLastCalledWith(5, 5);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/lib/util/sync/core/providers/mega-core.test.ts`
+Expected: FAIL — `downloadFile` still reads `megaShareUrl` / calls `fromURL`.
+
+- [ ] **Step 3: Rewrite `downloadFile()` + add `getDownloadApi`**
+
+In `mega-core.ts`, after the upload-storage helpers, add:
+
+```ts
+// Lightweight, per-sid API instances for owned-node downloads. A Storage built with
+// autologin/autoload false makes no network call and loads no tree; we only need its
+// `api` (with the session id) to authorize `a:"g", n:<nodeId>` requests.
+const downloadApiBySid = new Map<string, any>();
+
+function getDownloadApi(sid: string): any {
+  let api = downloadApiBySid.get(sid);
+  if (!api) {
+    const storage: any = new Storage({
+      autologin: false,
+      autoload: false,
+      keepalive: false
+    } as any);
+    storage.api.sid = sid;
+    api = storage.api;
+    downloadApiBySid.set(sid, api);
+  }
+  return api;
+}
+```
+
+Replace `downloadFile()` (53-96):
+
+```ts
+  async downloadFile({ credentials, onProgress }): Promise<ArrayBuffer> {
+    const sid = requireCredentialString(credentials, 'sid', 'MEGA session id');
+    const nodeId = requireCredentialString(credentials, 'nodeId', 'MEGA node id');
+    const fileKey = requireCredentialString(credentials, 'fileKey', 'MEGA file key');
+    const api = getDownloadApi(sid);
+
+    return await new Promise<ArrayBuffer>((resolve, reject) => {
+      try {
+        // formatKey(fileKey) base64url-decodes into a real megajs Buffer.
+        const file: any = new MegaFile({ downloadId: nodeId, key: fileKey, api });
+        // Force the owned-node download path (req.n = nodeId, authorized by api.sid).
+        file.nodeId = nodeId;
+
+        const stream = file.download({});
+        const chunks: Uint8Array[] = [];
+
+        stream.on('data', (chunk: Uint8Array) => {
+          chunks.push(chunk);
+        });
+        stream.on('progress', (p: { bytesLoaded: number; bytesTotal: number }) => {
+          onProgress(p.bytesLoaded, p.bytesTotal);
+        });
+        stream.on('end', async () => {
+          const blob = new Blob(chunks as BlobPart[]);
+          const buffer = await blob.arrayBuffer();
+          chunks.length = 0;
+          resolve(buffer);
+        });
+        stream.on('error', (streamError: Error) => {
+          reject(new Error(`MEGA download failed: ${streamError.message}`));
+        });
+      } catch (error) {
+        reject(
+          new Error(
+            `MEGA download init failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+          )
+        );
+      }
+    });
+  },
+```
+
+(The top-of-file `import { File as MegaFile, Storage } from 'megajs';` already provides both. `requireCredentialString` is already imported.)
+
+- [ ] **Step 4: Run test + type-check**
+
+Run: `npx vitest run src/lib/util/sync/core/providers/mega-core.test.ts`
+Expected: PASS.
+Run: `npm run check`
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/util/sync/core/providers/mega-core.ts src/lib/util/sync/core/providers/mega-core.test.ts
+git commit -m "feat(mega): download owned nodes in workers via sid + per-file key (no share links)"
+```
+
+---
+
+### Task 10: Integration cleanup + live verification
+
+**Files:**
+
+- Verify: `src/lib/util/download-queue.ts` (cleanup call sites 622-623, 732, 741), `src/lib/util/backup-queue.ts` (268-269)
+- Test: whole suite + manual live MEGA verification
+
+**Interfaces:** none new — this task confirms the removed `cleanupWorkerDownload` and changed credential shapes integrate cleanly.
+
+- [ ] **Step 1: Confirm no dangling references to removed symbols / old credential keys**
+
+Run:
+
+```bash
+grep -rn "megaShareUrl\|createShareLink\|deleteShareLink\|cleanupWorkerDownload\|megaEmail\|megaPassword" src --include="*.ts" --include="*.svelte"
+```
+
+Expected: no matches in `src/lib/util/sync/**` or `src/lib/workers/**` or `src/lib/util/*queue*.ts`. (`download-queue.ts:622` guards `if (activeProvider.cleanupWorkerDownload)`, which is now always false for MEGA — that's correct and needs no change.)
+
+- [ ] **Step 2: Full automated regression**
+
+Run: `npx vitest run` and `npm run check` and `npm run lint`.
+Expected: all green; no regressions.
+
+- [ ] **Step 3: Live verification against a real MEGA account (not CI)**
+
+Run `npm run dev` (or a Playwright session with a test account) and confirm in DevTools → Network/Application:
+
+- **Download a volume from MEGA via the worker:** no `link`/`unshare` API calls are issued (search Network for `cs?` requests with `"a":"l"` / `"a":"l2"`); the file downloads and imports correctly.
+- **Upload a volume:** the worker `postMessage` payload contains `megaSession` and **no** `megaPassword`/`megaEmail` (inspect via a temporary `console.log` of credential keys — never log the value — then remove it).
+- **Reconnect on expiry:** in MEGA web → Settings → Session history, close this app's session; back in the app trigger a sync → the UI shows the needs-attention reconnect prompt with the email pre-filled; re-login restores sync.
+
+- [ ] **Step 4: Final commit (if any verification fixes were needed)**
+
+```bash
+git add -A
+git commit -m "chore(mega): finalize session-token worker integration and verification"
+```
+
+---
+
+## Self-Review (completed against the spec)
+
+**Spec coverage:** §A stored artifact → Task 2 (`persistSession`, `STORAGE_KEYS.SESSION`) + Task 1 (`sanitizeSessionBlob`). §B login/restore → Tasks 2–3. §C 2FA → Task 2 (provider) + Task 7 (UI). §D needs-attention → Task 4 + Task 7. §E migration → Task 3 + Task 5 (detection/manager). §F download workers → Tasks 8–9. §G upload worker → Task 6. Testing → per-task Vitest + Task 10 live. Build-time verifications #1/#3/#4 land in Phase 1 (Tasks 3/6); #2 (owned-node download) lands in Task 9 + Task 10 live check.
+
+**Placeholder scan:** none — every code/test step contains full content.
+
+**Type consistency:** `MegaSessionBlob`, `STORAGE_KEYS.SESSION`, `needsReconnect`, `reconnectEmail`, `persistSession`, `restoreSession`, `restorePersistedSession`, `markSessionExpired`, `getLastUsername`, and credential shapes (`{ megaSession }`, `{ sid, nodeId, fileKey }`) are defined once and used consistently across tasks. The megajs mock's `fromJSON`/`reload`/`Storage`/`File` shapes match the real browser-build signatures verified in the spec.

--- a/docs/superpowers/specs/2026-06-29-mega-session-auth-design.md
+++ b/docs/superpowers/specs/2026-06-29-mega-session-auth-design.md
@@ -1,0 +1,234 @@
+# MEGA Session-Token Auth, 2FA, and Worker Hardening — Design
+
+**Date:** 2026-06-29
+**Branch:** `feat/mega-session-auth` (based on `develop`)
+**Status:** Approved design → implementation planning
+
+## Problem
+
+The MEGA cloud-sync provider has three coupled issues, all rooted in how it authenticates:
+
+1. **Plaintext password storage.** Credentials are stored as plaintext `mega_email` + `mega_password`
+   in `localStorage` (`mega-provider.ts:21-25`, save at `:230-233`). A full
+   `new Storage({ email, password })` login runs on **every** app load, manual connect, and cache
+   refresh (`reinitialize()`), creating a brand-new MEGA session each time. The password is the most
+   dangerous secret possible — it grants permanent, full account control (change email/password,
+   disable 2FA, delete account) and never expires.
+
+2. **No 2FA support.** Because login replays the stored password on every reload, there is no way to
+   support two-factor accounts: a single-use TOTP code cannot be replayed. There is no 2FA handling
+   or UI anywhere today.
+
+3. **Hacky worker file access.**
+   - _Downloads_ use a **public share-link workaround**: the main thread mints a `file.link()` URL
+     (decryption key embedded), ships `megaShareUrl` to the worker, the worker downloads anonymously
+     via `MegaFile.fromURL`, then the main thread tears the link down with `unshare()`
+     (`mega-provider.ts:1011-1088`, `mega-core.ts:53-67`). A mutex + 200 ms throttle gates link
+     creation. This briefly exposes every downloaded file as a public URL.
+   - _Uploads_ hand the **plaintext password** to the worker (`getWorkerUploadCredentials()` →
+     `{ megaEmail, megaPassword }`, `mega-provider.ts:1197-1202`), which spins up its own full
+     `Storage`.
+
+## Goal
+
+Replace password storage with a reused, revocable **session token**; add **2FA** login; and replace
+both worker hacks with lightweight, session-based file access — without leaving any plaintext
+password in storage or in worker messages.
+
+## Library constraints (megajs 1.3.9, verified against installed source)
+
+These facts, verified against `node_modules/megajs/dist/*` and `types/cjs.d.ts`, drive the design.
+
+- **Session persistence is via `storage.toJSON()` / `Storage.fromJSON()`** — there is **no**
+  `sessionID` constructor option, no `Storage.fromSession`, no `'login'` event.
+  - `storage.toJSON()` → `{ sid, key, user, name, options }` (`main.node-cjs.js:2275-2283`).
+  - `Storage.fromJSON(json)` rebuilds an authenticated `Storage` with **zero network calls**,
+    forcing `autoload:false` + `autologin:false` and injecting `sid` into the API layer
+    (`:2284-2295`).
+- **⚠ The persisted blob contains the account master key (`key`), not just a session id.** The bare
+  `sid` authenticates raw API calls but cannot decrypt owned-file keys — that needs the master key,
+  derivable only from the password at login time. So the stored "token" is still a sensitive secret.
+  It is nonetheless **meaningfully safer than the password**: the session is server-revocable, and it
+  **cannot** change the account password/email or disable 2FA (those require the password). The
+  serialized blob does **not** contain the password (deleted by the lib at login,
+  `:2088`). **Accepted tradeoff** — there is no lower-privilege artifact in this library.
+- **2FA is supported.** `new Storage({ email, password, secondFactorCode })` → maps to the `us`
+  command's `mfa` field (`:2087-2091`). "2FA required" is signaled **only** by an error message
+  containing `EMFAREQUIRED` / `-26` / `Multi-Factor` (`:804`, `:884-892`) — no numeric `.code`
+  property; the caller must string-match.
+- **Lightweight sessions are supported.** `autoload:false` authenticates (gets `sid` + master key)
+  without fetching the file tree (`:2055-2068`); `fromJSON()` is lighter still (no network at all,
+  no keepalive long-poll).
+- **Owned-node download by id is possible without the tree.** `File.download` issues an
+  authenticated `{ a:"g", g:1, n:<nodeId> }` when `file.nodeId` is set, authorized by `api.sid`
+  (`:1140-1158`, `:856-857`). Construct `new File({ downloadId: nodeId, key, api })`, force
+  `file.nodeId = nodeId`, call `downloadBuffer()`. **No share link, and the master key is not needed
+  in the download worker** — only `sid` + the per-file key.
+- **Session invalidation** surfaces as `ESID (-15): Invalid or expired user session, please relogin`
+  (`:798`).
+- The browser build (`main.browser-es.mjs`) is at parity for all of the above (`fromJSON`,
+  `secondFactorCode`, `sid`, `EMFAREQUIRED`).
+
+## Design
+
+### A. Stored artifact (replaces `mega_email`/`mega_password`)
+
+- New `localStorage` key **`mega_session`** = `JSON.stringify(storage.toJSON())`.
+  - Before persisting, sanitize `blob.options` to drop `secondFactorCode` (single-use) and any
+    `password` residue. Email remains in `blob.options.email` — used for status display and
+    reconnect pre-fill, so **no separate `mega_email` key is required going forward.**
+- On migration, **remove** the legacy `mega_email` and `mega_password` keys.
+- Stored plaintext, consistent with the existing `gdrive_token` pattern
+  (`google-drive/token-manager.ts`). Encrypting-at-rest is **out of scope**: there is no user secret
+  to derive a key from, and both `localStorage` and IndexedDB are equally readable by same-origin JS.
+
+### B. Login & restore (main thread — `mega-provider.ts`)
+
+- **Fresh interactive login** `login({ email, password, secondFactorCode? })`:
+  `new Storage({ email, password, secondFactorCode, autoload: true })` → `await ready` →
+  `ensureMokuroFolder()` → capture `toJSON()`, sanitize, write `mega_session`, remove legacy keys,
+  `setActiveProviderKey('mega')`.
+- **Restore** `restoreSession(blob)`: `Storage.fromJSON(blob)` (no network, no password) → then
+  `storage.reload()` to load the file tree the main thread needs for listing/upload/rename/delete.
+  This **replaces today's full re-login-on-every-load**: no password, the session is reused, and we
+  do one tree fetch instead of a login round-trip + tree fetch.
+- **`reinitialize()`** (cache-staleness refresh) calls `storage.reload()` on the existing session
+  instead of a fresh `login()`. Must confirm `reload()` refreshes `storage.files` (verification #1).
+- **Error discrimination** (unchanged philosophy): transient/network errors keep `mega_session` and
+  retry; genuine auth/session failures route to needs-attention (§D).
+
+### C. 2FA — two-step, reveal-on-demand
+
+- Provider: in `login()`, catch the login rejection; if its message matches
+  `/EMFAREQUIRED|-26|Multi-Factor/i`, rethrow a **typed** `ProviderError` with a stable
+  `code: 'MFA_REQUIRED'` (and `isAuthError: false`) so the UI branches on a code, not a string.
+- UI (`CloudView.svelte`): MEGA form shows email + password only. On `MFA_REQUIRED`, keep
+  email/password in component state, set `megaNeeds2fa = true`, reveal a 6-digit code `<input>`
+  (`bind:value={megaTwoFactorCode}`), and resubmit `login({ email, password, secondFactorCode })`.
+  The code is **never** persisted. On success, clear all fields including the code.
+- `provider-interface.ts`: document `secondFactorCode` in the `ProviderCredentials` comment; add the
+  `MFA_REQUIRED` code to the `ProviderError` conventions.
+
+### D. Session loss / needs-attention (no stored password)
+
+- Detect `ESID (-15)` (message match) on any authenticated operation → `markSessionExpired()`:
+  remove `mega_session`, set an internal `needsAttention` flag, retain the email (parsed from the old
+  blob before clearing, or held in memory) for reconnect pre-fill.
+- `getStatus()` returns `{ isAuthenticated:false, needsAttention:true, statusMessage:'MEGA session
+expired — please reconnect' }`.
+- `CloudView.svelte` renders a reconnect prompt (pre-filled email) when MEGA needs attention,
+  reusing the WebDAV needs-attention UI scaffolding (`CloudView.svelte:55-60`, `:113-115`,
+  `:693-697`) extended to MEGA. MEGA has no needs-attention UI today, so this is net-new wiring.
+- Because no password is stored, reconnect always goes through the full login form (+ 2FA if
+  required). MEGA sessions are long-lived, so this is rare in practice.
+
+### E. Migration (existing users)
+
+In the restore path (`loadPersistedCredentials` → renamed/reworked `restorePersistedSession`):
+
+1. If `mega_session` present → `restoreSession(blob)`.
+2. Else if legacy `mega_email` + `mega_password` present → silent `login({ email, password })`. On
+   success this writes `mega_session` and deletes the legacy keys (in-place upgrade). On
+   `MFA_REQUIRED` (account enabled 2FA since the password was stored) → `markSessionExpired()` /
+   needs-attention reconnect. On genuine auth failure → clear + needs-attention. On transient error →
+   keep legacy keys for retry.
+3. Else → unauthenticated.
+
+- `provider-detection.ts`: `detectProviderFromCredentials()` recognizes `mega_session` **or** the
+  legacy pair (so a not-yet-migrated user is still detected as MEGA).
+- `provider-manager.ts`: `logout()` hard-clear list removes `mega_session` **and** the legacy
+  `mega_email`/`mega_password`/`mega_folder_path`.
+
+### F. Worker downloads — remove share links (Phase 2)
+
+_Verified: `createShareLink`/`deleteShareLink` have no callers outside the worker-download path, so
+the entire share-link mechanism can be removed._
+
+- `getWorkerDownloadCredentials(fileId)`: from the already-loaded tree, locate the node and return
+  **`{ sid, nodeId, fileKey }`** — the session id, node id, and the node's already-decrypted per-file
+  key (base64). **No share link, no master key in the download worker.** Drop the
+  mutex/`workerShareLinkMutex`/`WORKER_SHARE_LINK_THROTTLE_MS`/`workerShareLinksToCleanup`.
+- `mega-core.downloadFile`: build a lightweight, per-`sid`-cached api
+  (`new Storage({ autologin:false, autoload:false })`; set `api.sid = sid`), then
+  `new File({ downloadId: nodeId, key: fileKeyBuffer, api })`, force `file.nodeId = nodeId`, call
+  `downloadBuffer()` (with progress). Remove the `MegaFile.fromURL(shareUrl)` path.
+- `cleanupWorkerDownload(fileId)` becomes a no-op (or is removed); `download-queue.ts` cleanup
+  branches for MEGA are removed.
+- Remove `createShareLink` / `deleteShareLink` and the `megaShareUrl` credential.
+
+### G. Worker uploads — remove password (Phase 1 — forced by §A)
+
+_This lands in Phase 1, not Phase 2: §A deletes the stored password, but the upload worker currently
+reads `mega_email`/`mega_password`. Once the password is gone, the upload path must already use the
+session blob. (Download share links, §F, are unaffected — they use the main-thread session, which
+keeps working post-migration — so only §F is deferrable to Phase 2.)_
+
+- `getWorkerUploadCredentials()`: return **`{ megaSession: <sanitized toJSON blob> }`** instead of
+  `{ megaEmail, megaPassword }`.
+- `mega-core.getUploadStorage(session)`: `Storage.fromJSON(blob)` + `reload()` for the target folder;
+  cache per `sid` (replacing the email+password-keyed cache). Remove the `requireCredentialString`
+  reads of `megaEmail`/`megaPassword`.
+- **Asymmetry (documented):** upload necessarily needs the master key to wrap the new file key, so
+  the upload worker receives the full session blob (incl. master key). This is still strictly safer
+  than today's plaintext password (the password adds permanent account control + lockout; the blob
+  does not). Download workers never receive the master key.
+
+## Module boundaries
+
+- **`mega-provider.ts`** (main thread): owns the authenticated `Storage`, session persistence
+  (`toJSON`/`fromJSON`), migration, 2FA error mapping, needs-attention state, and worker-credential
+  minting. Public surface unchanged except credential-bag shapes and new typed errors.
+- **`mega-core.ts`** (worker): stateless download via `sid + nodeId + fileKey`; upload via
+  `fromJSON(session)`. No knowledge of localStorage or the UI.
+- **`CloudView.svelte`**: 2FA two-step form state + needs-attention reconnect UI. Calls the provider;
+  no megajs knowledge.
+- **`provider-detection.ts` / `provider-manager.ts`**: detection + logout key hygiene for the new
+  `mega_session` key alongside legacy cleanup.
+- **`provider-interface.ts`**: documents `secondFactorCode` + `MFA_REQUIRED`.
+
+## Testing
+
+- **Vitest (CI, mocked megajs).** Mock `Storage` / `Storage.fromJSON` / `File`. Cover:
+  - migration: legacy `mega_email`+`mega_password` → `mega_session` written, legacy keys removed;
+  - 2FA: login throws `EMFAREQUIRED` → provider rethrows `MFA_REQUIRED`; retry with code succeeds;
+  - session loss: `ESID` on an op → `markSessionExpired()` clears `mega_session` + needs-attention;
+  - logout clears `mega_session` + legacy keys;
+  - worker credential shapes: download → `{ sid, nodeId, fileKey }` (no master key); upload →
+    `{ megaSession }` (no password).
+- **Manual / live (not CI; needs a real account).** non-2FA login; 2FA login; reload reuses session
+  (DevTools: no `us` login request, `mega_session` present, no `mega_password`); worker download
+  issues **no** `link`/`unshare` requests; worker upload `postMessage` carries **no** password;
+  revoke session in MEGA settings → reconnect prompt appears.
+
+## Build-time verification items (confirm via tests/spikes during implementation)
+
+1. `Storage.fromJSON` + `storage.reload()` signature, and that `reload()` refreshes `storage.files`
+   on a `fromJSON`'d session (drives §B restore + §C `reinitialize`).
+2. **Linchpin:** Option-B owned-node download (`new File({ downloadId: nodeId, key, api })` +
+   `file.nodeId = nodeId` + `api.sid`) actually downloads an owned file. Source analysis says yes;
+   confirm live in Phase 2. _Fallback if it fails:_ download worker uses `fromJSON(session)` +
+   `reload()` and `storage.files[nodeId].downloadBuffer()` (accepts the master key in the download
+   worker — still no share link).
+3. Upload via `fromJSON + reload` reaches the target folder correctly (§G).
+4. Browser megajs build exports `Storage.fromJSON` / `File` for worker use (research says yes;
+   `mega-core` already imports both).
+
+## Phasing
+
+- **Phase 1 (auth + upload worker):** §A–E **and §G** — token storage, 2FA two-step UI,
+  needs-attention/session-loss UX, migration, detection/logout hygiene, **and the upload-worker
+  switch from password to session blob** (forced because §A removes the password the upload worker
+  reads). Download workers continue using share links unchanged (the main-thread session restored via
+  `fromJSON` still mints them). Self-contained and shippable. One reviewable PR.
+  - Build-time verifications needed here: #1 (`fromJSON`/`reload`), #3 (upload via `fromJSON+reload`),
+    #4 (browser build exports).
+- **Phase 2 (download workers):** §F — replace share-link downloads with `sid + nodeId + fileKey`,
+  delete the entire share-link machinery (`createShareLink`/`deleteShareLink`/mutex/throttle/
+  `megaShareUrl`), unit tests + live verification. One reviewable PR.
+  - Build-time verification needed here: #2 (the owned-node-download linchpin).
+
+## Out of scope
+
+- Encrypting the stored session blob at rest.
+- Re-architecting megajs's upload key-wrapping to keep the master key out of the upload worker.
+- Changes to other providers (Google Drive, WebDAV) beyond shared interface documentation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mokuro-reader",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mokuro-reader",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "dependencies": {
         "@types/gapi": "^0.0.47",
         "@vercel/analytics": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mokuro-reader",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/lib/components/Reader/PagedViewport.svelte
+++ b/src/lib/components/Reader/PagedViewport.svelte
@@ -140,8 +140,10 @@
     }
     e.preventDefault();
     motion.beforeAnimatedScroll();
-    camera.panBy(-normalizeWheelDelta(e.deltaX, e.deltaMode),
-      -normalizeWheelDelta(e.deltaY, e.deltaMode));
+    camera.panBy(
+      -normalizeWheelDelta(e.deltaX, e.deltaMode),
+      -normalizeWheelDelta(e.deltaY, e.deltaMode)
+    );
   }
 
   function doubleTap(x: number, y: number) {

--- a/src/lib/components/Reader/PagedViewport.svelte
+++ b/src/lib/components/Reader/PagedViewport.svelte
@@ -140,7 +140,8 @@
     }
     e.preventDefault();
     motion.beforeAnimatedScroll();
-    camera.panBy(0, -normalizeWheelDelta(e.deltaY, e.deltaMode));
+    camera.panBy(-normalizeWheelDelta(e.deltaX, e.deltaMode),
+      -normalizeWheelDelta(e.deltaY, e.deltaMode));
   }
 
   function doubleTap(x: number, y: number) {

--- a/src/lib/components/VolumeItem.svelte
+++ b/src/lib/components/VolumeItem.svelte
@@ -345,10 +345,10 @@
           deleteVolumeStats(volume.volume_uuid);
         }
 
-        // Delete from cloud if checkbox checked
+        // Delete from cloud if checkbox checked (archive + sidecars)
         if (deleteCloud && hasCloudBackup && cloudFile) {
           try {
-            await unifiedCloudManager.deleteFile(cloudFile);
+            await unifiedCloudManager.deleteManagedVolume(volume.series_title, volume.volume_title);
             showSnackbar(`Deleted from ${providerDisplayName}`);
           } catch (error) {
             console.error('Failed to delete from cloud:', error);
@@ -468,9 +468,12 @@
 
     // If already backed up, delete from cloud
     if (isBackedUp && cloudFile) {
+      // Capture provider before the await: cloudFile is a $derived that becomes
+      // undefined once the delete refreshes the cache.
+      const providerType = cloudFile.provider;
       try {
-        await unifiedCloudManager.deleteFile(cloudFile);
-        const providerName = cloudFile.provider === 'google-drive' ? 'Drive' : cloudFile.provider;
+        await unifiedCloudManager.deleteManagedVolume(volume.series_title, volume.volume_title);
+        const providerName = providerType === 'google-drive' ? 'Drive' : providerType;
         showSnackbar(`Deleted from ${providerName}`);
       } catch (error) {
         console.error('Delete failed:', error);

--- a/src/lib/util/sync/core/providers/mega-core.test.ts
+++ b/src/lib/util/sync/core/providers/mega-core.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// vi.hoisted: state that the vi.mock factory can close over without TDZ issues.
+// The factory must NOT reference any module-level imports (they'd be in TDZ when
+// the factory is registered), so we use vi.hoisted for shared mutable state and
+// implement EventEmitter inline to avoid importing 'events'.
+const state = vi.hoisted(() => ({
+  lastFileOpts: null as any,
+  fileNodeIdAfterConstruct: null as any,
+  chunks: [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5])]
+}));
+
+vi.mock('megajs', () => {
+  // Minimal EventEmitter — no external import needed inside a hoisted factory.
+  class SimpleEmitter {
+    private _h: Record<string, Array<(...args: any[]) => void>> = {};
+    on(event: string, fn: (...args: any[]) => void) {
+      (this._h[event] ??= []).push(fn);
+      return this;
+    }
+    emit(event: string, ...args: any[]) {
+      (this._h[event] ?? []).forEach((h) => h(...args));
+      return true;
+    }
+  }
+
+  class MockStorage {
+    api: any = { sid: null };
+    constructor(_opts: any) {}
+  }
+
+  class MockFile extends SimpleEmitter {
+    nodeId: any = null;
+    constructor(opts: any) {
+      super();
+      state.lastFileOpts = opts;
+    }
+    download() {
+      state.fileNodeIdAfterConstruct = this.nodeId;
+      const stream = new SimpleEmitter() as any;
+      queueMicrotask(() => {
+        let loaded = 0;
+        for (const c of state.chunks) {
+          loaded += c.length;
+          stream.emit('data', c);
+          stream.emit('progress', { bytesLoaded: loaded, bytesTotal: 5 });
+        }
+        stream.emit('end');
+      });
+      return stream;
+    }
+  }
+
+  return { Storage: MockStorage, File: MockFile };
+});
+
+import { megaCore, isImageUpload } from './mega-core';
+
+describe('isImageUpload (MEGA thumbnail eligibility)', () => {
+  it('detects images by mime type', () => {
+    expect(isImageUpload('image/webp', 'cover.bin')).toBe(true);
+    expect(isImageUpload('image/jpeg', 'x')).toBe(true);
+  });
+  it('detects images by filename extension when mime is missing/generic', () => {
+    expect(isImageUpload(undefined, 'thumb.webp')).toBe(true);
+    expect(isImageUpload('application/octet-stream', 'thumb.PNG')).toBe(true);
+  });
+  it('rejects non-images (cbz, json)', () => {
+    expect(isImageUpload('application/x-cbz', 'Vol 1.cbz')).toBe(false);
+    expect(isImageUpload('application/json', 'volume-data.json')).toBe(false);
+    expect(isImageUpload(undefined, 'series.mokuro')).toBe(false);
+  });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.lastFileOpts = null;
+  state.fileNodeIdAfterConstruct = null;
+  state.chunks = [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5])];
+});
+
+describe('megaCore.downloadFile() (Phase 2)', () => {
+  it('builds an owned-node File (downloadId+key+api) and forces file.nodeId', async () => {
+    const onProgress = vi.fn();
+    const buf = await megaCore.downloadFile({
+      fileId: 'node1',
+      credentials: { sid: 'SID123', nodeId: 'node1', fileKey: '____' },
+      onProgress
+    } as any);
+
+    expect(state.lastFileOpts.downloadId).toBe('node1');
+    expect(state.lastFileOpts.key).toBe('____');
+    expect(state.lastFileOpts.api.sid).toBe('SID123');
+    expect(state.fileNodeIdAfterConstruct).toBe('node1'); // owned-node path forced
+    expect(new Uint8Array(buf)).toEqual(new Uint8Array([1, 2, 3, 4, 5]));
+    expect(onProgress).toHaveBeenLastCalledWith(5, 5);
+  });
+});

--- a/src/lib/util/sync/core/providers/mega-core.test.ts
+++ b/src/lib/util/sync/core/providers/mega-core.test.ts
@@ -54,7 +54,61 @@ vi.mock('megajs', () => {
   return { Storage: MockStorage, File: MockFile };
 });
 
-import { megaCore, isImageUpload } from './mega-core';
+import { megaCore, isImageUpload, resolveSeriesUploadFolder } from './mega-core';
+
+describe('resolveSeriesUploadFolder (no duplicate series folders)', () => {
+  function makeStorage(opts: { files?: any; rootChildren?: any[]; reloadAdds?: any } = {}) {
+    const storage: any = {
+      files: { ...(opts.files ?? {}) },
+      root: {
+        children: opts.rootChildren ?? [],
+        mkdir: vi.fn(async (name: string) => ({
+          name,
+          directory: true,
+          children: [],
+          mkdir: vi.fn(async (n: string) => ({ name: n, directory: true, children: [] }))
+        }))
+      },
+      reload: vi.fn(async () => {
+        Object.assign(storage.files, opts.reloadAdds ?? {});
+      })
+    };
+    return storage;
+  }
+
+  it('returns the folder by id without reload or mkdir when already in the tree', async () => {
+    const folder = { nodeId: 'F1', name: 'S', directory: true };
+    const storage = makeStorage({ files: { F1: folder } });
+    const result = await resolveSeriesUploadFolder(storage, 'F1', 'S');
+    expect(result).toBe(folder);
+    expect(storage.reload).not.toHaveBeenCalled();
+    expect(storage.root.mkdir).not.toHaveBeenCalled();
+  });
+
+  it('reloads once to find a folder created after the cached tree, never mkdir', async () => {
+    const folder = { nodeId: 'F1', name: 'S', directory: true };
+    const storage = makeStorage({ files: {}, reloadAdds: { F1: folder } });
+    const result = await resolveSeriesUploadFolder(storage, 'F1', 'S');
+    expect(storage.reload).toHaveBeenCalledWith(true);
+    expect(result).toBe(folder);
+    expect(storage.root.mkdir).not.toHaveBeenCalled();
+  });
+
+  it('falls back to finding an existing folder by name when no id is provided', async () => {
+    const seriesFolder = { name: 'S', directory: true };
+    const mokuro = { name: 'mokuro-reader', directory: true, children: [seriesFolder] };
+    const storage = makeStorage({ rootChildren: [mokuro] });
+    const result = await resolveSeriesUploadFolder(storage, undefined, 'S');
+    expect(result).toBe(seriesFolder);
+    expect(storage.root.mkdir).not.toHaveBeenCalled();
+  });
+
+  it('only creates folders by name in the legacy no-id path', async () => {
+    const storage = makeStorage({ rootChildren: [] });
+    await resolveSeriesUploadFolder(storage, undefined, 'New Series');
+    expect(storage.root.mkdir).toHaveBeenCalledWith('mokuro-reader');
+  });
+});
 
 describe('isImageUpload (MEGA thumbnail eligibility)', () => {
   it('detects images by mime type', () => {

--- a/src/lib/util/sync/core/providers/mega-core.ts
+++ b/src/lib/util/sync/core/providers/mega-core.ts
@@ -12,15 +12,19 @@ async function resetUploadStorage(): Promise<void> {
   if (!storagePromise) return;
 
   try {
-    const storage = await storagePromise;
-    await storage.close();
+    const storage = (await storagePromise) as any;
+    // Release the keepalive/server-change poll WITHOUT terminating the session:
+    // storage.close() issues {a:'sml'}, which kills the shared session sid (used by
+    // the persisted token and every other storage). api.close() only aborts the poll.
+    storage?.api?.close?.();
   } catch (error) {
-    console.warn('Worker: Failed to close MEGA upload storage:', error);
+    console.warn('Worker: Failed to release MEGA upload storage:', error);
   }
 }
 
-async function getUploadStorage(email: string, password: string): Promise<Storage> {
-  const sessionKey = `${email}\u0000${password}`;
+async function getUploadStorage(session: string): Promise<Storage> {
+  const parsed = JSON.parse(session);
+  const sessionKey: string = parsed.sid;
 
   if (uploadStoragePromise && uploadSessionKey === sessionKey) {
     return await uploadStoragePromise;
@@ -32,9 +36,15 @@ async function getUploadStorage(email: string, password: string): Promise<Storag
 
   uploadSessionKey = sessionKey;
   const pendingSession = (async () => {
-    const storage = new Storage({ email, password });
-    await storage.ready;
-    return storage;
+    // keepalive:false: no server-change poll in the worker session (we don't need it,
+    // and its handler crashes on delete events).
+    const storage = Storage.fromJSON({
+      ...parsed,
+      options: { ...(parsed.options ?? {}), keepalive: false }
+    }) as any;
+    // fromJSON loads no tree; reload populates storage.root for folder navigation/upload.
+    await storage.reload(true);
+    return storage as Storage;
   })();
   uploadStoragePromise = pendingSession;
 
@@ -49,56 +59,165 @@ async function getUploadStorage(email: string, password: string): Promise<Storag
   }
 }
 
+// Lightweight, per-sid API instances for owned-node downloads. A Storage built with
+// autologin/autoload false makes no network call and loads no tree; we only need its
+// `api` (with the session id) to authorize `a:"g", n:<nodeId>` requests.
+const downloadApiBySid = new Map<string, any>();
+
+function getDownloadApi(sid: string): any {
+  let api = downloadApiBySid.get(sid);
+  if (!api) {
+    const storage: any = new Storage({
+      autologin: false,
+      autoload: false,
+      keepalive: false
+    } as any);
+    storage.api.sid = sid;
+    api = storage.api;
+    downloadApiBySid.set(sid, api);
+  }
+  return api;
+}
+
+const IMAGE_MIME_RE = /^image\//;
+const IMAGE_EXT_RE = /\.(webp|jpe?g|png|gif|bmp|avif)$/i;
+
+/** Whether an upload is an image MEGA's browser could show a thumbnail for. */
+export function isImageUpload(mimeType: string | undefined, filename: string): boolean {
+  if (mimeType && IMAGE_MIME_RE.test(mimeType)) return true;
+  return IMAGE_EXT_RE.test(filename);
+}
+
+/**
+ * Render a MEGA-style thumbnail (120x120 JPEG, the type-0 convention) from an image
+ * blob, in the worker. Returns null if the worker lacks OffscreenCanvas/createImageBitmap
+ * or decoding fails — callers treat thumbnails as best-effort.
+ */
+async function renderMegaThumbnail(blob: Blob): Promise<Uint8Array | null> {
+  if (typeof OffscreenCanvas === 'undefined' || typeof createImageBitmap === 'undefined') {
+    return null;
+  }
+  let bitmap: ImageBitmap | null = null;
+  try {
+    bitmap = await createImageBitmap(blob);
+    // MEGA type-0 thumbnails are square 120x120 (the official clients crop to a square,
+    // and the browser's grid assumes square cells). We keep 120x120 but CONTAIN-fit so
+    // nothing is cropped or stretched — important for portrait manga covers.
+    const SIZE = 120;
+    const canvas = new OffscreenCanvas(SIZE, SIZE);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return null;
+    // Dark letterbox fill (JPEG has no alpha, so the bars need an explicit colour).
+    ctx.fillStyle = '#1a1a1a';
+    ctx.fillRect(0, 0, SIZE, SIZE);
+    // Contain-fit: scale to fit inside the square (no stretch), then center.
+    const scale = Math.min(SIZE / bitmap.width, SIZE / bitmap.height);
+    const dw = bitmap.width * scale;
+    const dh = bitmap.height * scale;
+    ctx.drawImage(bitmap, (SIZE - dw) / 2, (SIZE - dh) / 2, dw, dh);
+    const jpeg = await canvas.convertToBlob({ type: 'image/jpeg', quality: 0.8 });
+    return new Uint8Array(await jpeg.arrayBuffer());
+  } catch {
+    return null;
+  } finally {
+    bitmap?.close?.();
+  }
+}
+
+/**
+ * Wrap bytes as a minimal readable source for megajs's streamToCb, which only uses
+ * .on('data'|'end'|'error') and Buffer.concat. This avoids needing megajs's internal
+ * (non-exported) Buffer class. The emit is deferred so streamToCb registers its handlers
+ * synchronously first.
+ */
+function megaSourceFromBytes(bytes: Uint8Array): any {
+  const handlers: Record<string, ((arg?: any) => void) | undefined> = {};
+  queueMicrotask(() => {
+    handlers['data']?.(bytes);
+    handlers['end']?.();
+  });
+  return {
+    on(event: string, cb: (arg?: any) => void) {
+      handlers[event] = cb;
+      return this;
+    }
+  };
+}
+
+/** Attach a MEGA thumbnail file-attribute to an uploaded image node. Best-effort; never throws. */
+async function attachMegaThumbnail(fileNode: any, blob: Blob): Promise<void> {
+  if (!fileNode || typeof fileNode.uploadAttribute !== 'function') return;
+  const thumb = await renderMegaThumbnail(blob);
+  if (!thumb) return;
+  await new Promise<void>((resolve) => {
+    try {
+      fileNode.uploadAttribute('thumbnail', megaSourceFromBytes(thumb), (error: unknown) => {
+        if (error) console.warn('Worker: MEGA thumbnail attach failed (non-fatal):', error);
+        resolve();
+      });
+    } catch (error) {
+      console.warn('Worker: MEGA thumbnail attach threw (non-fatal):', error);
+      resolve();
+    }
+  });
+}
+
 export const megaCore: CloudProviderCore = {
   async downloadFile({ credentials, onProgress }): Promise<ArrayBuffer> {
-    const shareUrl = requireCredentialString(credentials, 'megaShareUrl', 'MEGA share URL');
+    const sid = requireCredentialString(credentials, 'sid', 'MEGA session id');
+    const nodeId = requireCredentialString(credentials, 'nodeId', 'MEGA node id');
+    const fileKey = requireCredentialString(credentials, 'fileKey', 'MEGA file key');
+    const api = getDownloadApi(sid);
 
-    return await new Promise((resolve, reject) => {
+    return await new Promise<ArrayBuffer>((resolve, reject) => {
       try {
-        const file = MegaFile.fromURL(shareUrl);
+        // formatKey(fileKey) base64url-decodes into a real megajs Buffer.
+        const file: any = new MegaFile({ downloadId: nodeId, key: fileKey, api });
+        // Force the owned-node download path (req.n = nodeId, authorized by api.sid).
+        file.nodeId = nodeId;
 
-        file.loadAttributes((error) => {
-          if (error) {
-            reject(new Error(`MEGA metadata failed: ${error.message}`));
-            return;
-          }
+        const stream = file.download({});
+        const chunks: Uint8Array[] = [];
 
-          const totalSize = file.size || 0;
-          const stream = file.download({});
-          const chunks: Uint8Array[] = [];
-          let loaded = 0;
-
-          stream.on('data', (chunk: Uint8Array) => {
-            chunks.push(chunk);
-            loaded += chunk.length;
-            onProgress(loaded, totalSize);
-          });
-
-          stream.on('end', async () => {
+        stream.on('data', (chunk: Uint8Array) => {
+          chunks.push(chunk);
+        });
+        stream.on('progress', (p: { bytesLoaded: number; bytesTotal: number }) => {
+          onProgress(p.bytesLoaded, p.bytesTotal);
+        });
+        stream.on('end', async () => {
+          try {
             const blob = new Blob(chunks as BlobPart[]);
             const buffer = await blob.arrayBuffer();
             chunks.length = 0;
             resolve(buffer);
-          });
-
-          stream.on('error', (streamError: Error) => {
-            reject(new Error(`MEGA download failed: ${streamError.message}`));
-          });
+          } catch (error) {
+            reject(error instanceof Error ? error : new Error(String(error)));
+          }
+        });
+        stream.on('error', (streamError: Error) => {
+          reject(new Error(`MEGA download failed: ${streamError.message}`));
         });
       } catch (error) {
         reject(
           new Error(
-            `MEGA initialization failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+            `MEGA download init failed: ${error instanceof Error ? error.message : 'Unknown error'}`
           )
         );
       }
     });
   },
 
-  async uploadFile({ seriesTitle, filename, blob, credentials, onProgress }): Promise<string> {
-    const email = requireCredentialString(credentials, 'megaEmail', 'MEGA credentials');
-    const password = requireCredentialString(credentials, 'megaPassword', 'MEGA credentials');
-    const storage = await getUploadStorage(email, password);
+  async uploadFile({
+    seriesTitle,
+    filename,
+    blob,
+    credentials,
+    onProgress,
+    mimeType
+  }): Promise<string> {
+    const session = requireCredentialString(credentials, 'megaSession', 'MEGA session');
+    const storage = await getUploadStorage(session);
 
     try {
       const CHUNK_SIZE = 1024 * 1024;
@@ -121,6 +240,7 @@ export const megaCore: CloudProviderCore = {
 
       const uploadStream: any = seriesFolder.upload({ name: filename, size: blob.size });
       let uploadedFileId: string | undefined;
+      let uploadedFile: any;
 
       await new Promise<void>((resolve, reject) => {
         let offset = 0;
@@ -134,6 +254,7 @@ export const megaCore: CloudProviderCore = {
         });
 
         uploadStream.on('complete', (file: any) => {
+          uploadedFile = file;
           uploadedFileId = file?.nodeId || file?.id || uploadedFileId;
           resolve();
         });
@@ -160,6 +281,12 @@ export const megaCore: CloudProviderCore = {
 
       if (!uploadedFileId) {
         throw new Error('MEGA upload succeeded but did not return file ID');
+      }
+
+      // Give image files a thumbnail so MEGA's file browser previews them without opening.
+      // Best-effort: a failure here never fails the upload.
+      if (isImageUpload(mimeType, filename)) {
+        await attachMegaThumbnail(uploadedFile, blob);
       }
 
       return uploadedFileId;

--- a/src/lib/util/sync/core/providers/mega-core.ts
+++ b/src/lib/util/sync/core/providers/mega-core.ts
@@ -79,6 +79,47 @@ function getDownloadApi(sid: string): any {
   return api;
 }
 
+/**
+ * Resolve the series folder to upload into.
+ *
+ * The main thread's prepareUploadTarget() creates the folder once (coalesced by a mutex)
+ * and passes its node id here. Parallel upload workers must NEVER mkdir the series folder:
+ * each worker has its own Storage tree, so concurrent mkdir creates duplicate series
+ * folders. We resolve the folder by id, reloading once if our cached tree predates its
+ * creation, and only fall back to name-based creation when no id was supplied.
+ */
+export async function resolveSeriesUploadFolder(
+  storage: any,
+  seriesFolderNodeId: string | undefined,
+  seriesTitle: string
+): Promise<any> {
+  if (seriesFolderNodeId) {
+    let folder = storage.files?.[seriesFolderNodeId];
+    if (!folder) {
+      await storage.reload(true);
+      folder = storage.files?.[seriesFolderNodeId];
+    }
+    if (folder) return folder;
+    // Id was provided but didn't resolve even after a reload — fall through rather than
+    // failing the upload outright.
+  }
+
+  // Legacy fallback (only when no id was provided): find by name, create if missing.
+  let mokuroFolder = storage.root?.children?.find(
+    (child: any) => child.name === 'mokuro-reader' && child.directory
+  );
+  if (!mokuroFolder) {
+    mokuroFolder = await storage.root.mkdir('mokuro-reader');
+  }
+  let seriesFolder = mokuroFolder.children?.find(
+    (child: any) => child.name === seriesTitle && child.directory
+  );
+  if (!seriesFolder) {
+    seriesFolder = await mokuroFolder.mkdir(seriesTitle);
+  }
+  return seriesFolder;
+}
+
 const IMAGE_MIME_RE = /^image\//;
 const IMAGE_EXT_RE = /\.(webp|jpe?g|png|gif|bmp|avif)$/i;
 
@@ -222,21 +263,17 @@ export const megaCore: CloudProviderCore = {
     try {
       const CHUNK_SIZE = 1024 * 1024;
 
-      let mokuroFolder = storage.root.children?.find(
-        (child: any) => child.name === 'mokuro-reader' && child.directory
+      // Upload into the folder the main thread already created (passed as a node id).
+      // Never mkdir here — parallel workers would each create a duplicate series folder.
+      const seriesFolderNodeId =
+        typeof credentials?.megaSeriesFolderNodeId === 'string'
+          ? credentials.megaSeriesFolderNodeId
+          : undefined;
+      const seriesFolder = await resolveSeriesUploadFolder(
+        storage,
+        seriesFolderNodeId,
+        seriesTitle
       );
-
-      if (!mokuroFolder) {
-        mokuroFolder = await storage.root.mkdir('mokuro-reader');
-      }
-
-      let seriesFolder = mokuroFolder.children?.find(
-        (child: any) => child.name === seriesTitle && child.directory
-      );
-
-      if (!seriesFolder) {
-        seriesFolder = await mokuroFolder.mkdir(seriesTitle);
-      }
 
       const uploadStream: any = seriesFolder.upload({ name: filename, size: blob.size });
       let uploadedFileId: string | undefined;

--- a/src/lib/util/sync/provider-detection.test.ts
+++ b/src/lib/util/sync/provider-detection.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('$lib/util/sync/providers/google-drive/constants', () => ({
+  GOOGLE_DRIVE_CONFIG: {
+    STORAGE_KEYS: { HAS_AUTHENTICATED: 'gdrive_has_authenticated', TOKEN: 'gdrive_token' }
+  }
+}));
+
+import { getConfiguredProviderType } from './provider-detection';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('provider detection (MEGA)', () => {
+  it('detects MEGA from a session blob (new key)', () => {
+    localStorage.setItem('mega_session', JSON.stringify({ sid: 'S', key: 'K' }));
+    expect(getConfiguredProviderType()).toBe('mega');
+  });
+
+  it('still detects MEGA from legacy email/password (pre-migration)', () => {
+    localStorage.setItem('mega_email', 'a@b.c');
+    localStorage.setItem('mega_password', 'p');
+    expect(getConfiguredProviderType()).toBe('mega');
+  });
+});

--- a/src/lib/util/sync/provider-detection.ts
+++ b/src/lib/util/sync/provider-detection.ts
@@ -50,10 +50,11 @@ function detectProviderFromCredentials(): ProviderType | null {
     return 'google-drive';
   }
 
-  // Check MEGA credentials
+  // Check MEGA credentials (new session token or legacy email/password)
+  const megaSession = localStorage.getItem('mega_session');
   const megaEmail = localStorage.getItem('mega_email');
   const megaPassword = localStorage.getItem('mega_password');
-  if (megaEmail && megaPassword) {
+  if (megaSession || (megaEmail && megaPassword)) {
     return 'mega';
   }
 

--- a/src/lib/util/sync/provider-manager.ts
+++ b/src/lib/util/sync/provider-manager.ts
@@ -194,6 +194,7 @@ class ProviderManager {
       localStorage.removeItem('webdav_username');
       localStorage.removeItem('webdav_password');
       // MEGA
+      localStorage.removeItem('mega_session');
       localStorage.removeItem('mega_email');
       localStorage.removeItem('mega_password');
       localStorage.removeItem('mega_folder_path');

--- a/src/lib/util/sync/providers/mega/mega-provider.test.ts
+++ b/src/lib/util/sync/providers/mega/mega-provider.test.ts
@@ -304,3 +304,17 @@ describe('MegaProvider.reinitialize() — session-safe refresh', () => {
     expect(localStorage.getItem('mega_session')).toBeNull();
   });
 });
+
+describe('MegaProvider.prepareUploadTarget()', () => {
+  it('returns the series folder node id so workers reuse it instead of mkdir-ing', async () => {
+    const provider = new MegaProvider();
+    await provider.whenReady();
+    (provider as any).storage = { files: {} };
+    (provider as any).ensureMokuroFolder = vi.fn(async () => ({ nodeId: 'MOKURO' }));
+    (provider as any).ensureSeriesFolder = vi.fn(async () => ({ nodeId: 'SERIES1' }));
+
+    const result = await provider.prepareUploadTarget('My Series');
+
+    expect(result).toEqual({ megaSeriesFolderNodeId: 'SERIES1' });
+  });
+});

--- a/src/lib/util/sync/providers/mega/mega-provider.test.ts
+++ b/src/lib/util/sync/providers/mega/mega-provider.test.ts
@@ -1,0 +1,306 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('./mega-cache', () => ({ megaCache: { fetch: vi.fn() } }));
+vi.mock('../../cache-manager', () => ({
+  cacheManager: { clearAll: vi.fn(), registerCache: vi.fn() }
+}));
+
+// Controllable megajs Storage mock.
+const storageState = vi.hoisted(() => ({
+  // What the next `new Storage(opts, cb)` should do.
+  loginError: null as Error | null,
+  lastOptions: null as any,
+  toJSON: () => ({
+    key: 'MASTERKEY',
+    sid: 'SID123',
+    name: 'n',
+    user: 'u',
+    options: { email: 'a@b.c', password: 'secret', secondFactorCode: '123456', autoload: true }
+  }),
+  files: { f1: { name: 'mokuro-reader', directory: true } } as Record<string, any>,
+  reloadError: null as Error | null
+}));
+
+vi.mock('megajs', () => {
+  class MockStorage {
+    files: Record<string, any>;
+    sid = 'SID123';
+    reload = vi.fn(async () => {});
+    constructor(options: any, cb?: (e: Error | null) => void) {
+      storageState.lastOptions = options;
+      this.files = storageState.files;
+      // Defer cb so the caller's `const s = new Storage(...)` is assigned first.
+      if (cb) queueMicrotask(() => cb(storageState.loginError));
+    }
+    toJSON() {
+      return storageState.toJSON();
+    }
+    getAccountInfo() {
+      return Promise.resolve({ spaceUsed: 0, spaceTotal: 100 });
+    }
+    static fromJSON = vi.fn((json: any) => {
+      const s = new MockStorage({ autologin: false, autoload: false } as any);
+      s.sid = json.sid;
+      (s as any).reload = vi.fn(async () => {
+        if (storageState.reloadError) throw storageState.reloadError;
+      });
+      return s;
+    });
+  }
+  return { Storage: MockStorage, File: vi.fn() };
+});
+
+import { MegaProvider } from './mega-provider';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  storageState.loginError = null;
+  storageState.reloadError = null;
+  storageState.files = { f1: { name: 'mokuro-reader', directory: true } };
+});
+
+describe('MegaProvider.login()', () => {
+  it('persists a sanitized session blob and removes legacy password on success', async () => {
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    localStorage.setItem('mega_email', 'a@b.c');
+    localStorage.setItem('mega_password', 'secret');
+
+    await provider.login({ email: 'a@b.c', password: 'secret' });
+
+    expect(provider.isAuthenticated()).toBe(true);
+    const raw = localStorage.getItem('mega_session');
+    expect(raw).toBeTruthy();
+    const blob = JSON.parse(raw!);
+    expect(blob.sid).toBe('SID123');
+    expect(blob.key).toBe('MASTERKEY');
+    expect(blob.options).not.toHaveProperty('password');
+    expect(blob.options).not.toHaveProperty('secondFactorCode');
+    expect(localStorage.getItem('mega_email')).toBeNull();
+    expect(localStorage.getItem('mega_password')).toBeNull();
+    expect(localStorage.getItem('active_cloud_provider')).toBe('mega');
+  });
+
+  it('forwards secondFactorCode to the Storage constructor', async () => {
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    await provider.login({ email: 'a@b.c', password: 'secret', secondFactorCode: '654321' });
+
+    expect(storageState.lastOptions.secondFactorCode).toBe('654321');
+  });
+
+  it('logs in with keepalive disabled (no crashing server-change poll)', async () => {
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    await provider.login({ email: 'a@b.c', password: 'secret' });
+
+    expect(storageState.lastOptions.keepalive).toBe(false);
+  });
+
+  it('maps EMFAREQUIRED to a MFA_REQUIRED ProviderError', async () => {
+    storageState.loginError = new Error('EMFAREQUIRED (-26): Multi-Factor Authentication Required');
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    await expect(provider.login({ email: 'a@b.c', password: 'secret' })).rejects.toMatchObject({
+      code: 'MFA_REQUIRED'
+    });
+    expect(provider.isAuthenticated()).toBe(false);
+    expect(localStorage.getItem('mega_session')).toBeNull();
+  });
+});
+
+describe('MegaProvider session restore + migration', () => {
+  it('migrates legacy email/password to a session blob on load', async () => {
+    localStorage.setItem('mega_email', 'a@b.c');
+    localStorage.setItem('mega_password', 'secret');
+
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    expect(provider.isAuthenticated()).toBe(true);
+    expect(localStorage.getItem('mega_session')).toBeTruthy();
+    expect(localStorage.getItem('mega_password')).toBeNull();
+  });
+
+  it('restores from an existing session blob without re-login', async () => {
+    localStorage.setItem(
+      'mega_session',
+      JSON.stringify({ key: 'MASTERKEY', sid: 'SID123', name: 'n', user: 'u', options: {} })
+    );
+
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    expect(provider.isAuthenticated()).toBe(true);
+    const { Storage } = (await import('megajs')) as any;
+    expect(Storage.fromJSON).toHaveBeenCalledOnce();
+  });
+
+  it('flags needs-attention when the stored session is expired (ESID)', async () => {
+    storageState.reloadError = new Error(
+      'ESID (-15): Invalid or expired user session, please relogin'
+    );
+    localStorage.setItem(
+      'mega_session',
+      JSON.stringify({
+        key: 'MASTERKEY',
+        sid: 'DEAD',
+        name: 'n',
+        user: 'u',
+        options: { email: 'a@b.c' }
+      })
+    );
+
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    expect(provider.isAuthenticated()).toBe(false);
+    expect(provider.getStatus().needsAttention).toBe(true);
+    expect(localStorage.getItem('mega_session')).toBeNull();
+  });
+});
+
+describe('MegaProvider needs-attention', () => {
+  it('exposes the stored email via getLastUsername after session expiry', async () => {
+    storageState.reloadError = new Error('ESID (-15): please relogin');
+    localStorage.setItem(
+      'mega_session',
+      JSON.stringify({ key: 'K', sid: 'DEAD', options: { email: 'me@host.dev' } })
+    );
+    const provider = new MegaProvider();
+    await provider.whenReady();
+    expect(provider.getLastUsername()).toBe('me@host.dev');
+  });
+});
+
+describe('MegaProvider.logout()', () => {
+  it('clears session, legacy keys, and needs-attention flag', async () => {
+    localStorage.setItem('mega_session', JSON.stringify({ key: 'K', sid: 'S', options: {} }));
+    localStorage.setItem('mega_email', 'a@b.c');
+    localStorage.setItem('mega_password', 'p');
+    localStorage.setItem('mega_folder_path', '/Mokuro');
+    localStorage.setItem('active_cloud_provider', 'mega');
+
+    const provider = new MegaProvider();
+    await provider.whenReady();
+    await provider.logout();
+
+    expect(localStorage.getItem('mega_session')).toBeNull();
+    expect(localStorage.getItem('mega_email')).toBeNull();
+    expect(localStorage.getItem('mega_password')).toBeNull();
+    expect(localStorage.getItem('mega_folder_path')).toBeNull();
+    expect(localStorage.getItem('active_cloud_provider')).toBeNull();
+    expect(provider.getStatus().needsAttention).toBe(false);
+    expect(provider.isAuthenticated()).toBe(false);
+  });
+});
+
+describe('MegaProvider.getWorkerUploadCredentials()', () => {
+  it('returns the session blob, never a password', async () => {
+    const sessionRaw = JSON.stringify({ key: 'K', sid: 'S', options: { email: 'a@b.c' } });
+    localStorage.setItem('mega_session', sessionRaw);
+
+    const provider = new MegaProvider();
+    await provider.whenReady();
+    const creds = await provider.getWorkerUploadCredentials();
+
+    expect(creds).toEqual({ megaSession: sessionRaw });
+    expect(creds).not.toHaveProperty('megaPassword');
+    expect(creds).not.toHaveProperty('megaEmail');
+  });
+});
+
+describe('MegaProvider.getWorkerDownloadCredentials() (Phase 2)', () => {
+  it('returns sid + nodeId + encoded per-file key, never a share link or master key', async () => {
+    localStorage.setItem('mega_session', JSON.stringify({ key: 'K', sid: 'SID123', options: {} }));
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    // Seed the restored storage's tree with a target node.
+    (provider as any).storage = {
+      sid: 'SID123',
+      files: {
+        node1: { nodeId: 'node1', directory: false, key: new Uint8Array([255, 255, 255]) }
+      }
+    };
+
+    const creds = await provider.getWorkerDownloadCredentials('node1');
+    expect(creds).toEqual({ sid: 'SID123', nodeId: 'node1', fileKey: '____' });
+    expect(creds).not.toHaveProperty('megaShareUrl');
+  });
+
+  it('throws NOT_AUTHENTICATED when not authenticated', async () => {
+    const provider = new MegaProvider();
+    await provider.whenReady();
+    await expect(provider.getWorkerDownloadCredentials('node1')).rejects.toMatchObject({
+      code: 'NOT_AUTHENTICATED'
+    });
+  });
+
+  it('throws NODE_NOT_FOUND when the node is missing', async () => {
+    const provider = new MegaProvider();
+    await provider.whenReady();
+    (provider as any).storage = { sid: 'SID123', files: {} };
+    await expect(provider.getWorkerDownloadCredentials('missing')).rejects.toMatchObject({
+      code: 'NODE_NOT_FOUND'
+    });
+  });
+});
+
+describe('MegaProvider.reinitialize() — session-safe refresh', () => {
+  // Regression: megajs storage.close() sends {a:'sml'}, which TERMINATES the shared
+  // session sid server-side. Because every storage (login, restore, reinitialize) reuses
+  // the one persisted sid, closing any of them invalidates the persisted token and every
+  // subsequent request fails with ESID (-15). reinitialize must refresh the file tree in
+  // place via reload(true) and NEVER call storage.close().
+  it('reloads the existing session in place and never calls storage.close()', async () => {
+    const provider = new MegaProvider();
+    await provider.whenReady();
+
+    const reload = vi.fn(async () => {});
+    const close = vi.fn(async () => {});
+    (provider as any).storage = {
+      sid: 'SID123',
+      files: { f1: { name: 'mokuro-reader', directory: true } },
+      reload,
+      close
+    };
+
+    await (provider as any).reinitialize();
+
+    expect(reload).toHaveBeenCalledWith(true);
+    expect(close).not.toHaveBeenCalled();
+    expect(provider.isAuthenticated()).toBe(true);
+  });
+
+  it('marks the session expired (without closing) when in-place reload throws ESID', async () => {
+    const provider = new MegaProvider();
+    await provider.whenReady();
+    localStorage.setItem(
+      'mega_session',
+      JSON.stringify({ key: 'K', sid: 'SID', options: { email: 'a@b.c' } })
+    );
+
+    const close = vi.fn(async () => {});
+    (provider as any).storage = {
+      sid: 'SID',
+      files: {},
+      close,
+      reload: vi.fn(async () => {
+        throw new Error('ESID (-15): Invalid or expired user session, please relogin');
+      })
+    };
+
+    await (provider as any).reinitialize();
+
+    expect(close).not.toHaveBeenCalled();
+    expect(provider.getStatus().needsAttention).toBe(true);
+    expect(localStorage.getItem('mega_session')).toBeNull();
+  });
+});

--- a/src/lib/util/sync/providers/mega/mega-provider.ts
+++ b/src/lib/util/sync/providers/mega/mega-provider.ts
@@ -12,13 +12,26 @@ import { megaCache } from './mega-cache';
 import { cacheManager } from '../../cache-manager';
 import { setActiveProviderKey, clearActiveProviderKey } from '../../provider-detection';
 import type { FolderOperations, FolderInfo, FolderItem } from '../../folder-deduplicator';
+import {
+  isMfaRequiredError,
+  isSessionExpiredError,
+  isAuthRejectionError,
+  sanitizeSessionBlob,
+  encodeMegaKey,
+  type MegaSessionBlob
+} from './mega-session';
 
 interface MegaCredentials {
   email: string;
   password: string;
+  /** One-time TOTP code for 2FA-enabled accounts. Never persisted. */
+  secondFactorCode?: string;
 }
 
 const STORAGE_KEYS = {
+  /** Sanitized Storage.toJSON() blob (sid + master key). The only persisted secret. */
+  SESSION: 'mega_session',
+  // Legacy keys — read for migration, removed on first successful login.
   EMAIL: 'mega_email',
   PASSWORD: 'mega_password',
   FOLDER_PATH: 'mega_folder_path'
@@ -136,16 +149,15 @@ async function retryWithCacheRefresh<T>(
 export class MegaProvider implements SyncProvider {
   readonly type = 'mega' as const;
   readonly name = 'MEGA';
-  readonly supportsWorkerDownload = true; // Workers can download via MEGA API from share links
+  readonly supportsWorkerDownload = true; // Workers download owned nodes via sid + per-file key
   readonly uploadConcurrencyLimit = 6;
   readonly downloadConcurrencyLimit = 6;
 
   private storage: any = null;
   private mokuroFolder: any = null;
+  private needsReconnect = false;
+  private reconnectEmail: string | null = null;
   private initPromise: Promise<void>;
-  private workerShareLinksToCleanup = new Set<string>();
-  private workerShareLinkMutex: Promise<void | { megaShareUrl: string }> = Promise.resolve();
-  private static readonly WORKER_SHARE_LINK_THROTTLE_MS = 200;
 
   // Mutexes preventing concurrent uploads from racing to create the same folder.
   // Without these, N parallel uploads each find no folder and call mkdir N times.
@@ -154,7 +166,7 @@ export class MegaProvider implements SyncProvider {
 
   constructor() {
     if (browser) {
-      this.initPromise = this.loadPersistedCredentials();
+      this.initPromise = this.restorePersistedSession();
     } else {
       this.initPromise = Promise.resolve();
     }
@@ -173,7 +185,8 @@ export class MegaProvider implements SyncProvider {
   }
 
   getStatus(): ProviderStatus {
-    const hasCredentials = !!(
+    const hasSession = !!(browser && localStorage.getItem(STORAGE_KEYS.SESSION));
+    const hasLegacy = !!(
       browser &&
       localStorage.getItem(STORAGE_KEYS.EMAIL) &&
       localStorage.getItem(STORAGE_KEYS.PASSWORD)
@@ -182,14 +195,56 @@ export class MegaProvider implements SyncProvider {
 
     return {
       isAuthenticated: isConnected,
-      hasStoredCredentials: hasCredentials,
-      needsAttention: false,
+      hasStoredCredentials: hasSession || hasLegacy,
+      needsAttention: this.needsReconnect,
       statusMessage: isConnected
         ? 'Connected to MEGA'
-        : hasCredentials
-          ? 'Configured (not connected)'
-          : 'Not configured'
+        : this.needsReconnect
+          ? 'MEGA session expired — please reconnect'
+          : hasSession || hasLegacy
+            ? 'Configured (not connected)'
+            : 'Not configured'
     };
+  }
+
+  /** Drop the stored session and flag the UI to prompt for reconnect (password never stored). */
+  private markSessionExpired(): void {
+    // Capture email for reconnect pre-fill before clearing.
+    if (browser && !this.reconnectEmail) {
+      const sessionRaw = localStorage.getItem(STORAGE_KEYS.SESSION);
+      if (sessionRaw) {
+        try {
+          this.reconnectEmail = JSON.parse(sessionRaw)?.options?.email ?? null;
+        } catch {
+          /* ignore */
+        }
+      }
+      this.reconnectEmail = this.reconnectEmail ?? localStorage.getItem(STORAGE_KEYS.EMAIL);
+    }
+
+    this.storage = null;
+    this.mokuroFolder = null;
+    this.needsReconnect = true;
+
+    if (browser) {
+      localStorage.removeItem(STORAGE_KEYS.SESSION);
+      // Keep active_cloud_provider so the UI still shows MEGA in a needs-attention state.
+    }
+  }
+
+  /** Email captured for reconnect pre-fill (mirrors WebDAV's getLastUsername). */
+  getLastUsername(): string | null {
+    if (this.reconnectEmail) return this.reconnectEmail;
+    if (!browser) return null;
+    const sessionRaw = localStorage.getItem(STORAGE_KEYS.SESSION);
+    if (sessionRaw) {
+      try {
+        return JSON.parse(sessionRaw)?.options?.email ?? null;
+      } catch {
+        return null;
+      }
+    }
+    return localStorage.getItem(STORAGE_KEYS.EMAIL);
   }
 
   async login(credentials?: ProviderCredentials): Promise<void> {
@@ -197,47 +252,43 @@ export class MegaProvider implements SyncProvider {
       throw new ProviderError('Email and password are required', 'mega', 'INVALID_CREDENTIALS');
     }
 
-    const { email, password } = credentials as MegaCredentials;
+    const { email, password, secondFactorCode } = credentials as MegaCredentials;
 
     try {
       // Dynamically import megajs to reduce initial bundle size
       const { Storage } = await import('megajs');
 
-      // Initialize MEGA storage
-      this.storage = await new Promise((resolve, reject) => {
-        const storage = new Storage(
-          {
-            email,
-            password
-          },
-          (error: Error | null) => {
-            if (error) {
-              reject(error);
-            } else {
-              resolve(storage);
-            }
-          }
+      // Fresh interactive login. The constructor cb fires after the tree loads
+      // (autoload:true), so the Storage is ready once this promise resolves.
+      // keepalive:false disables megajs's server-change (sc) long-poll. We never use
+      // push notifications (we reload explicitly), and that poll's handler crashes on
+      // delete events ("Cannot read properties of undefined (reading 'parent')").
+      const storage: any = await new Promise((resolve, reject) => {
+        const s = new Storage(
+          { email, password, secondFactorCode, autoload: true, keepalive: false } as any,
+          (error: Error | null) => (error ? reject(error) : resolve(s))
         );
       });
 
-      // Wait for storage to be ready
-      await this.waitForReady();
-
-      // Ensure mokuro folder exists
+      this.storage = storage;
       await this.ensureMokuroFolder();
-
-      // Store credentials in localStorage
-      if (browser) {
-        localStorage.setItem(STORAGE_KEYS.EMAIL, email);
-        localStorage.setItem(STORAGE_KEYS.PASSWORD, password);
-      }
-
-      // Set the active provider key for lazy loading on next startup
+      this.persistSession();
+      this.needsReconnect = false;
+      this.reconnectEmail = email;
       setActiveProviderKey('mega');
       console.log('✅ MEGA login successful');
     } catch (error) {
       this.storage = null;
       this.mokuroFolder = null;
+
+      if (isMfaRequiredError(error)) {
+        throw new ProviderError(
+          'MEGA requires a two-factor authentication code',
+          'mega',
+          'MFA_REQUIRED',
+          false
+        );
+      }
 
       throw new ProviderError(
         `MEGA login failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
@@ -248,122 +299,126 @@ export class MegaProvider implements SyncProvider {
     }
   }
 
+  /** Persist the current session as a sanitized toJSON() blob; drop legacy keys. */
+  private persistSession(): void {
+    if (!browser || !this.storage) return;
+    const blob: MegaSessionBlob = sanitizeSessionBlob(this.storage.toJSON());
+    localStorage.setItem(STORAGE_KEYS.SESSION, JSON.stringify(blob));
+    localStorage.removeItem(STORAGE_KEYS.EMAIL);
+    localStorage.removeItem(STORAGE_KEYS.PASSWORD);
+  }
+
   async logout(): Promise<void> {
     this.storage = null;
     this.mokuroFolder = null;
+    this.needsReconnect = false;
+    this.reconnectEmail = null;
 
     if (browser) {
+      localStorage.removeItem(STORAGE_KEYS.SESSION);
       localStorage.removeItem(STORAGE_KEYS.EMAIL);
       localStorage.removeItem(STORAGE_KEYS.PASSWORD);
       localStorage.removeItem(STORAGE_KEYS.FOLDER_PATH);
     }
 
-    // Clear the active provider key
     clearActiveProviderKey();
     console.log('MEGA logged out');
   }
 
-  async loadPersistedCredentials(): Promise<void> {
+  /** Rebuild an authenticated Storage from a saved session blob (no password, no login round-trip). */
+  private async restoreSession(blob: MegaSessionBlob): Promise<void> {
+    const { Storage } = await import('megajs');
+    // Force keepalive:false so the restored session never starts the crashing sc poll,
+    // even for blobs persisted before that default changed.
+    const storage: any = Storage.fromJSON({
+      ...(blob as any),
+      options: { ...((blob as any).options ?? {}), keepalive: false }
+    });
+    // fromJSON does no network and loads no tree; reload populates root + files.
+    // A dead session throws ESID here.
+    await storage.reload(true);
+    this.storage = storage;
+    this.mokuroFolder = null;
+    await this.ensureMokuroFolder();
+    this.needsReconnect = false;
+    this.reconnectEmail = (blob.options && (blob.options as any).email) || this.reconnectEmail;
+    setActiveProviderKey('mega');
+  }
+
+  /** Restore on app load: session blob first, then one-time legacy email/password migration. */
+  async restorePersistedSession(): Promise<void> {
     if (!browser) return;
 
+    const sessionRaw = localStorage.getItem(STORAGE_KEYS.SESSION);
+    if (sessionRaw) {
+      try {
+        await this.restoreSession(JSON.parse(sessionRaw) as MegaSessionBlob);
+        console.log('Restored MEGA session from stored token');
+      } catch (error) {
+        if (isSessionExpiredError(error) || isAuthRejectionError(error)) {
+          console.error('Stored MEGA session invalid; reconnect required');
+          this.markSessionExpired();
+        } else {
+          console.warn('Failed to restore MEGA session (temporary error), will retry:', error);
+        }
+      }
+      return;
+    }
+
+    // Legacy migration: log in with stored email/password, which persists a session blob
+    // and removes the password (see login()/persistSession()).
     const email = localStorage.getItem(STORAGE_KEYS.EMAIL);
     const password = localStorage.getItem(STORAGE_KEYS.PASSWORD);
-
     if (email && password) {
       try {
         await this.login({ email, password });
-        console.log('Restored MEGA session from stored credentials');
+        console.log('Migrated MEGA legacy credentials to session token');
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-
-        // Only clear credentials if they're actually invalid (wrong password/email)
-        // Don't clear on network errors, rate limiting, or temporary server issues
-        const isAuthError =
-          errorMessage.includes('ENOENT') ||
-          errorMessage.includes('incorrect') ||
-          errorMessage.includes('invalid') ||
-          errorMessage.includes('authentication failed') ||
-          errorMessage.includes('wrong password');
-
-        if (isAuthError) {
-          console.error('MEGA credentials invalid, clearing stored credentials');
-          this.logout();
+        if (isMfaRequiredError(error)) {
+          // Account enabled 2FA after the password was stored — cannot migrate silently.
+          this.reconnectEmail = email;
+          this.markSessionExpired();
+        } else if (isAuthRejectionError(error)) {
+          this.reconnectEmail = email;
+          this.markSessionExpired();
         } else {
-          // Temporary error - keep credentials for retry later
-          console.warn(
-            'Failed to restore MEGA session (temporary error), will retry on next sync:',
-            errorMessage
-          );
+          console.warn('MEGA migration deferred (temporary error), keeping legacy creds:', error);
         }
       }
     }
   }
 
-  private waitForReady(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      // If storage is already ready, resolve immediately
-      if (this.storage.ready) {
-        resolve();
-        return;
-      }
-
-      // Wait for ready event
-      const timeout = setTimeout(() => {
-        reject(new Error('Timeout waiting for MEGA storage to be ready'));
-      }, 30000); // 30 second timeout
-
-      this.storage.once('ready', () => {
-        clearTimeout(timeout);
-        resolve();
-      });
-
-      // Also listen for error events
-      this.storage.once('error', (error: Error) => {
-        clearTimeout(timeout);
-        reject(error);
-      });
-    });
-  }
-
   /**
-   * Reinitialize the MEGA connection to get a fresh storage cache
-   * This is needed when files change on other devices and the cache becomes stale
+   * Refresh the file-tree cache by rebuilding the session from the stored token.
+   * No password and no re-login round-trip — fromJSON + reload only.
    */
   private async reinitialize(): Promise<void> {
     if (!browser) return;
 
-    // Save current credentials
-    const email = localStorage.getItem(STORAGE_KEYS.EMAIL);
-    const password = localStorage.getItem(STORAGE_KEYS.PASSWORD);
-
-    if (!email || !password) {
-      console.warn('Cannot reinitialize MEGA: no stored credentials');
+    // No live session to refresh — fall back to restoring from the stored token.
+    if (!this.storage) {
+      await this.restorePersistedSession();
       return;
     }
 
-    console.log('🔄 Reinitializing MEGA connection to refresh cache...');
-
-    // Save current storage in case reconnection fails
-    const oldStorage = this.storage;
-    const oldMokuroFolder = this.mokuroFolder;
-
-    // Clear current storage
-    this.storage = null;
-    this.mokuroFolder = null;
-
-    // Reconnect with fresh credentials
     try {
-      await this.login({ email, password });
-      console.log('✅ MEGA connection reinitialized successfully');
+      // Refresh the file tree on the EXISTING session, in place.
+      //
+      // We must NOT rebuild the storage and close the old one: megajs
+      // `storage.close()` issues `{a:'sml'}`, which TERMINATES the session sid
+      // server-side. Every storage (login, restore, reinitialize, upload worker)
+      // reuses the one persisted sid, so closing any of them invalidates the
+      // stored token and makes every later request fail with ESID (-15).
+      await this.storage.reload(true);
+      this.mokuroFolder = null;
+      console.log('✅ MEGA cache reinitialized (in-place reload)');
     } catch (error) {
-      // Restore previous connection on failure so user doesn't get logged out
-      console.error('Failed to reinitialize MEGA, restoring previous connection:', error);
-      this.storage = oldStorage;
-      this.mokuroFolder = oldMokuroFolder;
-
-      // Don't throw - allow operations to continue with stale cache
-      // This prevents temporary network issues from appearing as logouts
-      console.warn('Continuing with potentially stale MEGA cache');
+      if (isSessionExpiredError(error)) {
+        this.markSessionExpired();
+        return;
+      }
+      // Transient error: keep the existing storage so we don't appear logged out.
+      console.warn('Continuing with potentially stale MEGA cache:', error);
     }
   }
 
@@ -1000,116 +1055,6 @@ export class MegaProvider implements SyncProvider {
   }
 
   /**
-   * Create a temporary share link for a file
-   * Returns a public download URL that includes the decryption key
-   * Uses exponential backoff to handle MEGA rate limiting
-   *
-   * IMPORTANT: MEGA likely reuses existing share links, so calling this multiple
-   * times on the same file returns the same URL. This means orphaned links from
-   * previous failed cleanup attempts are automatically reused - a self-healing behavior.
-   */
-  async createShareLink(fileId: string): Promise<string> {
-    if (!this.isAuthenticated()) {
-      throw new ProviderError('Not authenticated', 'mega', 'NOT_AUTHENTICATED', true);
-    }
-
-    try {
-      // Wrap with cache refresh retry for stale cache, then backoff for rate limiting
-      return await retryWithCacheRefresh(
-        async () => {
-          return await retryWithBackoff(
-            async () => {
-              // Find the file by ID
-              const files = Object.values(this.storage.files || {});
-              const file = files.find(
-                (f: any) => (f.nodeId === fileId || f.id === fileId) && !f.directory
-              );
-
-              if (!file) {
-                throw new Error('File not found');
-              }
-
-              return new Promise<string>((resolve, reject) => {
-                // Create/get share link with decryption key (noKey: false is default)
-                // NOTE: If file already has a share link, MEGA API likely returns the existing one
-                (file as any).link((error: Error | null, url: string) => {
-                  if (error) {
-                    reject(error);
-                  } else {
-                    resolve(url);
-                  }
-                });
-              });
-            },
-            8, // maxRetries
-            500, // baseDelay (ms)
-            `Create MEGA share link (${fileId})`
-          );
-        },
-        `Create MEGA share link (${fileId})`,
-        () => this.reinitialize()
-      );
-    } catch (error) {
-      throw new ProviderError(
-        `Failed to create share link: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        'mega',
-        'LINK_FAILED',
-        false,
-        true
-      );
-    }
-  }
-
-  /**
-   * Delete a share link for a file
-   * This removes the public share link to prevent clutter
-   */
-  async deleteShareLink(fileId: string): Promise<void> {
-    if (!this.isAuthenticated()) {
-      throw new ProviderError('Not authenticated', 'mega', 'NOT_AUTHENTICATED', true);
-    }
-
-    try {
-      // Wrap delete in retry logic to handle stale cache
-      await retryWithCacheRefresh(
-        async () => {
-          // Find the file by ID
-          const files = Object.values(this.storage.files || {});
-          const file = files.find(
-            (f: any) => (f.nodeId === fileId || f.id === fileId) && !f.directory
-          );
-
-          if (!file) {
-            throw new Error('File not found');
-          }
-
-          return new Promise<void>((resolve, reject) => {
-            // Unshare the file (removes the share link)
-            (file as any).unshare((error: Error | null) => {
-              if (error) {
-                reject(error);
-              } else {
-                console.log(`✅ Deleted MEGA share link for file ${fileId}`);
-                resolve();
-              }
-            });
-          });
-        },
-        `Delete MEGA share link for file ${fileId}`,
-        () => this.reinitialize()
-      );
-    } catch (error) {
-      throw new ProviderError(
-        `Failed to delete share link: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        'mega',
-        'UNSHARE_FAILED',
-        false,
-        true
-      );
-    }
-  }
-
-  /**
    * Delete an entire series folder
    */
   async deleteSeriesFolder(seriesTitle: string): Promise<void> {
@@ -1196,9 +1141,9 @@ export class MegaProvider implements SyncProvider {
 
   async getWorkerUploadCredentials(): Promise<Record<string, any>> {
     if (!browser) return {};
-    const email = localStorage.getItem(STORAGE_KEYS.EMAIL);
-    const password = localStorage.getItem(STORAGE_KEYS.PASSWORD);
-    return { megaEmail: email, megaPassword: password };
+    const session = localStorage.getItem(STORAGE_KEYS.SESSION);
+    if (!session) return {};
+    return { megaSession: session };
   }
 
   async prepareUploadTarget(seriesTitle: string): Promise<void> {
@@ -1207,29 +1152,26 @@ export class MegaProvider implements SyncProvider {
   }
 
   async getWorkerDownloadCredentials(fileId: string): Promise<Record<string, any>> {
-    const result = await (this.workerShareLinkMutex = this.workerShareLinkMutex.then(async () => {
-      await new Promise((resolve) =>
-        setTimeout(resolve, MegaProvider.WORKER_SHARE_LINK_THROTTLE_MS)
-      );
-
-      const shareUrl = await this.createShareLink(fileId);
-      this.workerShareLinksToCleanup.add(fileId);
-      return { megaShareUrl: shareUrl };
-    }));
-
-    return result || {};
-  }
-
-  async cleanupWorkerDownload(fileId: string): Promise<void> {
-    if (!this.workerShareLinksToCleanup.has(fileId)) return;
-
-    try {
-      await this.deleteShareLink(fileId);
-    } catch (error) {
-      console.warn(`Failed to cleanup MEGA share link for ${fileId}:`, error);
-    } finally {
-      this.workerShareLinksToCleanup.delete(fileId);
+    if (!this.isAuthenticated()) {
+      throw new ProviderError('Not authenticated', 'mega', 'NOT_AUTHENTICATED', true);
     }
+    const node = this.getNodeById(fileId);
+    if (!node || !node.key) {
+      throw new ProviderError(
+        `MEGA node not found or missing key: ${fileId}`,
+        'mega',
+        'NODE_NOT_FOUND',
+        false,
+        true
+      );
+    }
+    // sid authorizes the owned-node download; the per-file key decrypts it.
+    // The download worker never receives the account master key.
+    return {
+      sid: this.storage.sid,
+      nodeId: node.nodeId,
+      fileKey: encodeMegaKey(node.key as Uint8Array)
+    };
   }
 
   /**

--- a/src/lib/util/sync/providers/mega/mega-provider.ts
+++ b/src/lib/util/sync/providers/mega/mega-provider.ts
@@ -1146,9 +1146,14 @@ export class MegaProvider implements SyncProvider {
     return { megaSession: session };
   }
 
-  async prepareUploadTarget(seriesTitle: string): Promise<void> {
+  async prepareUploadTarget(seriesTitle: string): Promise<Record<string, any>> {
+    // Create the series folder once here (coalesced by ensureSeriesFolder's mutex) and pass
+    // its node id to the upload workers. Workers must NOT mkdir — each worker has its own
+    // Storage tree, so parallel mkdir would create duplicate series folders.
     const mokuroFolder = await this.ensureMokuroFolder();
-    await this.ensureSeriesFolder(seriesTitle, mokuroFolder);
+    const seriesFolder = await this.ensureSeriesFolder(seriesTitle, mokuroFolder);
+    const nodeId = seriesFolder?.nodeId ?? seriesFolder?.id;
+    return nodeId ? { megaSeriesFolderNodeId: nodeId } : {};
   }
 
   async getWorkerDownloadCredentials(fileId: string): Promise<Record<string, any>> {

--- a/src/lib/util/sync/providers/mega/mega-session.test.ts
+++ b/src/lib/util/sync/providers/mega/mega-session.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isMfaRequiredError,
+  isSessionExpiredError,
+  isAuthRejectionError,
+  sanitizeSessionBlob,
+  encodeMegaKey
+} from './mega-session';
+
+describe('mega-session error classifiers', () => {
+  it('detects 2FA-required from the EMFAREQUIRED message', () => {
+    expect(
+      isMfaRequiredError(new Error('EMFAREQUIRED (-26): Multi-Factor Authentication Required'))
+    ).toBe(true);
+    expect(isMfaRequiredError(new Error('wrong password'))).toBe(false);
+  });
+
+  it('detects expired session from the ESID message', () => {
+    expect(
+      isSessionExpiredError(
+        new Error('ESID (-15): Invalid or expired user session, please relogin')
+      )
+    ).toBe(true);
+    expect(isSessionExpiredError(new Error('EAGAIN congestion'))).toBe(false);
+  });
+
+  it('detects genuine auth rejection but not transient errors', () => {
+    expect(isAuthRejectionError(new Error('wrong password'))).toBe(true);
+    expect(isAuthRejectionError(new Error('ENOENT'))).toBe(true);
+    expect(isAuthRejectionError(new Error('network timeout'))).toBe(false);
+  });
+});
+
+describe('sanitizeSessionBlob', () => {
+  it('keeps sid/key/user/name and strips password + secondFactorCode from options', () => {
+    const blob = sanitizeSessionBlob({
+      key: 'KEY',
+      sid: 'SID',
+      name: 'n',
+      user: 'u',
+      options: { email: 'a@b.c', password: 'p', secondFactorCode: '123456', autoload: true }
+    });
+    expect(blob).toEqual({
+      key: 'KEY',
+      sid: 'SID',
+      name: 'n',
+      user: 'u',
+      options: { email: 'a@b.c', autoload: true }
+    });
+    expect(blob.options).not.toHaveProperty('password');
+    expect(blob.options).not.toHaveProperty('secondFactorCode');
+  });
+});
+
+describe('encodeMegaKey', () => {
+  it('produces URL-safe base64 without padding (matches megajs e64)', () => {
+    // btoa('\xff\xff\xff') === '////'  -> '____'
+    expect(encodeMegaKey(new Uint8Array([255, 255, 255]))).toBe('____');
+    // btoa('\x00') === 'AA==' -> strip padding -> 'AA'
+    expect(encodeMegaKey(new Uint8Array([0]))).toBe('AA');
+  });
+});

--- a/src/lib/util/sync/providers/mega/mega-session.ts
+++ b/src/lib/util/sync/providers/mega/mega-session.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure helpers for MEGA session-token auth: error classification, session-blob
+ * sanitization, and per-file key encoding for worker transport.
+ *
+ * No side effects, no DOM, no megajs imports — safe to unit test in isolation.
+ */
+
+/** Sanitized megajs `Storage.toJSON()` blob persisted under localStorage['mega_session']. */
+export interface MegaSessionBlob {
+  /** Account master key (base64url) — sensitive. */
+  key: string;
+  /** Session id. */
+  sid: string;
+  name?: string;
+  user?: string;
+  /** megajs options minus password/secondFactorCode. */
+  options?: Record<string, any>;
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** MEGA signals "2FA code required" only via the EMFAREQUIRED (-26) error message. */
+export function isMfaRequiredError(error: unknown): boolean {
+  return /EMFAREQUIRED|Multi-Factor|\(-26\)/i.test(messageOf(error));
+}
+
+/** MEGA signals an invalid/expired session via ESID (-15). */
+export function isSessionExpiredError(error: unknown): boolean {
+  return /ESID|\(-15\)|expired user session|please relogin/i.test(messageOf(error));
+}
+
+/** Genuine credential rejection (wrong email/password) vs transient/network errors. */
+export function isAuthRejectionError(error: unknown): boolean {
+  return /ENOENT|incorrect|invalid credentials|authentication failed|wrong password/i.test(
+    messageOf(error)
+  );
+}
+
+/** Strip single-use / sensitive fields from a `toJSON()` blob before persisting. */
+export function sanitizeSessionBlob(blob: any): MegaSessionBlob {
+  const options = { ...(blob?.options ?? {}) };
+  delete options.password;
+  delete options.secondFactorCode;
+  return { key: blob.key, sid: blob.sid, name: blob.name, user: blob.user, options };
+}
+
+/**
+ * Encode a raw MEGA key buffer to MEGA's base64url ("e64") form so a worker's
+ * `formatKey` (d64) reconstructs the identical megajs Buffer.
+ */
+export function encodeMegaKey(key: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < key.length; i++) binary += String.fromCharCode(key[i]);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}

--- a/src/lib/util/sync/unified-cloud-manager.test.ts
+++ b/src/lib/util/sync/unified-cloud-manager.test.ts
@@ -173,3 +173,63 @@ describe('UnifiedCloudManager rename operations', () => {
     );
   });
 });
+
+describe('UnifiedCloudManager.deleteManagedVolume', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const baseFiles = (): CloudFileMetadata[] => [
+    { provider: 'mega', fileId: 'cbz-1', path: 'S/Vol 1.cbz', modifiedTime: '', size: 100 },
+    { provider: 'mega', fileId: 'mokuro-1', path: 'S/Vol 1.mokuro', modifiedTime: '', size: 10 },
+    { provider: 'mega', fileId: 'thumb-1', path: 'S/Vol 1.webp', modifiedTime: '', size: 5 },
+    { provider: 'mega', fileId: 'other-1', path: 'S/Vol 2.cbz', modifiedTime: '', size: 100 }
+  ];
+
+  it('deletes the archive and all sidecars (archive last) and clears the cache', async () => {
+    const cache = { removeById: vi.fn() };
+    const deleted: string[] = [];
+    const provider = {
+      type: 'mega',
+      deleteFile: vi.fn(async (file: CloudFileMetadata) => {
+        deleted.push(file.path);
+      })
+    };
+    const files = baseFiles();
+    getActiveProvider.mockReturnValue(provider);
+    getBySeries.mockImplementation((s: string) => files.filter((f) => f.path.startsWith(`${s}/`)));
+    getCache.mockReturnValue(cache);
+
+    const { unifiedCloudManager } = await import('$lib/util/sync/unified-cloud-manager');
+    await unifiedCloudManager.deleteManagedVolume('S', 'Vol 1');
+
+    // Only Vol 1's three files (not Vol 2), and the .cbz archive is deleted LAST.
+    expect(provider.deleteFile).toHaveBeenCalledTimes(3);
+    expect(deleted).not.toContain('S/Vol 2.cbz');
+    expect(deleted[deleted.length - 1]).toBe('S/Vol 1.cbz');
+    expect(cache.removeById).toHaveBeenCalledTimes(3);
+  });
+
+  it('reports a summary on partial failure but still clears the successes', async () => {
+    const cache = { removeById: vi.fn() };
+    const provider = {
+      type: 'mega',
+      deleteFile: vi.fn(async (file: CloudFileMetadata) => {
+        if (file.path.endsWith('.mokuro')) throw new Error('boom');
+      })
+    };
+    const files = baseFiles();
+    getActiveProvider.mockReturnValue(provider);
+    getBySeries.mockImplementation((s: string) => files.filter((f) => f.path.startsWith(`${s}/`)));
+    getCache.mockReturnValue(cache);
+
+    const { unifiedCloudManager } = await import('$lib/util/sync/unified-cloud-manager');
+    await expect(unifiedCloudManager.deleteManagedVolume('S', 'Vol 1')).rejects.toThrow(
+      /Failed to delete 1 of 3/
+    );
+    // The .cbz and .webp still got removed from cache; only the .mokuro failed.
+    expect(cache.removeById).toHaveBeenCalledWith('cbz-1');
+    expect(cache.removeById).toHaveBeenCalledWith('thumb-1');
+    expect(cache.removeById).not.toHaveBeenCalledWith('mokuro-1');
+  });
+});

--- a/src/lib/util/sync/unified-cloud-manager.ts
+++ b/src/lib/util/sync/unified-cloud-manager.ts
@@ -197,6 +197,46 @@ class UnifiedCloudManager {
     }
   }
 
+  /**
+   * Delete a backed-up volume and ALL its managed cloud files (archive + sidecars).
+   * deleteFile() removes only a single node, which leaves the .mokuro and thumbnail
+   * sidecars orphaned. Sidecars are deleted first and the .cbz archive last, so a
+   * sidecar failure leaves the volume still marked backed-up (and retryable) rather
+   * than half-deleted.
+   */
+  async deleteManagedVolume(seriesTitle: string, volumeTitle: string): Promise<void> {
+    const provider = this.getActiveProvider();
+    if (!provider) {
+      throw new Error('No cloud provider authenticated');
+    }
+
+    const files = this.getManagedCloudFilesForVolume(seriesTitle, volumeTitle);
+    if (files.length === 0) return;
+
+    const ordered = [...files].sort(
+      (a, b) =>
+        Number(normalizeCloudPath(a.path).endsWith('.cbz')) -
+        Number(normalizeCloudPath(b.path).endsWith('.cbz'))
+    );
+
+    const cache = cacheManager.getCache(provider.type);
+    const failures: string[] = [];
+    for (const file of ordered) {
+      try {
+        await provider.deleteFile(file);
+        cache?.removeById?.(file.fileId);
+      } catch (error) {
+        failures.push(`${file.path}: ${error instanceof Error ? error.message : 'error'}`);
+      }
+    }
+
+    if (failures.length > 0) {
+      throw new Error(
+        `Failed to delete ${failures.length} of ${files.length} file(s): ${failures.join('; ')}`
+      );
+    }
+  }
+
   private replaceCachedFile(oldFile: CloudFileMetadata, updatedFile: CloudFileMetadata): void {
     const provider = this.getActiveProvider();
     if (!provider) return;

--- a/src/lib/views/CloudView.svelte
+++ b/src/lib/views/CloudView.svelte
@@ -99,6 +99,9 @@
   let megaEmail = $state('');
   let megaPassword = $state('');
   let megaLoading = $state(false);
+  let megaTwoFactorCode = $state('');
+  let megaNeeds2fa = $state(false);
+  let megaNeedsReLogin = $state(false);
 
   // WebDAV login state
   let webdavUrl = $state('');
@@ -335,6 +338,20 @@
         // Provider not loadable, ignore
       }
     }
+
+    // Pre-fill MEGA email + reconnect banner from last session (needs-attention)
+    try {
+      const megaProviderInstance = await providerManager.getOrLoadProvider('mega');
+      const lastEmail = megaProviderInstance.getLastUsername?.();
+      if (!megaEmail && lastEmail) megaEmail = lastEmail;
+      if (megaProviderInstance.getStatus().needsAttention) {
+        megaNeedsReLogin = true;
+        const megaForm = document.getElementById('mega-login-form');
+        if (megaForm) megaForm.classList.remove('hidden');
+      }
+    } catch {
+      // Provider not loadable, ignore
+    }
   });
 
   // Google Drive handlers
@@ -370,30 +387,38 @@
   async function handleMegaLogin() {
     megaLoading = true;
     try {
-      // Lazy-load MEGA provider
       const megaProvider = await providerManager.getOrLoadProvider('mega');
-      await megaProvider.login({ email: megaEmail, password: megaPassword });
+      await megaProvider.login({
+        email: megaEmail,
+        password: megaPassword,
+        secondFactorCode: megaNeeds2fa ? megaTwoFactorCode : undefined
+      });
 
-      // Set as current provider (auto-logs out any other provider)
       await providerManager.setCurrentProvider(megaProvider);
 
-      // Populate unified cache for rest of app to use
       showSnackbar('Connected to MEGA - loading cloud data...');
       await unifiedCloudManager.fetchAllCloudVolumes();
 
-      // Update status after cache loads to ensure UI shows "Connected"
       providerManager.updateStatus();
       showSnackbar('MEGA connected');
 
-      // Clear form and trigger reactivity
+      // Clear form + 2FA/reconnect state
       megaEmail = '';
       megaPassword = '';
+      megaTwoFactorCode = '';
+      megaNeeds2fa = false;
+      megaNeedsReLogin = false;
 
-      // Automatically sync after login
       await handlePostLogin();
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      showSnackbar(message);
+      if (error && (error as { code?: string }).code === 'MFA_REQUIRED') {
+        // Reveal the 2FA field and keep email/password so the user just adds the code.
+        megaNeeds2fa = true;
+        showSnackbar('Enter your MEGA two-factor authentication code');
+      } else {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        showSnackbar(message);
+      }
     } finally {
       megaLoading = false;
     }
@@ -412,6 +437,9 @@
     if (provider === 'mega') {
       megaEmail = '';
       megaPassword = '';
+      megaTwoFactorCode = '';
+      megaNeeds2fa = false;
+      megaNeedsReLogin = false;
       showSnackbar('Logged out of MEGA');
     } else if (provider === 'webdav') {
       webdavPassword = '';
@@ -646,6 +674,11 @@
           </button>
 
           <div id="mega-login-form" class="hidden pr-4 pb-4 pl-12">
+            {#if megaNeedsReLogin}
+              <p class="mb-3 text-sm text-amber-400">
+                Your MEGA session expired — sign in again to reconnect.
+              </p>
+            {/if}
             <form
               onsubmit={(e) => {
                 e.preventDefault();
@@ -667,8 +700,24 @@
                 required
                 class="rounded-lg border border-gray-600 bg-gray-700 p-2.5 text-sm text-white"
               />
+              {#if megaNeeds2fa}
+                <input
+                  type="text"
+                  inputmode="numeric"
+                  autocomplete="one-time-code"
+                  required
+                  maxlength="6"
+                  bind:value={megaTwoFactorCode}
+                  placeholder="6-digit 2FA code"
+                  class="rounded-lg border border-amber-600 bg-gray-700 p-2.5 text-sm text-white"
+                />
+              {/if}
               <Button type="submit" disabled={megaLoading} color="blue" size="sm">
-                {megaLoading ? 'Connecting...' : 'Connect to MEGA'}
+                {megaLoading
+                  ? 'Connecting...'
+                  : megaNeeds2fa
+                    ? 'Verify & Connect'
+                    : 'Connect to MEGA'}
               </Button>
             </form>
           </div>


### PR DESCRIPTION
Promotes `develop` to `main` for the **v1.7.4** release.

### Added
- Horizontal panning with wheel and touchpad (thanks @binaryBrandon)
- MEGA two-factor authentication (2FA) login
- Uploaded covers now show thumbnails in MEGA

### Changed
- MEGA support no longer held together with hope and duct tape
- Faster MEGA downloads

### Fixed (post-1.7.4 on develop)
- Parallel MEGA uploads no longer create duplicate series folders (#241)

On merge, `release.yml` should tag `v1.7.4` and create the GitHub Release. Note: the release-notes extraction in `release.yml` doesn't match the bracketed `## [x.y.z]` changelog headers, so the auto-generated notes may be empty — will verify and fix after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)