### PR TITLE
Revert per-line layering contract to per-box z-index stacking

### DIFF
--- a/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
+++ b/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
@@ -101,6 +101,14 @@ Per line:
   is the block size and a wrapped line's lower fit does NOT pull the block
   down (p53: three lines at ~39.8 stay there). With 0-1 clean lines the block
   follows the wrapped line down so all lines still share one size (p32).
+- **No-clean-lines blocks** (e.g. a whole balloon captured as one quad+line,
+  Dr Stone 01 p87 `人類が全員石化して`: 9 chars in a 356×390 quad): the
+  reference derives from the suspect line itself and cannot gate the wrap, so
+  suspect lines wrap at their geometry-optimal size (unbounded start,
+  ≈ √(main × cross / advance)), still gated on the ≥ 1.25× benefit — a
+  genuine one-liner in a loose quad gains nothing from wrapping and stays
+  single. Hallucinated lines now wrap into dense contained columns instead of
+  rendering sub-pixel.
 
 Returns `null` (→ caller falls back to legacy rendering) when `lines_coords` is
 missing, length-mismatched with `lines`, or any quad is malformed/degenerate.

--- a/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
+++ b/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
@@ -116,14 +116,17 @@ Per line:
   single. Hallucinated lines now wrap into dense contained columns instead of
   rendering sub-pixel.
 
-- **Intra-block overlap dedupe** (Saki 02 p129): the detector sometimes
+- **Intra-block overlap handling** (Saki 02 p129): the detector sometimes
   re-captures the same ink region as several overlapping "lines" (a column
   alone AND a bigger quad spanning it plus neighbors), which renders stacked.
   When one line bbox covers ≥ 0.7 of a smaller one: if the smaller's text is
   contained in the bigger's, the smaller hides (bigger wraps the full region,
-  no text lost); otherwise the texts diverged (hallucination cluster) and the
-  enclosing blob hides, keeping the precise small captures. Hidden lines do
-  not vote on the reference and are not rendered.
+  no text lost). Otherwise the texts diverged (hallucination clusters on
+  dense/slanted regions) — individual placements are garbage but every OCR
+  line must remain READABLE even when wrong (user requirement): the
+  cluster's union bbox is partitioned into reading-order bands weighted by
+  text length, and each line wraps inside its own band. Hidden/clustered
+  lines do not vote on the block reference size.
 
 Returns `null` (→ caller falls back to legacy rendering) when `lines_coords` is
 missing, length-mismatched with `lines`, or any quad is malformed/degenerate.

--- a/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
+++ b/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
@@ -1,0 +1,142 @@
+# Original mode: per-line rendering from `lines_coords`
+
+**Date:** 2026-07-04
+**Branch:** `feat/original-mode-line-coords`
+**Status:** prototype
+
+## Problem
+
+Original mode renders every block at `font_size`px anchored at the box corner with
+`white-space: nowrap`. But mokuro's `font_size` is the mean detected line-quad
+_width_, which for vertical Japanese includes furigana and loose mask margin —
+median 1.20× (p95 2.0×) larger than the true character size across a 120-volume /
+160k-block scan. The reader's inherited `letter-spacing: 0.1em` and
+`line-height: 1.1em` add another ×1.1 per axis. Net: 62% of vertical blocks
+overflow their box by >25%; manga-ocr hallucinations overflow up to 90×.
+Auto mode works around this but discards line breaks and per-line positions.
+
+Root-cause analysis: see project memory `original-mode-overflow-root-cause` and
+https://claude.ai/code/artifact/611aa1cc-41ea-4186-ae7a-83542e5c4032
+
+## Insight
+
+`.mokuro` files carry `lines_coords` — one quadrilateral per OCR line — and the
+import pipeline stores blocks verbatim (`processing.ts` `blocks: page.blocks`),
+so the data is already in every user's IndexedDB. The quad gives each line's true
+position, length, and thickness. `quad_length ÷ text_advance` recovers the true
+font size per line.
+
+## Approach (chosen)
+
+Render each line as its own absolutely positioned span at its quad's position,
+with a per-line font size derived from quad geometry. Keep the existing one-box
+rendering as fallback when `lines_coords` is absent or inconsistent.
+
+Alternatives considered:
+
+- **Block-level shrink only** (cap block font_size so the longest line fits):
+  simplest, but keeps CSS-flow line positions, so multi-column balloons with
+  uneven columns still misalign, and furigana-as-separate-line renders huge.
+- **Fix upstream in mokuro** (emit corrected font_size): right long-term, but
+  doesn't help the existing library and loses per-line placement.
+- **Per-line transform scale-to-fit**: distorts glyphs; text selection boxes
+  misalign with visual text.
+
+## Components
+
+### 1. `src/lib/reader/line-coords-layout.ts` (new, pure)
+
+```ts
+export type Quad = number[][]; // 4 × [x, y]
+export type TextMeasurer = (text: string) => number; // advance in em units
+
+export interface LineLayout {
+  left: number; // px, relative to block box origin
+  top: number;
+  fontSize: number; // px
+}
+
+export function layoutLines(
+  block: { box: number[]; vertical: boolean; lines: string[]; lines_coords?: Quad[] },
+  lines: string[], // processed (post-ellipsis-substitution) text actually rendered
+  measure: TextMeasurer
+): LineLayout[] | null;
+```
+
+Per line:
+
+- Quad main/cross extents via edge-midpoint vectors (same math as
+  comic-text-detector's `examine_textblk`, rotation-tolerant):
+  vertical → main = ‖bottomMid − topMid‖, cross = ‖rightMid − leftMid‖;
+  horizontal → swapped.
+- `advanceEm = measure(processedLine)` — total advance in em units.
+- `fontSize = min(cross, main / advanceEm)`, floored at 4px.
+  - `cross` cap keeps the column no wider than the detected line.
+  - `main / advanceEm` cap keeps `chars × size` inside the detected length —
+    this also contains hallucinated lines (text ≫ quad → small but bounded).
+- Position = quad axis-aligned bbox top-left minus block box origin.
+
+Returns `null` (→ caller falls back to legacy rendering) when `lines_coords` is
+missing, length-mismatched with `lines`, or any quad is malformed/degenerate.
+
+Rotation: magnitudes handle rotated quads; placement is axis-aligned bbox.
+Rendering rotated text upright is accepted prototype behavior (future: CSS
+`rotate` above a threshold).
+
+### 2. Text measurer (in the same module)
+
+`createCanvasMeasurer(fontFamily)`: `CanvasRenderingContext2D.measureText` at
+100px `'Noto Sans JP', sans-serif`, memoized per string. Falls back to a
+char-class heuristic (fullwidth 1.0em, halfwidth 0.55em) when canvas is
+unavailable (jsdom). Vertical approximation: upright CJK advance ≈ 1em ≈
+horizontal measure; rotated Latin advance = horizontal measure. Good to a few
+percent; the `cross` cap bounds the error's visual effect.
+
+### 3. `src/lib/types/index.ts`
+
+`Block` gains `lines_coords?: number[][][]` (optional — image-only and stripped
+data stay valid).
+
+### 4. `TextBoxes.svelte`
+
+- In the `textBoxes` derived, when `isOriginalMode`, compute
+  `lineLayouts = layoutLines(block, processedLines, measurer)` (module-level
+  memoized measurer).
+- Template, original mode with `lineLayouts`: set `width`/`height` on the
+  `.textBox` (hover/tap target = OCR box, as other modes) and render
+  `<span class="ocr-line">` with `position:absolute`, per-line `left/top/font-size`,
+  `line-height: 1`, `letter-spacing: 0` (print tracking is already inside the
+  quad length). Container keeps `writing-mode`, so columns/rows flow correctly
+  inside each span. DOM order stays reading order.
+- Original mode without layouts: current markup and CSS unchanged.
+- Hover-visibility moves with the spans (background on spans; `p` keeps the
+  visibility toggle). The `.ocr-line::after { content: '\A' }` Yomitan/Migaku
+  continuity trick is preserved (zero layout effect inside positioned spans).
+- `.textBox` input-routing contract (double-tap Anki capture, selection drags,
+  contenteditable, copy handler) is untouched — same container, same handlers.
+- The auto-mode hover fit (`handleTextBoxHover`) already no-ops outside auto.
+
+## Error handling
+
+- Any inconsistency in coords → `null` → legacy path (never throw in render).
+- `advanceEm ≤ 0` (empty line) → fontSize = cross.
+- Non-finite/zero quad extents → `null`.
+
+## Testing
+
+1. **Unit (vitest, TDD)** — `layoutLines`: real fixtures captured from the
+   investigation (JJK furigana block, Hare+Guu shout, FMA hallucination block),
+   plus synthetic horizontal/halfwidth/mismatch/degenerate cases. Invariants:
+   `fontSize ≤ cross + ε`, `fontSize × advanceEm ≤ main + ε`, positions relative
+   to box, `null` fallbacks.
+2. **Component (vitest + testing-library)** — original mode with coords renders
+   positioned spans; without coords falls back; other modes unaffected.
+3. **E2E visual** — import a furigana-heavy volume (Pokémon Adventures 03) into
+   the dev app via Playwright (`E2E_PORT`), original mode + always-show OCR,
+   screenshot known-overflow pages before/after.
+
+## Out of scope
+
+- Upstream mokuro fix (separate effort).
+- Rotated-text rendering, per-line hover UX polish, Migaku deep-testing.
+- Auto/manual font-size modes — unchanged.

--- a/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
+++ b/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
@@ -74,7 +74,12 @@ Per line:
   - `cross` cap keeps the column no wider than the detected line.
   - `main / advanceEm` cap keeps `chars × size` inside the detected length —
     this also contains hallucinated lines (text ≫ quad → small but bounded).
-- Position = quad axis-aligned bbox top-left minus block box origin.
+- Position: anchored at the quad start on the reading axis (top for vertical,
+  left for horizontal), **centered on the cross axis** — quads are often wider
+  than the glyph column (attached ruby, mask slack, empty margin; e.g. Dr Stone
+  01 p27 `本物から` has a 125px quad for ~38px glyphs) and the base glyphs sit
+  near the middle, so edge-anchoring can shove a column into its neighbor.
+  Relative to the block box origin.
 
 Returns `null` (→ caller falls back to legacy rendering) when `lines_coords` is
 missing, length-mismatched with `lines`, or any quad is malformed/degenerate.
@@ -82,6 +87,18 @@ missing, length-mismatched with `lines`, or any quad is malformed/degenerate.
 Rotation: magnitudes handle rotated quads; placement is axis-aligned bbox.
 Rendering rotated text upright is accepted prototype behavior (future: CSS
 `rotate` above a threshold).
+
+### 1b. `src/lib/reader/block-dedupe.ts` (new, pure)
+
+comic-text-detector occasionally emits the same balloon twice: once properly
+segmented, once from a second YOLO hit whose seg-lines were claimed by the
+first block — that one gets its whole bbox as a single synthetic "line" with a
+huge font_size (e.g. Dr Stone 01 p29: 4-line block + 1-line `font_size: 199`
+twin; ~19 duplicate pairs per 1000 pages in a 60-volume scan). `dedupeBlocks`
+drops a block when another block has identical joined text and box IoU > 0.5,
+keeping the one with more lines (tie: the earlier). Applied in the `textBoxes`
+derived for all font modes; preserves original `page.blocks` indices for
+context-menu/Anki lookups.
 
 ### 2. Text measurer (in the same module)
 

--- a/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
+++ b/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-04
 **Branch:** `feat/original-mode-line-coords`
-**Status:** prototype
+**Status:** merged to develop as the auto-mode renderer (2026-07-05)
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
+++ b/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
@@ -89,13 +89,18 @@ Per line:
   length slack, 1.2× cross slack allowed); tighter quads fall back to their
   own fitted size so ruby lines never inflate to base size.
 - **Merged-column wrap**: a suspect line whose single-line fit is < 0.7 ×
-  reference AND whose quad cross is ≥ 1.6 × reference is multiple print
-  columns captured as one OCR "line" (typically base text + furigana reading,
-  e.g. Dr Stone 01 p32 `空は私ならだいじょうぶ`): it renders with
-  `white-space: normal` inside its full quad bbox, wrapping into columns.
+  reference AND for which wrapping buys ≥ 1.25 × the single-line size is
+  multiple print columns captured as one OCR "line" (typically base text +
+  furigana reading, e.g. Dr Stone 01 p32 `空は私ならだいじょうぶ`): it renders
+  with `white-space: normal` inside its full quad bbox, wrapping into columns.
   `wrapFitSize` picks the best column count n (size ≤ min(reference,
-  cross / n, n × main / advance)); the whole block's uniform size follows the
-  wrapped line down so all lines still share one size.
+  cross / n, n × main / advance)) — the gate is the achievable benefit, not a
+  quad-width ratio (a fixed 1.6× width gate missed Dr Stone 01 p53
+  `必要なことはう` by 0.7px, leaving it at 19px when 2 columns at 31.5px fit).
+- **Consensus trust**: when ≥ 2 clean lines agree within 1.25×, their median
+  is the block size and a wrapped line's lower fit does NOT pull the block
+  down (p53: three lines at ~39.8 stay there). With 0-1 clean lines the block
+  follows the wrapped line down so all lines still share one size (p32).
 
 Returns `null` (→ caller falls back to legacy rendering) when `lines_coords` is
 missing, length-mismatched with `lines`, or any quad is malformed/degenerate.

--- a/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
+++ b/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
@@ -29,8 +29,14 @@ font size per line.
 ## Approach (chosen)
 
 Render each line as its own absolutely positioned span at its quad's position,
-with a per-line font size derived from quad geometry. Keep the existing one-box
-rendering as fallback when `lines_coords` is absent or inconsistent.
+with a per-line font size derived from quad geometry.
+
+**Mode mapping (final, per user direction):** this reconstruction is neither
+the raw file (`original`) nor the old measure-and-shrink (`auto`) — it
+supersedes the old auto and ships as the new **`auto` mode** (the app
+default). Blocks without `lines_coords` (older imports, image-only) fall back
+to the legacy hover-fit auto behavior. `original` mode reverts to the
+faithful raw-`font_size` rendering. Block dedupe applies in all modes.
 
 Alternatives considered:
 

--- a/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
+++ b/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
@@ -116,6 +116,15 @@ Per line:
   single. Hallucinated lines now wrap into dense contained columns instead of
   rendering sub-pixel.
 
+- **Intra-block overlap dedupe** (Saki 02 p129): the detector sometimes
+  re-captures the same ink region as several overlapping "lines" (a column
+  alone AND a bigger quad spanning it plus neighbors), which renders stacked.
+  When one line bbox covers ≥ 0.7 of a smaller one: if the smaller's text is
+  contained in the bigger's, the smaller hides (bigger wraps the full region,
+  no text lost); otherwise the texts diverged (hallucination cluster) and the
+  enclosing blob hides, keeping the precise small captures. Hidden lines do
+  not vote on the reference and are not rendered.
+
 Returns `null` (→ caller falls back to legacy rendering) when `lines_coords` is
 missing, length-mismatched with `lines`, or any quad is malformed/degenerate.
 

--- a/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
+++ b/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
@@ -80,6 +80,15 @@ Per line:
   01 p27 `本物から` has a 125px quad for ~38px glyphs) and the base glyphs sit
   near the middle, so edge-anchoring can shove a column into its neighbor.
   Relative to the block box origin.
+- **Merged-column wrap**: `referenceSize = median(per-line candidates)`. A line
+  whose single-line fit is < 0.7 × reference AND whose quad cross is ≥ 1.6 ×
+  reference is treated as multiple print columns captured as one OCR "line"
+  (typically base text + furigana reading, e.g. Dr Stone 01 p32
+  `空は私ならだいじょうぶ`): it renders with `white-space: normal` inside its
+  full quad bbox at (near) the reference size, wrapping into columns. Clean
+  lines keep their own fitted size — print mixes sizes within a balloon
+  (emphasis words like `大丈夫`), so strict uniformity is deliberately not
+  enforced.
 
 Returns `null` (→ caller falls back to legacy rendering) when `lines_coords` is
 missing, length-mismatched with `lines`, or any quad is malformed/degenerate.

--- a/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
+++ b/docs/superpowers/specs/2026-07-04-original-mode-line-coords-design.md
@@ -80,15 +80,22 @@ Per line:
   01 p27 `本物から` has a 125px quad for ~38px glyphs) and the base glyphs sit
   near the middle, so edge-anchoring can shove a column into its neighbor.
   Relative to the block box origin.
-- **Merged-column wrap**: `referenceSize = median(per-line candidates)`. A line
-  whose single-line fit is < 0.7 × reference AND whose quad cross is ≥ 1.6 ×
-  reference is treated as multiple print columns captured as one OCR "line"
-  (typically base text + furigana reading, e.g. Dr Stone 01 p32
-  `空は私ならだいじょうぶ`): it renders with `white-space: normal` inside its
-  full quad bbox at (near) the reference size, wrapping into columns. Clean
-  lines keep their own fitted size — print mixes sizes within a balloon
-  (emphasis words like `大丈夫`), so strict uniformity is deliberately not
-  enforced.
+- **Uniform block sizing**: print keeps one size per balloon; per-quad fitted
+  sizes differ only through quad slack, and rendering them per-line looks
+  sloppy. Reference = median of candidates from lines that are neither
+  merged-columns suspects (quad ≥ 1.6 × its own fitted size) nor deliberately
+  small (< 0.7 × the clean median — standalone furigana, asides). Every line
+  renders at the block's uniform size when its quad can carry it (1.15×
+  length slack, 1.2× cross slack allowed); tighter quads fall back to their
+  own fitted size so ruby lines never inflate to base size.
+- **Merged-column wrap**: a suspect line whose single-line fit is < 0.7 ×
+  reference AND whose quad cross is ≥ 1.6 × reference is multiple print
+  columns captured as one OCR "line" (typically base text + furigana reading,
+  e.g. Dr Stone 01 p32 `空は私ならだいじょうぶ`): it renders with
+  `white-space: normal` inside its full quad bbox, wrapping into columns.
+  `wrapFitSize` picks the best column count n (size ≤ min(reference,
+  cross / n, n × main / advance)); the whole block's uniform size follows the
+  wrapped line down so all lines still share one size.
 
 Returns `null` (→ caller falls back to legacy rendering) when `lines_coords` is
 missing, length-mismatched with `lines`, or any quad is malformed/degenerate.

--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -67,11 +67,29 @@
 
         let [_xmin, _ymin, _xmax, _ymax] = box;
 
-        // Only expand bounding boxes when using auto font sizing
-        // Manual font sizes should use exact OCR bounding boxes
+        // Replace manual ellipsis with proper ellipsis character (…)
+        // Handle both ASCII periods (...) and full-width periods (．．．)
+        const processedLines = lines.map((line) =>
+          line.replace(/\.\.\./g, '…').replace(/．．．/g, '…')
+        );
+
+        const isOriginalMode = $settings.fontSize === 'original';
+        const isAutoMode = $settings.fontSize === 'auto';
+
+        // Auto mode: derive per-line position/size from the OCR line quads.
+        // mokuro's block font_size overstates the true character size (it is
+        // the quad width, furigana included), so rendering it as-is overflows
+        // the box; the quads themselves are accurate. Null (no lines_coords,
+        // e.g. pre-lines_coords imports) → legacy hover-fit auto below.
+        const lineLayouts = isAutoMode
+          ? layoutLines(block, processedLines, getDefaultMeasurer())
+          : null;
+
+        // Only expand bounding boxes for legacy hover-fit auto sizing;
+        // per-line layout and manual font sizes use exact OCR bounding boxes
         let xmin, ymin, xmax, ymax;
 
-        if ($settings.fontSize === 'auto') {
+        if (isAutoMode && !lineLayouts) {
           // Expand bounding box by 10% (5% on each side) to give text more room
           const originalWidth = _xmax - _xmin;
           const originalHeight = _ymax - _ymin;
@@ -83,7 +101,6 @@
           xmax = clamp(_xmax + expansionX, 0, img_width);
           ymax = clamp(_ymax + expansionY, 0, img_height);
         } else {
-          // Use exact OCR bounding boxes for manual font sizes
           xmin = _xmin;
           ymin = _ymin;
           xmax = _xmax;
@@ -94,12 +111,6 @@
         const height = ymax - ymin;
         const area = width * height;
 
-        // Replace manual ellipsis with proper ellipsis character (…)
-        // Handle both ASCII periods (...) and full-width periods (．．．)
-        const processedLines = lines.map((line) =>
-          line.replace(/\.\.\./g, '…').replace(/．．．/g, '…')
-        );
-
         // Determine font size based on setting
         let fontSize: string;
         if ($settings.fontSize === 'auto' || $settings.fontSize === 'original') {
@@ -107,16 +118,6 @@
         } else {
           fontSize = `${$settings.fontSize}pt`;
         }
-
-        const isOriginalMode = $settings.fontSize === 'original';
-
-        // Original mode: derive per-line position/size from the OCR line quads.
-        // mokuro's block font_size overstates the true character size (it is the
-        // quad width, furigana included), so rendering it overflows the box;
-        // the quads themselves are accurate. Null → legacy block rendering.
-        const lineLayouts = isOriginalMode
-          ? layoutLines(block, processedLines, getDefaultMeasurer())
-          : null;
 
         const textBox: TextBoxData = {
           left: `${xmin}px`,
@@ -288,8 +289,14 @@
     const [index, initialFontSize] = params;
 
     const calculate = () => {
-      // Skip if already processed, OCR is hidden, or using manual font size
-      if (processedTextBoxes.has(index) || display !== 'block' || $settings.fontSize !== 'auto')
+      // Skip if already processed, OCR is hidden, using manual font size, or
+      // the box is laid out per-line from lines_coords (no fitting needed)
+      if (
+        processedTextBoxes.has(index) ||
+        display !== 'block' ||
+        $settings.fontSize !== 'auto' ||
+        element.classList.contains('perLine')
+      )
         return;
 
       // Mark as processed immediately to prevent duplicate calculations
@@ -545,7 +552,7 @@
 </script>
 
 {#each textBoxes as { fontSize, height, left, lines, top, width, writingMode, useMinDimensions, isOriginalMode, lineLayouts, blockIndex }, index (`${volumeUuid}-textBox-${index}`)}
-  {@const usePerLine = isOriginalMode && lineLayouts !== null}
+  {@const usePerLine = lineLayouts !== null}
   <div
     use:handleTextBoxHover={[index, fontSize]}
     class="textBox"

--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -668,15 +668,33 @@
     white-space: nowrap;
   }
 
-  /* Original mode with lines_coords: each line is placed at its detected quad
-     with a geometry-derived font size. line-height 1 keeps the column/row no
-     thicker than the font size; letter-spacing 0 because the print's tracking
-     is already baked into the quad length the size was fitted to. */
+  /* Per-line mode: each line is placed at its detected quad with a
+     geometry-derived font size. line-height 1 keeps the column/row no
+     thicker than the font size; letter-spacing 0 because the print's
+     tracking is already baked into the quad length the size was fitted to. */
   .textBox.perLine .ocr-line.positionedLine {
     position: absolute;
     line-height: 1;
     letter-spacing: 0;
     white-space: nowrap;
+  }
+
+  /* Per-line mode: the white backing lives on each line, not the box —
+     block boxes can overlap (misassigned cross-block quads), and a whole-box
+     panel would blank out the other block's text. Each line's own strip
+     still masks the printed glyphs beneath it. */
+  .textBox.perLine:focus,
+  .textBox.perLine:hover,
+  .textBox.perLine.forceVisible,
+  .textBox.perLine.alwaysVisible {
+    background: transparent;
+  }
+
+  .textBox.perLine:focus .ocr-line.positionedLine,
+  .textBox.perLine:hover .ocr-line.positionedLine,
+  .textBox.perLine.forceVisible .ocr-line.positionedLine,
+  .textBox.perLine.alwaysVisible .ocr-line.positionedLine {
+    background: rgb(255, 255, 255);
   }
 
   /* A quad that captured multiple print columns (base text + furigana):

--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -53,8 +53,8 @@
     area: number;
     useMinDimensions: boolean;
     isOriginalMode: boolean;
-    /** Per-line positions/sizes from lines_coords (original mode only);
-     * null falls back to block-level rendering */
+    /** Per-line positions/sizes from lines_coords (auto mode only);
+     * null falls back to legacy hover-fit auto rendering */
     lineLayouts: LineLayout[] | null;
     blockIndex: number; // Original index in page.blocks
   }
@@ -579,19 +579,19 @@
   >
     <p>
       {#if usePerLine && lineLayouts}
-        {#each lines as line, lineIndex}<span
-            class="ocr-line positionedLine"
-            class:wrappedLine={lineLayouts[lineIndex].wrap}
-            style:left={`${lineLayouts[lineIndex].left}px`}
-            style:top={`${lineLayouts[lineIndex].top}px`}
-            style:width={lineLayouts[lineIndex].wrap
-              ? `${lineLayouts[lineIndex].width}px`
-              : undefined}
-            style:height={lineLayouts[lineIndex].wrap
-              ? `${lineLayouts[lineIndex].height}px`
-              : undefined}
-            style:font-size={`${lineLayouts[lineIndex].fontSize}px`}>{line}</span
-          >{/each}
+        {#each lines as line, lineIndex}{#if !lineLayouts[lineIndex].hidden}<span
+              class="ocr-line positionedLine"
+              class:wrappedLine={lineLayouts[lineIndex].wrap}
+              style:left={`${lineLayouts[lineIndex].left}px`}
+              style:top={`${lineLayouts[lineIndex].top}px`}
+              style:width={lineLayouts[lineIndex].wrap
+                ? `${lineLayouts[lineIndex].width}px`
+                : undefined}
+              style:height={lineLayouts[lineIndex].wrap
+                ? `${lineLayouts[lineIndex].height}px`
+                : undefined}
+              style:font-size={`${lineLayouts[lineIndex].fontSize}px`}>{line}</span
+            >{/if}{/each}
       {:else}
         {#each lines as line}<span class="ocr-line">{line}</span>{/each}
       {/if}

--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -574,8 +574,15 @@
       {#if usePerLine && lineLayouts}
         {#each lines as line, lineIndex}<span
             class="ocr-line positionedLine"
+            class:wrappedLine={lineLayouts[lineIndex].wrap}
             style:left={`${lineLayouts[lineIndex].left}px`}
             style:top={`${lineLayouts[lineIndex].top}px`}
+            style:width={lineLayouts[lineIndex].wrap
+              ? `${lineLayouts[lineIndex].width}px`
+              : undefined}
+            style:height={lineLayouts[lineIndex].wrap
+              ? `${lineLayouts[lineIndex].height}px`
+              : undefined}
             style:font-size={`${lineLayouts[lineIndex].fontSize}px`}>{line}</span
           >{/each}
       {:else}
@@ -663,6 +670,14 @@
     line-height: 1;
     letter-spacing: 0;
     white-space: nowrap;
+  }
+
+  /* A quad that captured multiple print columns (base text + furigana):
+     the text flows inside the full quad bbox at the block's reference size,
+     wrapping into columns/rows instead of shrinking onto one line. */
+  .textBox.perLine .ocr-line.positionedLine.wrappedLine {
+    white-space: normal;
+    line-break: anywhere;
   }
 
   /* Use CSS-generated newline instead of <br/> so DOM walkers

--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -16,6 +16,7 @@
     type VolumeMetadata
   } from '$lib/anki-connect';
   import { db } from '$lib/catalog/db';
+  import { layoutLines, getDefaultMeasurer, type LineLayout } from '$lib/reader/line-coords-layout';
 
   interface ContextMenuData {
     x: number;
@@ -51,6 +52,9 @@
     area: number;
     useMinDimensions: boolean;
     isOriginalMode: boolean;
+    /** Per-line positions/sizes from lines_coords (original mode only);
+     * null falls back to block-level rendering */
+    lineLayouts: LineLayout[] | null;
     blockIndex: number; // Original index in page.blocks
   }
 
@@ -105,6 +109,14 @@
 
         const isOriginalMode = $settings.fontSize === 'original';
 
+        // Original mode: derive per-line position/size from the OCR line quads.
+        // mokuro's block font_size overstates the true character size (it is the
+        // quad width, furigana included), so rendering it overflows the box;
+        // the quads themselves are accurate. Null → legacy block rendering.
+        const lineLayouts = isOriginalMode
+          ? layoutLines(block, processedLines, getDefaultMeasurer())
+          : null;
+
         const textBox: TextBoxData = {
           left: `${xmin}px`,
           top: `${ymin}px`,
@@ -116,6 +128,7 @@
           area,
           useMinDimensions: $settings.fontSize !== 'auto' && !isOriginalMode,
           isOriginalMode,
+          lineLayouts,
           blockIndex
         };
 
@@ -530,15 +543,17 @@
   }
 </script>
 
-{#each textBoxes as { fontSize, height, left, lines, top, width, writingMode, useMinDimensions, isOriginalMode, blockIndex }, index (`${volumeUuid}-textBox-${index}`)}
+{#each textBoxes as { fontSize, height, left, lines, top, width, writingMode, useMinDimensions, isOriginalMode, lineLayouts, blockIndex }, index (`${volumeUuid}-textBox-${index}`)}
+  {@const usePerLine = isOriginalMode && lineLayouts !== null}
   <div
     use:handleTextBoxHover={[index, fontSize]}
     class="textBox"
     class:originalMode={isOriginalMode}
+    class:perLine={usePerLine}
     class:forceVisible
     class:alwaysVisible={alwaysShowOCR}
-    style:width={isOriginalMode ? undefined : useMinDimensions ? undefined : width}
-    style:height={isOriginalMode ? undefined : useMinDimensions ? undefined : height}
+    style:width={usePerLine ? width : isOriginalMode || useMinDimensions ? undefined : width}
+    style:height={usePerLine ? height : isOriginalMode || useMinDimensions ? undefined : height}
     style:min-width={isOriginalMode ? undefined : useMinDimensions ? width : undefined}
     style:min-height={isOriginalMode ? undefined : useMinDimensions ? height : undefined}
     style:left
@@ -555,7 +570,16 @@
     {contenteditable}
   >
     <p>
-      {#each lines as line}<span class="ocr-line">{line}</span>{/each}
+      {#if usePerLine && lineLayouts}
+        {#each lines as line, lineIndex}<span
+            class="ocr-line positionedLine"
+            style:left={`${lineLayouts[lineIndex].left}px`}
+            style:top={`${lineLayouts[lineIndex].top}px`}
+            style:font-size={`${lineLayouts[lineIndex].fontSize}px`}>{line}</span
+          >{/each}
+      {:else}
+        {#each lines as line}<span class="ocr-line">{line}</span>{/each}
+      {/if}
     </p>
   </div>
 {/each}
@@ -626,6 +650,17 @@
   }
 
   .textBox.originalMode p {
+    white-space: nowrap;
+  }
+
+  /* Original mode with lines_coords: each line is placed at its detected quad
+     with a geometry-derived font size. line-height 1 keeps the column/row no
+     thicker than the font size; letter-spacing 0 because the print's tracking
+     is already baked into the quad length the size was fitted to. */
+  .textBox.perLine .ocr-line.positionedLine {
+    position: absolute;
+    line-height: 1;
+    letter-spacing: 0;
     white-space: nowrap;
   }
 

--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -17,6 +17,7 @@
   } from '$lib/anki-connect';
   import { db } from '$lib/catalog/db';
   import { layoutLines, getDefaultMeasurer, type LineLayout } from '$lib/reader/line-coords-layout';
+  import { dedupeBlocks } from '$lib/reader/block-dedupe';
 
   interface ContextMenuData {
     x: number;
@@ -59,8 +60,8 @@
   }
 
   let textBoxes = $derived(
-    page.blocks
-      .map((block, blockIndex) => {
+    dedupeBlocks(page.blocks)
+      .map(({ block, blockIndex }) => {
         const { img_height, img_width } = page;
         const { box, font_size, lines, vertical } = block;
 

--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -609,6 +609,7 @@
     font-family: 'Noto Sans JP', sans-serif;
     /* Word wrapping controlled dynamically by JavaScript */
     border: 1px solid rgba(0, 0, 0, 0);
+    z-index: 11;
     user-select: text;
     -webkit-user-select: text;
     -moz-user-select: text;
@@ -632,6 +633,7 @@
     background-color: rgb(255, 255, 255);
     font-weight: var(--bold);
     font-family: 'Noto Sans JP', sans-serif;
+    z-index: 11;
     user-select: text;
     -webkit-user-select: text;
     -moz-user-select: text;
@@ -666,27 +668,15 @@
     white-space: nowrap;
   }
 
-  /* Per-line mode: each line is placed at its detected quad with a
-     geometry-derived font size. line-height 1 keeps the column/row no
-     thicker than the font size; letter-spacing 0 because the print's
-     tracking is already baked into the quad length the size was fitted to. */
+  /* Original mode with lines_coords: each line is placed at its detected quad
+     with a geometry-derived font size. line-height 1 keeps the column/row no
+     thicker than the font size; letter-spacing 0 because the print's tracking
+     is already baked into the quad length the size was fitted to. */
   .textBox.perLine .ocr-line.positionedLine {
     position: absolute;
     line-height: 1;
     letter-spacing: 0;
     white-space: nowrap;
-  }
-
-  /* Layering contract for overlapping blocks (detector sometimes assigns a
-     column to the neighboring block, so boxes overlap): every box's white
-     panel must paint below every box's per-line text. The boxes stay
-     z-index:auto (no own stacking context — tree order still stacks smaller
-     boxes over bigger ones), while positioned line spans get a positive
-     z-index that lifts them above all panels in the page's context. The
-     whole-box panel is kept because it masks messy/angled print that
-     per-line strips cannot cover. */
-  .textBox.perLine .ocr-line.positionedLine {
-    z-index: 1;
   }
 
   /* A quad that captured multiple print columns (base text + furigana):

--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -609,7 +609,6 @@
     font-family: 'Noto Sans JP', sans-serif;
     /* Word wrapping controlled dynamically by JavaScript */
     border: 1px solid rgba(0, 0, 0, 0);
-    z-index: 11;
     user-select: text;
     -webkit-user-select: text;
     -moz-user-select: text;
@@ -633,7 +632,6 @@
     background-color: rgb(255, 255, 255);
     font-weight: var(--bold);
     font-family: 'Noto Sans JP', sans-serif;
-    z-index: 11;
     user-select: text;
     -webkit-user-select: text;
     -moz-user-select: text;
@@ -679,22 +677,16 @@
     white-space: nowrap;
   }
 
-  /* Per-line mode: the white backing lives on each line, not the box —
-     block boxes can overlap (misassigned cross-block quads), and a whole-box
-     panel would blank out the other block's text. Each line's own strip
-     still masks the printed glyphs beneath it. */
-  .textBox.perLine:focus,
-  .textBox.perLine:hover,
-  .textBox.perLine.forceVisible,
-  .textBox.perLine.alwaysVisible {
-    background: transparent;
-  }
-
-  .textBox.perLine:focus .ocr-line.positionedLine,
-  .textBox.perLine:hover .ocr-line.positionedLine,
-  .textBox.perLine.forceVisible .ocr-line.positionedLine,
-  .textBox.perLine.alwaysVisible .ocr-line.positionedLine {
-    background: rgb(255, 255, 255);
+  /* Layering contract for overlapping blocks (detector sometimes assigns a
+     column to the neighboring block, so boxes overlap): every box's white
+     panel must paint below every box's per-line text. The boxes stay
+     z-index:auto (no own stacking context — tree order still stacks smaller
+     boxes over bigger ones), while positioned line spans get a positive
+     z-index that lifts them above all panels in the page's context. The
+     whole-box panel is kept because it masks messy/angled print that
+     per-line strips cannot cover. */
+  .textBox.perLine .ocr-line.positionedLine {
+    z-index: 1;
   }
 
   /* A quad that captured multiple print columns (base text + furigana):

--- a/src/lib/components/Reader/__tests__/TextBoxes.test.ts
+++ b/src/lib/components/Reader/__tests__/TextBoxes.test.ts
@@ -9,7 +9,7 @@ vi.mock('$lib/settings', async () => {
   const { writable } = await import('svelte/store');
   return {
     settings: writable({
-      fontSize: 'original',
+      fontSize: 'auto',
       boldFont: false,
       displayOCR: true,
       alwaysShowOCR: true,
@@ -79,7 +79,7 @@ function makePage(blocks: unknown[]): Page {
   };
 }
 
-describe('TextBoxes original mode with lines_coords', () => {
+describe('TextBoxes auto mode with lines_coords', () => {
   it('renders each line as a positioned span sized from its quad', () => {
     const { container } = render(TextBoxes, {
       page: makePage([blockWithCoords]),
@@ -115,7 +115,7 @@ describe('TextBoxes original mode with lines_coords', () => {
     expect(box?.style.height).toBe('235px');
   });
 
-  it('falls back to block-level rendering when lines_coords is absent', () => {
+  it('falls back to legacy hover-fit auto when lines_coords is absent', () => {
     const { lines_coords: _dropped, ...legacyBlock } = blockWithCoords;
     const { container } = render(TextBoxes, {
       page: makePage([legacyBlock]),
@@ -127,12 +127,13 @@ describe('TextBoxes original mode with lines_coords', () => {
 
     const box = container.querySelector<HTMLElement>('.textBox');
     expect(box?.style.fontSize).toBe('46px');
-    // legacy original mode leaves the box unsized (overflow-visible)
-    expect(box?.style.width).toBe('');
+    expect(box?.classList.contains('perLine')).toBe(false);
+    // legacy auto expands the box 10% and fixes its dimensions as fit target
+    expect(parseFloat(box!.style.width)).toBeCloseTo(148 * 1.1, 1);
   });
 
-  it('does not use per-line rendering outside original mode', () => {
-    settingsStore.update((s) => ({ ...s, fontSize: 'auto' }));
+  it('original mode renders the raw block font_size without per-line layout', () => {
+    settingsStore.update((s) => ({ ...s, fontSize: 'original' }));
     try {
       const { container } = render(TextBoxes, {
         page: makePage([blockWithCoords]),
@@ -140,8 +141,12 @@ describe('TextBoxes original mode with lines_coords', () => {
       });
       expect(container.querySelectorAll('.ocr-line.positionedLine')).toHaveLength(0);
       expect(container.querySelectorAll('.ocr-line')).toHaveLength(3);
+      const box = container.querySelector<HTMLElement>('.textBox');
+      expect(box?.style.fontSize).toBe('46px');
+      // faithful original mode: unsized, overflow-visible box
+      expect(box?.style.width).toBe('');
     } finally {
-      settingsStore.update((s) => ({ ...s, fontSize: 'original' }));
+      settingsStore.update((s) => ({ ...s, fontSize: 'auto' }));
       expect(get(settingsStore)).toBeTruthy();
     }
   });

--- a/src/lib/components/Reader/__tests__/TextBoxes.test.ts
+++ b/src/lib/components/Reader/__tests__/TextBoxes.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+import { get, writable, type Writable } from 'svelte/store';
+import TextBoxes from '../TextBoxes.svelte';
+import { settings } from '$lib/settings';
+import type { Page } from '$lib/types';
+
+vi.mock('$lib/settings', async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    settings: writable({
+      fontSize: 'original',
+      boldFont: false,
+      displayOCR: true,
+      alwaysShowOCR: true,
+      textBoxBorders: false,
+      textEditable: false,
+      ankiConnectSettings: { triggerMethod: 'doubleTap', tags: [], cardMode: 'single' }
+    }),
+    volumes: writable({})
+  };
+});
+
+vi.mock('$lib/catalog/db', () => ({
+  db: { volumes: { get: vi.fn() } }
+}));
+
+vi.mock('$lib/anki-connect', () => ({
+  showCropper: vi.fn(),
+  openCreateModal: vi.fn(),
+  openUpdateModal: vi.fn(),
+  expandTextBoxBounds: vi.fn(),
+  sendQuickCapture: vi.fn(),
+  getLastCardInfo: vi.fn(),
+  getCardAgeInMin: vi.fn(),
+  extractFieldValues: vi.fn(),
+  getModelConfig: vi.fn(),
+  blobToBase64: vi.fn()
+}));
+
+const settingsStore = settings as unknown as Writable<Record<string, unknown>>;
+
+// Real block from Jujutsukaisen 24 p57: font_size 46 is furigana-inflated;
+// true glyphs are ~20-30px
+const blockWithCoords = {
+  box: [653, 123, 801, 358],
+  vertical: true,
+  font_size: 46,
+  lines_coords: [
+    [
+      [733, 123],
+      [793, 123],
+      [793, 298],
+      [733, 298]
+    ],
+    [
+      [697, 125],
+      [736, 125],
+      [741, 358],
+      [703, 358]
+    ],
+    [
+      [653, 128],
+      [692, 128],
+      [692, 325],
+      [653, 325]
+    ]
+  ],
+  lines: ['総則追加で言うのは', '結界の出入りを', '可能にしても']
+};
+
+function makePage(blocks: unknown[]): Page {
+  return {
+    version: '0.2.2',
+    img_width: 1500,
+    img_height: 2200,
+    img_path: 'page_001.jpg',
+    blocks: blocks as Page['blocks']
+  };
+}
+
+describe('TextBoxes original mode with lines_coords', () => {
+  it('renders each line as a positioned span sized from its quad', () => {
+    const { container } = render(TextBoxes, {
+      page: makePage([blockWithCoords]),
+      volumeUuid: 'test-uuid'
+    });
+
+    const spans = container.querySelectorAll<HTMLElement>('.ocr-line.positionedLine');
+    expect(spans).toHaveLength(3);
+
+    // first line sits at its quad offset within the box (733-653, 123-123)
+    expect(spans[0].style.left).toBe('80px');
+    expect(spans[0].style.top).toBe('0px');
+
+    for (const span of spans) {
+      const size = parseFloat(span.style.fontSize);
+      // fitted sizes stay below the inflated block font_size
+      expect(size).toBeGreaterThan(10);
+      expect(size).toBeLessThan(46);
+    }
+
+    // the box keeps its OCR dimensions as the hover/tap target
+    const box = container.querySelector<HTMLElement>('.textBox');
+    expect(box?.style.width).toBe('148px');
+    expect(box?.style.height).toBe('235px');
+  });
+
+  it('falls back to block-level rendering when lines_coords is absent', () => {
+    const { lines_coords: _dropped, ...legacyBlock } = blockWithCoords;
+    const { container } = render(TextBoxes, {
+      page: makePage([legacyBlock]),
+      volumeUuid: 'test-uuid'
+    });
+
+    expect(container.querySelectorAll('.ocr-line.positionedLine')).toHaveLength(0);
+    expect(container.querySelectorAll('.ocr-line')).toHaveLength(3);
+
+    const box = container.querySelector<HTMLElement>('.textBox');
+    expect(box?.style.fontSize).toBe('46px');
+    // legacy original mode leaves the box unsized (overflow-visible)
+    expect(box?.style.width).toBe('');
+  });
+
+  it('does not use per-line rendering outside original mode', () => {
+    settingsStore.update((s) => ({ ...s, fontSize: 'auto' }));
+    try {
+      const { container } = render(TextBoxes, {
+        page: makePage([blockWithCoords]),
+        volumeUuid: 'test-uuid'
+      });
+      expect(container.querySelectorAll('.ocr-line.positionedLine')).toHaveLength(0);
+      expect(container.querySelectorAll('.ocr-line')).toHaveLength(3);
+    } finally {
+      settingsStore.update((s) => ({ ...s, fontSize: 'original' }));
+      expect(get(settingsStore)).toBeTruthy();
+    }
+  });
+});

--- a/src/lib/components/Reader/__tests__/TextBoxes.test.ts
+++ b/src/lib/components/Reader/__tests__/TextBoxes.test.ts
@@ -89,11 +89,18 @@ describe('TextBoxes original mode with lines_coords', () => {
     const spans = container.querySelectorAll<HTMLElement>('.ocr-line.positionedLine');
     expect(spans).toHaveLength(3);
 
-    // first line: centered on its quad's cross axis (quad x [733,793], fs 175/9),
-    // anchored at the quad top (y 123 = box top)
-    const fs0 = 175 / 9;
-    expect(parseFloat(spans[0].style.left)).toBeCloseTo(763 - fs0 / 2 - 653, 3);
+    // first line: its quad captured a neighbor's ruby ink (60px wide for
+    // ~19px glyphs) → wraps inside the full quad bbox at the reference size
+    expect(spans[0].classList.contains('wrappedLine')).toBe(true);
+    expect(spans[0].style.left).toBe('80px');
     expect(spans[0].style.top).toBe('0px');
+    expect(spans[0].style.width).toBe('60px');
+    expect(spans[0].style.height).toBe('175px');
+    expect(parseFloat(spans[0].style.fontSize)).toBeCloseTo(30, 1);
+
+    // remaining lines: clean columns, no wrapping container
+    expect(spans[1].classList.contains('wrappedLine')).toBe(false);
+    expect(spans[1].style.width).toBe('');
 
     for (const span of spans) {
       const size = parseFloat(span.style.fontSize);

--- a/src/lib/components/Reader/__tests__/TextBoxes.test.ts
+++ b/src/lib/components/Reader/__tests__/TextBoxes.test.ts
@@ -89,8 +89,10 @@ describe('TextBoxes original mode with lines_coords', () => {
     const spans = container.querySelectorAll<HTMLElement>('.ocr-line.positionedLine');
     expect(spans).toHaveLength(3);
 
-    // first line sits at its quad offset within the box (733-653, 123-123)
-    expect(spans[0].style.left).toBe('80px');
+    // first line: centered on its quad's cross axis (quad x [733,793], fs 175/9),
+    // anchored at the quad top (y 123 = box top)
+    const fs0 = 175 / 9;
+    expect(parseFloat(spans[0].style.left)).toBeCloseTo(763 - fs0 / 2 - 653, 3);
     expect(spans[0].style.top).toBe('0px');
 
     for (const span of spans) {

--- a/src/lib/reader/block-dedupe.test.ts
+++ b/src/lib/reader/block-dedupe.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { dedupeBlocks } from './block-dedupe';
+import type { Block } from '$lib/types';
+
+// Real duplicate pair from Dr Stone 01 p28 (blocks 7 and 8): the detector
+// emitted the same balloon twice — once properly segmented into 4 lines,
+// once as a single synthetic whole-box "line" with font_size 199.
+const properBlock: Block = {
+  box: [762, 2102, 973, 2346],
+  vertical: true,
+  font_size: 51,
+  lines_coords: [
+    [
+      [910, 2102],
+      [973, 2102],
+      [973, 2201],
+      [910, 2201]
+    ],
+    [
+      [874, 2110],
+      [913, 2110],
+      [913, 2346],
+      [874, 2346]
+    ],
+    [
+      [817, 2105],
+      [869, 2105],
+      [869, 2233],
+      [817, 2233]
+    ],
+    [
+      [762, 2105],
+      [809, 2105],
+      [809, 2346],
+      [762, 2346]
+    ]
+  ],
+  lines: ['ぬう', 'よりによって', 'こんな', 'マヌケな姿を']
+};
+
+const duplicateBlock: Block = {
+  box: [765, 2109, 964, 2344],
+  vertical: true,
+  font_size: 199,
+  lines_coords: [
+    [
+      [765, 2109],
+      [964, 2109],
+      [964, 2344],
+      [765, 2344]
+    ]
+  ],
+  lines: ['ぬうよりによってこんなマヌケな姿を']
+};
+
+const unrelatedBlock: Block = {
+  box: [100, 100, 200, 300],
+  vertical: true,
+  font_size: 40,
+  lines: ['別のセリフ']
+};
+
+describe('dedupeBlocks', () => {
+  it('drops the single-line duplicate and keeps the segmented block', () => {
+    const kept = dedupeBlocks([properBlock, duplicateBlock, unrelatedBlock]);
+    expect(kept.map((k) => k.blockIndex)).toEqual([0, 2]);
+    expect(kept[0].block).toBe(properBlock);
+  });
+
+  it('keeps the segmented block regardless of array order', () => {
+    const kept = dedupeBlocks([duplicateBlock, properBlock]);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].block).toBe(properBlock);
+    expect(kept[0].blockIndex).toBe(1);
+  });
+
+  it('preserves original block indices for downstream page.blocks lookups', () => {
+    const kept = dedupeBlocks([unrelatedBlock, duplicateBlock, properBlock]);
+    expect(kept.map((k) => k.blockIndex)).toEqual([0, 2]);
+  });
+
+  it('does not merge same text in different places (repeated SFX)', () => {
+    const sfxA: Block = { box: [0, 0, 60, 200], vertical: true, font_size: 40, lines: ['ドン'] };
+    const sfxB: Block = {
+      box: [900, 1500, 960, 1700],
+      vertical: true,
+      font_size: 40,
+      lines: ['ドン']
+    };
+    expect(dedupeBlocks([sfxA, sfxB])).toHaveLength(2);
+  });
+
+  it('does not merge overlapping blocks with different text', () => {
+    const a: Block = { box: [0, 0, 100, 100], vertical: true, font_size: 30, lines: ['あい'] };
+    const b: Block = { box: [10, 10, 110, 110], vertical: true, font_size: 30, lines: ['うえ'] };
+    expect(dedupeBlocks([a, b])).toHaveLength(2);
+  });
+
+  it('keeps one of two identical single-line detections', () => {
+    const a: Block = { box: [0, 0, 100, 100], vertical: true, font_size: 30, lines: ['通路'] };
+    const b: Block = { box: [5, 5, 103, 102], vertical: true, font_size: 32, lines: ['通路'] };
+    const kept = dedupeBlocks([a, b]);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].blockIndex).toBe(0);
+  });
+
+  it('ignores blocks with empty text', () => {
+    const a: Block = { box: [0, 0, 100, 100], vertical: true, font_size: 30, lines: [''] };
+    const b: Block = { box: [0, 0, 100, 100], vertical: true, font_size: 30, lines: [''] };
+    expect(dedupeBlocks([a, b])).toHaveLength(2);
+  });
+
+  it('handles pages with no duplicates without changes', () => {
+    const kept = dedupeBlocks([properBlock, unrelatedBlock]);
+    expect(kept.map((k) => k.block)).toEqual([properBlock, unrelatedBlock]);
+  });
+});

--- a/src/lib/reader/block-dedupe.ts
+++ b/src/lib/reader/block-dedupe.ts
@@ -1,0 +1,60 @@
+/**
+ * Drop duplicate OCR blocks before rendering.
+ *
+ * comic-text-detector occasionally emits the same balloon twice: once
+ * properly segmented into lines, and once from a second YOLO hit whose
+ * segmentation lines were claimed by the first block — that block gets its
+ * whole bbox as one synthetic "line" (huge font_size, all text concatenated).
+ * ~19 duplicate pairs per 1000 pages in a 60-volume corpus scan.
+ *
+ * Rule: two blocks are duplicates when their joined text is identical and
+ * their boxes overlap (IoU > 0.5). The better-segmented block (more lines)
+ * wins; ties keep the earlier block. Render-time dedupe fixes volumes that
+ * are already imported.
+ */
+import type { Block } from '$lib/types';
+
+export interface KeptBlock {
+  block: Block;
+  /** Index into the original page.blocks array */
+  blockIndex: number;
+}
+
+const IOU_THRESHOLD = 0.5;
+
+function boxIoU(a: number[], b: number[]): number {
+  const ix = Math.max(0, Math.min(a[2], b[2]) - Math.max(a[0], b[0]));
+  const iy = Math.max(0, Math.min(a[3], b[3]) - Math.max(a[1], b[1]));
+  const inter = ix * iy;
+  if (inter <= 0) return 0;
+  const areaA = (a[2] - a[0]) * (a[3] - a[1]);
+  const areaB = (b[2] - b[0]) * (b[3] - b[1]);
+  const union = areaA + areaB - inter;
+  return union > 0 ? inter / union : 0;
+}
+
+export function dedupeBlocks(blocks: Block[]): KeptBlock[] {
+  const dropped = new Set<number>();
+  const texts = blocks.map((b) => (b.lines ?? []).join('').trim());
+
+  for (let i = 0; i < blocks.length; i++) {
+    if (dropped.has(i) || !texts[i]) continue;
+    for (let j = i + 1; j < blocks.length; j++) {
+      if (dropped.has(j)) continue;
+      if (texts[i] !== texts[j]) continue;
+      if (boxIoU(blocks[i].box, blocks[j].box) <= IOU_THRESHOLD) continue;
+      // duplicate pair: keep the better-segmented block (more lines);
+      // on a tie keep the earlier one
+      if (blocks[j].lines.length > blocks[i].lines.length) {
+        dropped.add(i);
+        break;
+      } else {
+        dropped.add(j);
+      }
+    }
+  }
+
+  return blocks
+    .map((block, blockIndex) => ({ block, blockIndex }))
+    .filter(({ blockIndex }) => !dropped.has(blockIndex));
+}

--- a/src/lib/reader/line-coords-layout.test.ts
+++ b/src/lib/reader/line-coords-layout.test.ts
@@ -144,11 +144,63 @@ describe('layoutLines', () => {
 
   it('contains hallucinated lines inside their quad instead of overflowing 90x', () => {
     const layouts = layoutLines(fmaHallucination, fmaHallucination.lines, heuristicMeasurer)!;
-    const { main } = quadMainCross(fmaHallucination.lines_coords![0], true);
+    const { main, cross } = quadMainCross(fmaHallucination.lines_coords![0], true);
     const advanceEm = heuristicMeasurer(fmaHallucination.lines[0]);
-    expect(layouts[0].fontSize * advanceEm).toBeLessThanOrEqual(main + 0.5);
-    // 99 chars in a 114px quad: about 1px per char — tiny but contained
-    expect(layouts[0].fontSize).toBeLessThan(3 * (114 / advanceEm));
+    // 99 chars in a 94x114 quad: wraps into dense columns (like the dense
+    // print it misread), but stays inside the quad
+    expect(layouts[0].wrap).toBe(true);
+    const cols = Math.ceil((advanceEm * layouts[0].fontSize) / main);
+    expect(cols * layouts[0].fontSize).toBeLessThanOrEqual(cross + 0.5);
+    expect(layouts[0].fontSize).toBeLessThan(15);
+  });
+
+  it('wraps a whole-balloon single-line block into columns (Dr Stone p87)', () => {
+    // The detector emitted one quad covering the entire 3-column balloon:
+    // 9 chars in a 356x390 box. Single-line fit is 43px in a huge box; the
+    // geometry-optimal wrap is 3 columns at ~119px — the print layout.
+    const drStoneP87: LayoutBlock = {
+      box: [1296, 104, 1652, 494],
+      vertical: true,
+      font_size: 356,
+      lines_coords: [
+        [
+          [1296, 104],
+          [1652, 104],
+          [1652, 494],
+          [1296, 494]
+        ]
+      ],
+      lines: ['人類が全員石化して']
+    };
+    const layouts = layoutLines(drStoneP87, drStoneP87.lines, heuristicMeasurer)!;
+    expect(layouts[0].wrap).toBe(true);
+    expect(layouts[0].fontSize).toBeGreaterThan(100);
+    // 3 columns at the computed size fit the quad width
+    const cols = Math.ceil((9 * layouts[0].fontSize) / 390);
+    expect(cols).toBe(3);
+    expect(cols * layouts[0].fontSize).toBeLessThanOrEqual(356 + 0.5);
+  });
+
+  it('keeps a genuine one-line block single when wrapping buys nothing', () => {
+    // Loose quad around a short line: wrapping to 2 columns would not let
+    // the text render meaningfully bigger, so it stays one column.
+    const block: LayoutBlock = {
+      box: [0, 0, 100, 100],
+      vertical: true,
+      font_size: 60,
+      lines_coords: [
+        [
+          [0, 0],
+          [100, 0],
+          [100, 100],
+          [0, 100]
+        ]
+      ],
+      lines: ['ドン'] // 2 chars: single-line fit 50px, 2-col wrap also 50px
+    };
+    const layouts = layoutLines(block, block.lines, heuristicMeasurer)!;
+    expect(layouts[0].wrap).toBe(false);
+    expect(layouts[0].fontSize).toBeCloseTo(50, 1);
   });
 
   it('centers each clean line on its quad cross axis, anchored at the reading start', () => {

--- a/src/lib/reader/line-coords-layout.test.ts
+++ b/src/lib/reader/line-coords-layout.test.ts
@@ -118,13 +118,15 @@ describe('layoutLines', () => {
       layouts!.forEach((l, i) => {
         const { main, cross } = quadMainCross(block.lines_coords![i], block.vertical);
         const advanceEm = heuristicMeasurer(block.lines[i]);
-        expect(l.fontSize).toBeLessThanOrEqual(cross + 0.5);
+        // uniform block sizing tolerates per-quad slack: 1.2x across the
+        // line, 1.15x along it (quad tightness varies; print size doesn't)
+        expect(l.fontSize).toBeLessThanOrEqual(cross * 1.2 + 0.5);
         if (l.wrap) {
           // wrapped lines fit as N columns inside the quad
           const cols = Math.ceil((advanceEm * l.fontSize) / main);
           expect(cols * l.fontSize).toBeLessThanOrEqual(cross + 0.5);
         } else {
-          expect(l.fontSize * advanceEm).toBeLessThanOrEqual(main + 0.5);
+          expect(l.fontSize * advanceEm).toBeLessThanOrEqual(main * 1.15 + 0.5);
         }
         // sanity: real dialogue lines land at readable sizes
         expect(l.fontSize).toBeGreaterThanOrEqual(10);
@@ -151,10 +153,9 @@ describe('layoutLines', () => {
 
   it('centers each clean line on its quad cross axis, anchored at the reading start', () => {
     const layouts = layoutLines(jjkFurigana, jjkFurigana.lines, heuristicMeasurer)!;
-    // L3: clean column — quad x [653,692], fs = 197/6 → centered at 672.5
-    const fs2 = 197 / 6;
+    // L3: clean column — quad x [653,692] → column centered at 672.5
     expect(layouts[2].wrap).toBe(false);
-    expect(layouts[2].left).toBeCloseTo(672.5 - fs2 / 2 - 653, 3);
+    expect(layouts[2].left + layouts[2].fontSize / 2).toBeCloseTo(672.5 - 653, 3);
     expect(layouts[2].top).toBeCloseTo(128 - 123, 5);
   });
 
@@ -204,9 +205,85 @@ describe('layoutLines', () => {
     // merged line wraps at readable size instead of squeezing to 14.7px
     expect(layouts[0].fontSize).toBeGreaterThan(25);
     expect(layouts[0].fontSize).toBeLessThan(35);
-    // emphasis line keeps its own big fitted size, not forced uniform
+    // 大丈夫 is printed at the SAME size as the base line (its tall quad is
+    // just loose) — the block renders uniformly at the reference size
     expect(layouts[1].wrap).toBe(false);
-    expect(layouts[1].fontSize).toBeGreaterThan(40);
+    expect(layouts[1].fontSize).toBeCloseTo(layouts[0].fontSize, 3);
+  });
+
+  it('renders every line of a clean block at the same uniform size', () => {
+    // Dr Stone 01 p29 block 7: four clean columns; per-quad fitted sizes
+    // differ (39-50) only because of quad slack, so they render uniformly.
+    const drStoneP29: LayoutBlock = {
+      box: [762, 2102, 973, 2346],
+      vertical: true,
+      font_size: 51,
+      lines_coords: [
+        [
+          [910, 2102],
+          [973, 2102],
+          [973, 2201],
+          [910, 2201]
+        ],
+        [
+          [874, 2110],
+          [913, 2110],
+          [913, 2346],
+          [874, 2346]
+        ],
+        [
+          [817, 2105],
+          [869, 2105],
+          [869, 2233],
+          [817, 2233]
+        ],
+        [
+          [762, 2105],
+          [809, 2105],
+          [809, 2346],
+          [762, 2346]
+        ]
+      ],
+      lines: ['ぬう', 'よりによって', 'こんな', 'マヌケな姿を']
+    };
+    const layouts = layoutLines(drStoneP29, drStoneP29.lines, heuristicMeasurer)!;
+    const sizes = layouts.map((l) => l.fontSize);
+    for (const s of sizes) {
+      expect(s).toBeCloseTo(sizes[0], 3);
+      expect(s).toBeGreaterThan(35);
+      expect(s).toBeLessThan(50);
+    }
+    expect(layouts.every((l) => !l.wrap)).toBe(true);
+  });
+
+  it('still shrinks a line whose quad is far too small for the uniform size', () => {
+    // A separately-detected furigana line: half-size chars in a half-size
+    // quad. Rendering it at the block reference would double the print size
+    // and overflow its quad badly — it keeps its own fitted size.
+    const block: LayoutBlock = {
+      box: [0, 0, 120, 240],
+      vertical: true,
+      font_size: 40,
+      lines_coords: [
+        [
+          [80, 0],
+          [120, 0],
+          [120, 240],
+          [80, 240]
+        ],
+        [
+          [60, 0],
+          [80, 0],
+          [80, 80],
+          [60, 80]
+        ]
+      ],
+      lines: ['あいうえおか', 'るびるび'] // ruby line: 4 chars in an 80px quad
+    };
+    const layouts = layoutLines(block, block.lines, heuristicMeasurer)!;
+    expect(layouts[0].fontSize).toBeCloseTo(40, 1); // base at reference
+    expect(layouts[1].wrap).toBe(false);
+    expect(layouts[1].fontSize).toBeLessThan(25); // ruby stays small
   });
 
   it('uses the rotated quad bbox for wrapped slanted lines', () => {

--- a/src/lib/reader/line-coords-layout.test.ts
+++ b/src/lib/reader/line-coords-layout.test.ts
@@ -143,21 +143,55 @@ describe('layoutLines', () => {
     expect(layouts[0].fontSize).toBeLessThan(3 * (114 / advanceEm));
   });
 
-  it('positions each line at its quad bbox relative to the block box origin', () => {
+  it('centers each line on its quad cross axis, anchored at the reading start', () => {
     const layouts = layoutLines(jjkFurigana, jjkFurigana.lines, heuristicMeasurer)!;
-    // first line quad starts at x=733,y=123; box origin is (653,123)
-    expect(layouts[0].left).toBeCloseTo(733 - 653, 5);
-    expect(layouts[0].top).toBeCloseTo(123 - 123, 5);
-    // third line quad starts at x=653,y=128
-    expect(layouts[2].left).toBeCloseTo(0, 5);
+    // Quads are wider than the glyph column (ruby, mask slack); the base
+    // glyphs sit near the middle, so the column is centered horizontally.
+    // L1: quad x [733,793], fs = 175/9 → centered at 763
+    const fs0 = 175 / 9;
+    expect(layouts[0].left).toBeCloseTo(763 - fs0 / 2 - 653, 3);
+    expect(layouts[0].top).toBeCloseTo(123 - 123, 5); // reading axis: quad top
+    // L3: quad x [653,692], fs = 197/6 → centered at 672.5
+    const fs2 = 197 / 6;
+    expect(layouts[2].left).toBeCloseTo(672.5 - fs2 / 2 - 653, 3);
     expect(layouts[2].top).toBeCloseTo(128 - 123, 5);
   });
 
   it('uses the rotated quad bbox for placement of slanted lines', () => {
     const layouts = layoutLines(pokemonRotated, pokemonRotated.lines, heuristicMeasurer)!;
-    // rotated first quad: bbox x-min = 1737, y-min = 2127
-    expect(layouts[0].left).toBeCloseTo(1737 - 1649, 5);
+    // rotated first quad: bbox x [1737,1855], centered at 1796; y-min = 2127
+    expect(layouts[0].left + layouts[0].fontSize / 2).toBeCloseTo(1796 - 1649, 3);
     expect(layouts[0].top).toBeCloseTo(0, 5);
+  });
+
+  it('keeps neighboring columns apart when one quad is much wider than its glyphs', () => {
+    // Dr Stone 01 p26 b11: quad 1 is 125px wide (base 本物 + ruby ほんもの +
+    // empty margin) but its glyphs are ~38px; left-anchoring drew the column
+    // in the margin, colliding with the みたい～ column to its left.
+    const drStone: LayoutBlock = {
+      box: [770, 2455, 929, 2691],
+      vertical: true,
+      font_size: 87,
+      lines_coords: [
+        [
+          [804, 2455],
+          [929, 2455],
+          [929, 2608],
+          [804, 2608]
+        ],
+        [
+          [771, 2477],
+          [820, 2477],
+          [820, 2690],
+          [771, 2690]
+        ]
+      ],
+      lines: ['本物から', 'みたい～']
+    };
+    const layouts = layoutLines(drStone, drStone.lines, heuristicMeasurer)!;
+    const spans = layouts.map((l) => [l.left, l.left + l.fontSize]);
+    const gap = Math.max(spans[0][0] - spans[1][1], spans[1][0] - spans[0][1]);
+    expect(gap).toBeGreaterThan(10); // columns must not overlap
   });
 
   it('handles horizontal blocks with the axes swapped', () => {

--- a/src/lib/reader/line-coords-layout.test.ts
+++ b/src/lib/reader/line-coords-layout.test.ts
@@ -398,6 +398,92 @@ describe('layoutLines', () => {
     expect(layouts[2].fontSize).toBeLessThan(30);
   });
 
+  it('hides a line re-captured inside a bigger line quad (Saki 02 p129 あれは)', () => {
+    // L1's quad spans both print columns and its text re-contains L0's
+    // (あれは…). Rendering both stacks text; the smaller duplicate is hidden
+    // and the bigger line wraps over the full region — no text lost.
+    const sakiAreha: LayoutBlock = {
+      box: [151, 775, 266, 931],
+      vertical: true,
+      font_size: 68,
+      lines_coords: [
+        [
+          [215, 789],
+          [266, 789],
+          [266, 874],
+          [215, 874]
+        ],
+        [
+          [151, 775],
+          [254, 775],
+          [254, 931],
+          [151, 931]
+        ]
+      ],
+      lines: ['あれは', 'あれはキスではないですよ']
+    };
+    const layouts = layoutLines(sakiAreha, sakiAreha.lines, heuristicMeasurer)!;
+    expect(layouts[0].hidden).toBe(true);
+    expect(layouts[1].hidden).toBeFalsy();
+    expect(layouts[1].wrap).toBe(true);
+  });
+
+  it('drops the enclosing blob when overlapped lines have unrelated text (Saki 02 p129)', () => {
+    // Hallucination cluster: L3's quad contains L0 and L1, L0's contains L1,
+    // each with divergent OCR text. The precise small captures survive; the
+    // super-capture blobs hide, so nothing stacks.
+    const sakiGarbage: LayoutBlock = {
+      box: [307, 456, 609, 637],
+      vertical: false,
+      font_size: 81,
+      lines_coords: [
+        [
+          [385, 484],
+          [519, 484],
+          [519, 593],
+          [385, 593]
+        ],
+        [
+          [389, 544],
+          [498, 544],
+          [498, 581],
+          [389, 581]
+        ],
+        [
+          [366, 547],
+          [396, 547],
+          [396, 598],
+          [366, 598]
+        ],
+        [
+          [393, 456],
+          [609, 456],
+          [609, 637],
+          [393, 637]
+        ],
+        [
+          [334, 540],
+          [359, 540],
+          [359, 595],
+          [334, 595]
+        ]
+      ],
+      lines: [
+        'いつの年末のはいい',
+        'それは．．．おはようござい',
+        'いや、',
+        '生きたいなのはいいじじゃないこの好きなキスがまだというのはどういう',
+        'あ．．．'
+      ]
+    };
+    const layouts = layoutLines(sakiGarbage, sakiGarbage.lines, heuristicMeasurer)!;
+    expect(layouts[0].hidden).toBe(true); // contains L1, unrelated text
+    expect(layouts[3].hidden).toBe(true); // contains L0/L1, unrelated text
+    expect(layouts[1].hidden).toBeFalsy();
+    expect(layouts[2].hidden).toBeFalsy();
+    expect(layouts[4].hidden).toBeFalsy();
+  });
+
   it('still shrinks a line whose quad is far too small for the uniform size', () => {
     // A separately-detected furigana line: half-size chars in a half-size
     // quad. Rendering it at the block reference would double the print size

--- a/src/lib/reader/line-coords-layout.test.ts
+++ b/src/lib/reader/line-coords-layout.test.ts
@@ -358,6 +358,46 @@ describe('layoutLines', () => {
     }
   });
 
+  it('does not let ruby fragments outvote the base line (Killing Bites p42)', () => {
+    // 「百獣王」 with its katakana gloss split around it: two small ruby
+    // lines vs one big base line. A plain median is ruby-dominated and
+    // dragged the 76px base down to 31px; the reference must weight lines
+    // by quad ink area so the base wins.
+    const killingBites: LayoutBlock = {
+      box: [336, 71, 498, 466],
+      vertical: true,
+      font_size: 70,
+      lines_coords: [
+        [
+          [445, 164],
+          [495, 164],
+          [495, 322],
+          [445, 322]
+        ],
+        [
+          [336, 71],
+          [454, 71],
+          [454, 453],
+          [336, 453]
+        ],
+        [
+          [448, 330],
+          [489, 330],
+          [489, 412],
+          [448, 412]
+        ]
+      ],
+      lines: ['＞グオブキ', '「百獣王」', 'ンクス']
+    };
+    const layouts = layoutLines(killingBites, killingBites.lines, heuristicMeasurer)!;
+    // base line renders at its true large size
+    expect(layouts[1].wrap).toBe(false);
+    expect(layouts[1].fontSize).toBeGreaterThan(70);
+    // ruby fragments keep their own small sizes
+    expect(layouts[0].fontSize).toBeLessThan(35);
+    expect(layouts[2].fontSize).toBeLessThan(30);
+  });
+
   it('still shrinks a line whose quad is far too small for the uniform size', () => {
     // A separately-detected furigana line: half-size chars in a half-size
     // quad. Rendering it at the block reference would double the print size

--- a/src/lib/reader/line-coords-layout.test.ts
+++ b/src/lib/reader/line-coords-layout.test.ts
@@ -256,6 +256,56 @@ describe('layoutLines', () => {
     expect(layouts.every((l) => !l.wrap)).toBe(true);
   });
 
+  it('wraps a merged line even when its quad is just under 2 columns wide (Dr Stone p53)', () => {
+    // L2 必要なことはう: merged with ruby ink, 63px quad vs 63.7px old width
+    // gate → fell through to a tiny 19.2px single line. Wrapping fits 2
+    // columns at 31.5px — the gate must be the achievable benefit, not a
+    // fixed width ratio.
+    const drStoneP53: LayoutBlock = {
+      box: [92, 1123, 308, 1331],
+      vertical: true,
+      font_size: 50,
+      lines_coords: [
+        [
+          [262, 1129],
+          [303, 1129],
+          [308, 1328],
+          [267, 1328]
+        ],
+        [
+          [216, 1126],
+          [254, 1126],
+          [254, 1331],
+          [216, 1331]
+        ],
+        [
+          [144, 1123],
+          [207, 1126],
+          [202, 1260],
+          [139, 1257]
+        ],
+        [
+          [92, 1132],
+          [133, 1132],
+          [136, 1331],
+          [95, 1331]
+        ]
+      ],
+      lines: ['正確な暦は', 'どうしても', '必要なことはう', '情報だった']
+    };
+    const layouts = layoutLines(drStoneP53, drStoneP53.lines, heuristicMeasurer)!;
+    // the merged line wraps at a readable size instead of 19.2px
+    expect(layouts[2].wrap).toBe(true);
+    expect(layouts[2].fontSize).toBeGreaterThan(28);
+    // three clean lines agree at ~39.8 — their consensus is NOT dragged down
+    // to the wrapped line's fit
+    for (const i of [0, 1, 3]) {
+      expect(layouts[i].wrap).toBe(false);
+      expect(layouts[i].fontSize).toBeCloseTo(layouts[0].fontSize, 3);
+      expect(layouts[i].fontSize).toBeGreaterThan(37);
+    }
+  });
+
   it('still shrinks a line whose quad is far too small for the uniform size', () => {
     // A separately-detected furigana line: half-size chars in a half-size
     // quad. Rendering it at the block reference would double the print size

--- a/src/lib/reader/line-coords-layout.test.ts
+++ b/src/lib/reader/line-coords-layout.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from 'vitest';
+import { layoutLines, heuristicMeasurer, type LayoutBlock } from './line-coords-layout';
+
+// Real blocks captured from mokuro 0.2.2 output (see docs/superpowers/specs/
+// 2026-07-04-original-mode-line-coords-design.md for provenance).
+
+// Jujutsukaisen 24 p57 b1 — dialogue with furigana; quads ~1.6x wider than glyphs
+const jjkFurigana: LayoutBlock = {
+  box: [653, 123, 801, 358],
+  vertical: true,
+  font_size: 46,
+  lines_coords: [
+    [
+      [733, 123],
+      [793, 123],
+      [793, 298],
+      [733, 298]
+    ],
+    [
+      [697, 125],
+      [736, 125],
+      [741, 358],
+      [703, 358]
+    ],
+    [
+      [653, 128],
+      [692, 128],
+      [692, 325],
+      [653, 325]
+    ]
+  ],
+  lines: ['総則追加で言うのは', '結界の出入りを', '可能にしても']
+};
+
+// Hare+Guu 03 p128 b13 — two-line shout, font_size 60 vs ~40px glyphs
+const hareguuShout: LayoutBlock = {
+  box: [517, 2127, 637, 2296],
+  vertical: true,
+  font_size: 60,
+  lines_coords: [
+    [
+      [569, 2130],
+      [631, 2130],
+      [631, 2264],
+      [569, 2264]
+    ],
+    [
+      [517, 2127],
+      [574, 2127],
+      [574, 2296],
+      [517, 2296]
+    ]
+  ],
+  lines: ['殺すぞ', 'デカ女！！']
+};
+
+// FMA 22 p187 b19 — manga-ocr hallucination: 94x114px quad, 99-char line
+const fmaHallucination: LayoutBlock = {
+  box: [149, 2078, 243, 2192],
+  vertical: true,
+  font_size: 94,
+  lines_coords: [
+    [
+      [149, 2078],
+      [243, 2078],
+      [243, 2192],
+      [149, 2192]
+    ]
+  ],
+  lines: [
+    'そういうことでスタングが見えなくなったと決めていたんでしょうかもしれて、それをこの通りやらしたようにしていました。よろしくお客様はしかったら、そうですってことを忘れないたらいと思いんだってしたんだ。'
+  ]
+};
+
+// Pokemon Adventures 03 p24 b8 — first quad rotated (slanted text)
+const pokemonRotated: LayoutBlock = {
+  box: [1649, 2127, 1855, 2376],
+  vertical: true,
+  font_size: 70,
+  lines_coords: [
+    [
+      [1759, 2127],
+      [1855, 2141],
+      [1833, 2305],
+      [1737, 2291]
+    ],
+    [
+      [1699, 2146],
+      [1767, 2146],
+      [1767, 2296],
+      [1699, 2296]
+    ],
+    [
+      [1649, 2149],
+      [1696, 2149],
+      [1701, 2376],
+      [1655, 2376]
+    ]
+  ],
+  lines: ['今度はしかげん', '手加減', 'なしだぜ！']
+};
+
+function quadMainCross(quad: number[][], vertical: boolean): { main: number; cross: number } {
+  const mid = (a: number[], b: number[]) => [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2];
+  const [p0, p1, p2, p3] = quad;
+  const h = mid(p1, p2).map((v, i) => v - mid(p0, p3)[i]);
+  const v = mid(p2, p3).map((x, i) => x - mid(p0, p1)[i]);
+  const hn = Math.hypot(h[0], h[1]);
+  const vn = Math.hypot(v[0], v[1]);
+  return vertical ? { main: vn, cross: hn } : { main: hn, cross: vn };
+}
+
+describe('layoutLines', () => {
+  it('sizes every line to fit its own quad in both axes', () => {
+    for (const block of [jjkFurigana, hareguuShout, pokemonRotated]) {
+      const layouts = layoutLines(block, block.lines, heuristicMeasurer);
+      expect(layouts).not.toBeNull();
+      layouts!.forEach((l, i) => {
+        const { main, cross } = quadMainCross(block.lines_coords![i], block.vertical);
+        const advanceEm = heuristicMeasurer(block.lines[i]);
+        expect(l.fontSize).toBeLessThanOrEqual(cross + 0.5);
+        expect(l.fontSize * advanceEm).toBeLessThanOrEqual(main + 0.5);
+        // sanity: real dialogue lines land at readable sizes
+        expect(l.fontSize).toBeGreaterThanOrEqual(10);
+      });
+    }
+  });
+
+  it('shrinks well below the broken block font_size on furigana-inflated blocks', () => {
+    const layouts = layoutLines(jjkFurigana, jjkFurigana.lines, heuristicMeasurer)!;
+    // block font_size is 46; true glyphs are ~20-30px (quads include ruby columns)
+    for (const l of layouts) {
+      expect(l.fontSize).toBeLessThan(46);
+    }
+  });
+
+  it('contains hallucinated lines inside their quad instead of overflowing 90x', () => {
+    const layouts = layoutLines(fmaHallucination, fmaHallucination.lines, heuristicMeasurer)!;
+    const { main } = quadMainCross(fmaHallucination.lines_coords![0], true);
+    const advanceEm = heuristicMeasurer(fmaHallucination.lines[0]);
+    expect(layouts[0].fontSize * advanceEm).toBeLessThanOrEqual(main + 0.5);
+    // 99 chars in a 114px quad: about 1px per char — tiny but contained
+    expect(layouts[0].fontSize).toBeLessThan(3 * (114 / advanceEm));
+  });
+
+  it('positions each line at its quad bbox relative to the block box origin', () => {
+    const layouts = layoutLines(jjkFurigana, jjkFurigana.lines, heuristicMeasurer)!;
+    // first line quad starts at x=733,y=123; box origin is (653,123)
+    expect(layouts[0].left).toBeCloseTo(733 - 653, 5);
+    expect(layouts[0].top).toBeCloseTo(123 - 123, 5);
+    // third line quad starts at x=653,y=128
+    expect(layouts[2].left).toBeCloseTo(0, 5);
+    expect(layouts[2].top).toBeCloseTo(128 - 123, 5);
+  });
+
+  it('uses the rotated quad bbox for placement of slanted lines', () => {
+    const layouts = layoutLines(pokemonRotated, pokemonRotated.lines, heuristicMeasurer)!;
+    // rotated first quad: bbox x-min = 1737, y-min = 2127
+    expect(layouts[0].left).toBeCloseTo(1737 - 1649, 5);
+    expect(layouts[0].top).toBeCloseTo(0, 5);
+  });
+
+  it('handles horizontal blocks with the axes swapped', () => {
+    const horizontal: LayoutBlock = {
+      box: [100, 200, 400, 260],
+      vertical: false,
+      font_size: 50,
+      lines_coords: [
+        [
+          [100, 200],
+          [400, 200],
+          [400, 260],
+          [100, 260]
+        ]
+      ],
+      lines: ['ABCDEF']
+    };
+    const layouts = layoutLines(horizontal, horizontal.lines, heuristicMeasurer)!;
+    const advanceEm = heuristicMeasurer('ABCDEF');
+    expect(layouts[0].fontSize).toBeLessThanOrEqual(60 + 0.5); // cross = height
+    expect(layouts[0].fontSize * advanceEm).toBeLessThanOrEqual(300 + 0.5);
+  });
+
+  it('gives an empty line the quad cross size', () => {
+    const block: LayoutBlock = {
+      box: [0, 0, 50, 100],
+      vertical: true,
+      font_size: 50,
+      lines_coords: [
+        [
+          [0, 0],
+          [50, 0],
+          [50, 100],
+          [0, 100]
+        ]
+      ],
+      lines: ['']
+    };
+    const layouts = layoutLines(block, block.lines, heuristicMeasurer)!;
+    expect(layouts[0].fontSize).toBeCloseTo(50, 0);
+  });
+
+  it('measures the processed text passed in, not block.lines', () => {
+    const block: LayoutBlock = {
+      box: [0, 0, 50, 300],
+      vertical: true,
+      font_size: 50,
+      lines_coords: [
+        [
+          [0, 0],
+          [50, 0],
+          [50, 300],
+          [0, 300]
+        ]
+      ],
+      lines: ['あ．．．'] // renders as あ… (2 chars) after ellipsis substitution
+    };
+    const processed = ['あ…'];
+    const layouts = layoutLines(block, processed, heuristicMeasurer)!;
+    // 2em advance in a 300px quad → capped by cross (50), not squeezed to 75-ish by 4 chars
+    expect(layouts[0].fontSize).toBeCloseTo(50, 0);
+  });
+
+  describe('fallback to null', () => {
+    it('when lines_coords is missing', () => {
+      const { lines_coords: _drop, ...rest } = jjkFurigana;
+      expect(layoutLines(rest, rest.lines, heuristicMeasurer)).toBeNull();
+    });
+
+    it('when lines_coords length mismatches lines', () => {
+      const block = { ...jjkFurigana, lines_coords: jjkFurigana.lines_coords!.slice(0, 2) };
+      expect(layoutLines(block, block.lines, heuristicMeasurer)).toBeNull();
+    });
+
+    it('when a quad is malformed', () => {
+      const block = {
+        ...hareguuShout,
+        lines_coords: [
+          hareguuShout.lines_coords![0],
+          [
+            [517, 2127],
+            [574, 2127]
+          ]
+        ]
+      };
+      expect(layoutLines(block, block.lines, heuristicMeasurer)).toBeNull();
+    });
+
+    it('when a quad is degenerate (zero extent)', () => {
+      const block: LayoutBlock = {
+        box: [0, 0, 50, 100],
+        vertical: true,
+        font_size: 50,
+        lines_coords: [
+          [
+            [10, 10],
+            [10, 10],
+            [10, 10],
+            [10, 10]
+          ]
+        ],
+        lines: ['あ']
+      };
+      expect(layoutLines(block, block.lines, heuristicMeasurer)).toBeNull();
+    });
+  });
+});
+
+describe('heuristicMeasurer', () => {
+  it('counts fullwidth as 1em and ASCII as ~half', () => {
+    expect(heuristicMeasurer('あいう')).toBeCloseTo(3, 5);
+    expect(heuristicMeasurer('abc')).toBeLessThan(2);
+    expect(heuristicMeasurer('')).toBe(0);
+  });
+});

--- a/src/lib/reader/line-coords-layout.test.ts
+++ b/src/lib/reader/line-coords-layout.test.ts
@@ -119,7 +119,13 @@ describe('layoutLines', () => {
         const { main, cross } = quadMainCross(block.lines_coords![i], block.vertical);
         const advanceEm = heuristicMeasurer(block.lines[i]);
         expect(l.fontSize).toBeLessThanOrEqual(cross + 0.5);
-        expect(l.fontSize * advanceEm).toBeLessThanOrEqual(main + 0.5);
+        if (l.wrap) {
+          // wrapped lines fit as N columns inside the quad
+          const cols = Math.ceil((advanceEm * l.fontSize) / main);
+          expect(cols * l.fontSize).toBeLessThanOrEqual(cross + 0.5);
+        } else {
+          expect(l.fontSize * advanceEm).toBeLessThanOrEqual(main + 0.5);
+        }
         // sanity: real dialogue lines land at readable sizes
         expect(l.fontSize).toBeGreaterThanOrEqual(10);
       });
@@ -143,24 +149,71 @@ describe('layoutLines', () => {
     expect(layouts[0].fontSize).toBeLessThan(3 * (114 / advanceEm));
   });
 
-  it('centers each line on its quad cross axis, anchored at the reading start', () => {
+  it('centers each clean line on its quad cross axis, anchored at the reading start', () => {
     const layouts = layoutLines(jjkFurigana, jjkFurigana.lines, heuristicMeasurer)!;
-    // Quads are wider than the glyph column (ruby, mask slack); the base
-    // glyphs sit near the middle, so the column is centered horizontally.
-    // L1: quad x [733,793], fs = 175/9 → centered at 763
-    const fs0 = 175 / 9;
-    expect(layouts[0].left).toBeCloseTo(763 - fs0 / 2 - 653, 3);
-    expect(layouts[0].top).toBeCloseTo(123 - 123, 5); // reading axis: quad top
-    // L3: quad x [653,692], fs = 197/6 → centered at 672.5
+    // L3: clean column — quad x [653,692], fs = 197/6 → centered at 672.5
     const fs2 = 197 / 6;
+    expect(layouts[2].wrap).toBe(false);
     expect(layouts[2].left).toBeCloseTo(672.5 - fs2 / 2 - 653, 3);
     expect(layouts[2].top).toBeCloseTo(128 - 123, 5);
   });
 
-  it('uses the rotated quad bbox for placement of slanted lines', () => {
+  it('wraps a line whose quad is much wider than the block reference size', () => {
+    // JJK L1: quad 60px wide (contains a neighbor's ruby ink) but the text
+    // only fits at 19.4px while its siblings run at ~33px → treat the quad
+    // as holding multiple columns and wrap at the block reference size.
+    const layouts = layoutLines(jjkFurigana, jjkFurigana.lines, heuristicMeasurer)!;
+    const l = layouts[0];
+    expect(l.wrap).toBe(true);
+    // wrap-fit: reference 32.83 needs 2 cols = 65.7 > 60 → shrink to 60/2 = 30
+    expect(l.fontSize).toBeCloseTo(30, 1);
+    // wrapped lines occupy their full quad bbox
+    expect(l.left).toBeCloseTo(733 - 653, 5);
+    expect(l.top).toBeCloseTo(0, 5);
+    expect(l.width).toBeCloseTo(60, 5);
+    expect(l.height).toBeCloseTo(175, 5);
+  });
+
+  it('wraps merged base+furigana lines at the block reference size (Dr Stone p32)', () => {
+    // Real block: 空は私なら + its ruby だいじょうぶ merged into one 11-char
+    // "line" in a two-column-wide quad; sibling 大丈夫 is genuinely printed
+    // large (emphasis) and must keep its own fitted size.
+    const drStoneP32: LayoutBlock = {
+      box: [1523, 754, 1674, 916],
+      vertical: true,
+      font_size: 56,
+      lines_coords: [
+        [
+          [1562, 762],
+          [1660, 754],
+          [1674, 907],
+          [1575, 916]
+        ],
+        [
+          [1523, 771],
+          [1573, 771],
+          [1573, 902],
+          [1523, 902]
+        ]
+      ],
+      lines: ['空は私ならだいじょうぶ', '大丈夫']
+    };
+    const layouts = layoutLines(drStoneP32, drStoneP32.lines, heuristicMeasurer)!;
+    expect(layouts[0].wrap).toBe(true);
+    // reference size ≈ median(candidates) ≈ (14.7 + 43.7) / 2 ≈ 29.2 — the
+    // merged line wraps at readable size instead of squeezing to 14.7px
+    expect(layouts[0].fontSize).toBeGreaterThan(25);
+    expect(layouts[0].fontSize).toBeLessThan(35);
+    // emphasis line keeps its own big fitted size, not forced uniform
+    expect(layouts[1].wrap).toBe(false);
+    expect(layouts[1].fontSize).toBeGreaterThan(40);
+  });
+
+  it('uses the rotated quad bbox for wrapped slanted lines', () => {
     const layouts = layoutLines(pokemonRotated, pokemonRotated.lines, heuristicMeasurer)!;
-    // rotated first quad: bbox x [1737,1855], centered at 1796; y-min = 2127
-    expect(layouts[0].left + layouts[0].fontSize / 2).toBeCloseTo(1796 - 1649, 3);
+    // L1 merged 今度は+ruby in a 97px-wide rotated quad → wraps at reference
+    expect(layouts[0].wrap).toBe(true);
+    expect(layouts[0].left).toBeCloseTo(1737 - 1649, 5);
     expect(layouts[0].top).toBeCloseTo(0, 5);
   });
 

--- a/src/lib/reader/line-coords-layout.test.ts
+++ b/src/lib/reader/line-coords-layout.test.ts
@@ -428,10 +428,12 @@ describe('layoutLines', () => {
     expect(layouts[1].wrap).toBe(true);
   });
 
-  it('drops the enclosing blob when overlapped lines have unrelated text (Saki 02 p129)', () => {
+  it('partitions overlapped lines with unrelated text into readable bands (Saki 02 p129)', () => {
     // Hallucination cluster: L3's quad contains L0 and L1, L0's contains L1,
-    // each with divergent OCR text. The precise small captures survive; the
-    // super-capture blobs hide, so nothing stacks.
+    // each with divergent OCR text. Their individual placements are garbage,
+    // but the text must stay readable: the cluster's union bbox is split
+    // into reading-order bands (sized by text length) and each line wraps
+    // inside its own band — all text visible, nothing stacked.
     const sakiGarbage: LayoutBlock = {
       box: [307, 456, 609, 637],
       vertical: false,
@@ -477,11 +479,32 @@ describe('layoutLines', () => {
       ]
     };
     const layouts = layoutLines(sakiGarbage, sakiGarbage.lines, heuristicMeasurer)!;
-    expect(layouts[0].hidden).toBe(true); // contains L1, unrelated text
-    expect(layouts[3].hidden).toBe(true); // contains L0/L1, unrelated text
-    expect(layouts[1].hidden).toBeFalsy();
-    expect(layouts[2].hidden).toBeFalsy();
-    expect(layouts[4].hidden).toBeFalsy();
+    // nothing hidden — all OCR text stays readable even when it is wrong
+    for (const l of layouts) expect(l.hidden).toBeFalsy();
+
+    // cluster members (L0, L1, L3) wrap inside bands of the union bbox
+    // (horizontal block → bands stacked top-to-bottom in reading order)
+    const cluster = [layouts[0], layouts[1], layouts[3]];
+    for (const l of cluster) {
+      expect(l.wrap).toBe(true);
+      expect(l.fontSize).toBeGreaterThan(14); // readable, not sub-pixel
+    }
+    expect(layouts[0].top).toBeLessThan(layouts[1].top);
+    expect(layouts[1].top).toBeLessThan(layouts[3].top);
+    // bands do not overlap each other
+    expect(layouts[0].top + layouts[0].height).toBeLessThanOrEqual(layouts[1].top + 0.5);
+    expect(layouts[1].top + layouts[1].height).toBeLessThanOrEqual(layouts[3].top + 0.5);
+    // bands stay inside the cluster's union bbox (x [385,609] − box x 307)
+    for (const l of cluster) {
+      expect(l.left).toBeGreaterThanOrEqual(385 - 307 - 0.5);
+      expect(l.left + l.width).toBeLessThanOrEqual(609 - 307 + 0.5);
+    }
+
+    // independent small quads (L2, L4) render in their own quads, readable
+    for (const l of [layouts[2], layouts[4]]) {
+      expect(l.hidden).toBeFalsy();
+      expect(l.fontSize).toBeGreaterThan(8);
+    }
   });
 
   it('still shrinks a line whose quad is far too small for the uniform size', () => {

--- a/src/lib/reader/line-coords-layout.ts
+++ b/src/lib/reader/line-coords-layout.ts
@@ -30,6 +30,16 @@ export interface LineLayout {
   left: number;
   top: number;
   fontSize: number;
+  /**
+   * True when the quad is much wider than the block's reference size and the
+   * text only fits at a much smaller size — i.e. multiple print columns
+   * (typically base text + furigana) were captured as one OCR "line". The
+   * line then renders with white-space wrapping inside its full quad bbox.
+   */
+  wrap: boolean;
+  /** Quad bbox dims, px — the wrapping container for wrap lines */
+  width: number;
+  height: number;
 }
 
 /**
@@ -38,6 +48,34 @@ export interface LineLayout {
  * computed size may be legitimately sub-pixel.
  */
 const MIN_FONT_SIZE = 0.5;
+
+/**
+ * A line wraps when it would need to shrink below WRAP_SHRINK × reference to
+ * fit on one line AND its quad is at least WRAP_WIDTH × reference wide
+ * (room for 2+ columns at the block's typical size).
+ */
+const WRAP_SHRINK = 0.7;
+const WRAP_WIDTH = 1.6;
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/**
+ * Largest font size ≤ startSize at which `advanceEm` ems wrap into columns of
+ * length `main` without the column count overflowing `cross`.
+ */
+function wrapFitSize(startSize: number, advanceEm: number, main: number, cross: number): number {
+  let size = Math.min(startSize, cross);
+  for (let iter = 0; iter < 6; iter++) {
+    const cols = Math.max(1, Math.ceil((advanceEm * size) / main));
+    if (cols * size <= cross) break;
+    size = cross / cols;
+  }
+  return size;
+}
 
 /**
  * Fallback measurer for environments without canvas (tests, SSR): fullwidth
@@ -135,28 +173,62 @@ export function layoutLines(
   const coords = block.lines_coords;
   if (!coords || coords.length !== processedLines.length || coords.length === 0) return null;
 
-  const layouts: LineLayout[] = [];
+  // First pass: per-line geometry and single-line fitted sizes.
+  const measured = [];
   for (let i = 0; i < coords.length; i++) {
     const extents = quadExtents(coords[i], block.vertical);
     if (!extents) return null;
     const advanceEm = measure(processedLines[i]);
     const fitted = advanceEm > 0 ? extents.main / advanceEm : extents.cross;
-    const fontSize = Math.max(MIN_FONT_SIZE, Math.min(extents.cross, fitted));
+    measured.push({ extents, advanceEm, fitted, candidate: Math.min(extents.cross, fitted) });
+  }
+  // Reference size: what a typical line of this block runs at. Robust to a
+  // corrupted line (merged furigana, mask slack) in a multi-line block.
+  const referenceSize = median(measured.map((m) => m.candidate));
+
+  const layouts: LineLayout[] = [];
+  for (let i = 0; i < coords.length; i++) {
+    const { extents, advanceEm, fitted } = measured[i];
     const xs = coords[i].map((p) => p[0]);
     const ys = coords[i].map((p) => p[1]);
+    const minX = Math.min(...xs) - block.box[0];
+    const minY = Math.min(...ys) - block.box[1];
+    const maxX = Math.max(...xs) - block.box[0];
+    const maxY = Math.max(...ys) - block.box[1];
+    const width = maxX - minX;
+    const height = maxY - minY;
+
+    // Multiple print columns captured as one OCR "line" (base + furigana):
+    // the quad has room for 2+ columns at the block's typical size, and the
+    // text would have to shrink far below it to fit on one line. Wrap it
+    // inside the quad at (near) the reference size instead.
+    const wrap =
+      advanceEm > 0 &&
+      fitted < WRAP_SHRINK * referenceSize &&
+      extents.cross >= WRAP_WIDTH * referenceSize;
+
+    if (wrap) {
+      const fontSize = Math.max(
+        MIN_FONT_SIZE,
+        wrapFitSize(referenceSize, advanceEm, extents.main, extents.cross)
+      );
+      layouts.push({ left: minX, top: minY, fontSize, wrap: true, width, height });
+      continue;
+    }
+
+    const fontSize = Math.max(MIN_FONT_SIZE, Math.min(extents.cross, fitted));
     // Reading axis: anchor at the quad start (top for vertical, left for
     // horizontal). Cross axis: center the rendered column/row in the quad —
     // quads are often wider than the glyphs (attached ruby, mask slack, empty
     // margin) and the base glyphs sit near the middle; edge-anchoring can
     // shove a column into its neighbor's space.
-    const minX = Math.min(...xs) - block.box[0];
-    const minY = Math.min(...ys) - block.box[1];
-    const maxX = Math.max(...xs) - block.box[0];
-    const maxY = Math.max(...ys) - block.box[1];
     layouts.push({
       left: block.vertical ? (minX + maxX) / 2 - fontSize / 2 : minX,
       top: block.vertical ? minY : (minY + maxY) / 2 - fontSize / 2,
-      fontSize
+      fontSize,
+      wrap: false,
+      width,
+      height
     });
   }
   return layouts;

--- a/src/lib/reader/line-coords-layout.ts
+++ b/src/lib/reader/line-coords-layout.ts
@@ -40,6 +40,12 @@ export interface LineLayout {
   /** Quad bbox dims, px — the wrapping container for wrap lines */
   width: number;
   height: number;
+  /**
+   * True for lines suppressed by intra-block overlap dedupe: the detector
+   * re-captured the same ink region as multiple overlapping "lines", which
+   * would render stacked on top of each other.
+   */
+  hidden?: boolean;
 }
 
 /**
@@ -68,6 +74,9 @@ const SMALL_OUTLIER = 0.7;
 /** Lines may run this much past their own quad's length at the uniform size —
  * quad slack varies line to line while print size is constant. */
 const OVERFLOW_TOL = 1.15;
+/** Two lines whose bboxes overlap by this fraction of the smaller one are
+ * re-captures of the same ink region — one of them is suppressed. */
+const RECAPTURE_OVERLAP = 0.7;
 
 /**
  * Median of `values` where each value counts proportionally to its weight.
@@ -203,6 +212,8 @@ export function layoutLines(
     fitted: number;
     candidate: number;
     suspect: boolean;
+    bbox: { minX: number; minY: number; maxX: number; maxY: number };
+    hidden: boolean;
   }
   const measured: MeasuredLine[] = [];
   for (let i = 0; i < coords.length; i++) {
@@ -210,6 +221,8 @@ export function layoutLines(
     if (!extents) return null;
     const advanceEm = measure(processedLines[i]);
     const fitted = advanceEm > 0 ? extents.main / advanceEm : extents.cross;
+    const xs = coords[i].map((p) => p[0]);
+    const ys = coords[i].map((p) => p[1]);
     measured.push({
       extents,
       advanceEm,
@@ -217,8 +230,43 @@ export function layoutLines(
       candidate: Math.min(extents.cross, fitted),
       // quad wide enough for 1.6+ columns of its own fitted size: likely
       // multiple print columns captured as one OCR "line"
-      suspect: advanceEm > 0 && extents.cross >= SUSPECT_RATIO * fitted
+      suspect: advanceEm > 0 && extents.cross >= SUSPECT_RATIO * fitted,
+      bbox: {
+        minX: Math.min(...xs),
+        minY: Math.min(...ys),
+        maxX: Math.max(...xs),
+        maxY: Math.max(...ys)
+      },
+      hidden: false
     });
+  }
+
+  // Intra-block overlap dedupe: the detector sometimes re-captures the same
+  // ink region as several overlapping "lines" (a column alone AND a bigger
+  // quad spanning it plus its neighbors), which would render stacked. When
+  // one bbox covers most of a smaller one: if the smaller line's text is
+  // contained in the bigger's, the smaller is a re-capture and hides (the
+  // bigger wraps over the full region, no text lost); otherwise the texts
+  // diverged (hallucination cluster) and the enclosing blob hides, keeping
+  // the precise small captures.
+  const bboxArea = (b: MeasuredLine['bbox']) => (b.maxX - b.minX) * (b.maxY - b.minY);
+  for (let i = 0; i < measured.length; i++) {
+    if (measured[i].hidden) continue;
+    for (let j = i + 1; j < measured.length; j++) {
+      if (measured[i].hidden) break;
+      if (measured[j].hidden) continue;
+      const a = measured[i].bbox;
+      const b = measured[j].bbox;
+      const ox = Math.max(0, Math.min(a.maxX, b.maxX) - Math.max(a.minX, b.minX));
+      const oy = Math.max(0, Math.min(a.maxY, b.maxY) - Math.max(a.minY, b.minY));
+      const smallArea = Math.min(bboxArea(a), bboxArea(b));
+      if (smallArea <= 0 || ox * oy < RECAPTURE_OVERLAP * smallArea) continue;
+      const smaller = bboxArea(a) <= bboxArea(b) ? i : j;
+      const bigger = smaller === i ? j : i;
+      const smallText = processedLines[smaller].trim();
+      const dropSmaller = smallText.length > 0 && processedLines[bigger].includes(smallText);
+      measured[dropSmaller ? smaller : bigger].hidden = true;
+    }
   }
 
   // Block reference size: print keeps one size per balloon, so all lines
@@ -228,13 +276,14 @@ export function layoutLines(
   // their quad ink area: a big base line must not be outvoted by the small
   // ruby fragments split around it (Killing Bites 01 p42 「百獣王」).
   const area = (m: MeasuredLine) => m.extents.main * m.extents.cross;
-  const clean = measured.filter((m) => !m.suspect);
-  const refPool = clean.length ? clean : measured;
+  const visible = measured.filter((m) => !m.hidden);
+  const clean = visible.filter((m) => !m.suspect);
+  const refPool = clean.length ? clean : visible;
   const refBase = weightedMedian(
     refPool.map((m) => m.candidate),
     refPool.map(area)
   );
-  const consensus = measured.filter((m) => !m.suspect && m.candidate >= SMALL_OUTLIER * refBase);
+  const consensus = visible.filter((m) => !m.suspect && m.candidate >= SMALL_OUTLIER * refBase);
   const consensusSizes = consensus.map((m) => m.candidate);
   const referenceSize = consensus.length
     ? weightedMedian(consensusSizes, consensus.map(area))
@@ -247,6 +296,7 @@ export function layoutLines(
   const wrapStart = hasCleanLines ? referenceSize : Number.POSITIVE_INFINITY;
   const wraps = measured.map(
     (m) =>
+      !m.hidden &&
       m.suspect &&
       (m.fitted < WRAP_SHRINK * referenceSize || !hasCleanLines) &&
       wrapFitSize(wrapStart, m.advanceEm, m.extents.main, m.extents.cross) >= WRAP_GAIN * m.fitted
@@ -274,15 +324,26 @@ export function layoutLines(
 
   const layouts: LineLayout[] = [];
   for (let i = 0; i < coords.length; i++) {
-    const { extents, advanceEm, fitted, candidate } = measured[i];
-    const xs = coords[i].map((p) => p[0]);
-    const ys = coords[i].map((p) => p[1]);
-    const minX = Math.min(...xs) - block.box[0];
-    const minY = Math.min(...ys) - block.box[1];
-    const maxX = Math.max(...xs) - block.box[0];
-    const maxY = Math.max(...ys) - block.box[1];
+    const { extents, advanceEm, candidate, bbox, hidden } = measured[i];
+    const minX = bbox.minX - block.box[0];
+    const minY = bbox.minY - block.box[1];
+    const maxX = bbox.maxX - block.box[0];
+    const maxY = bbox.maxY - block.box[1];
     const width = maxX - minX;
     const height = maxY - minY;
+
+    if (hidden) {
+      layouts.push({
+        left: minX,
+        top: minY,
+        fontSize: MIN_FONT_SIZE,
+        wrap: false,
+        width,
+        height,
+        hidden: true
+      });
+      continue;
+    }
 
     if (wraps[i]) {
       const fontSize = Math.max(

--- a/src/lib/reader/line-coords-layout.ts
+++ b/src/lib/reader/line-coords-layout.ts
@@ -214,6 +214,8 @@ export function layoutLines(
     suspect: boolean;
     bbox: { minX: number; minY: number; maxX: number; maxY: number };
     hidden: boolean;
+    /** Band of an overlap cluster's union bbox this line renders in */
+    slice?: { minX: number; minY: number; maxX: number; maxY: number };
   }
   const measured: MeasuredLine[] = [];
   for (let i = 0; i < coords.length; i++) {
@@ -241,31 +243,96 @@ export function layoutLines(
     });
   }
 
-  // Intra-block overlap dedupe: the detector sometimes re-captures the same
-  // ink region as several overlapping "lines" (a column alone AND a bigger
-  // quad spanning it plus its neighbors), which would render stacked. When
-  // one bbox covers most of a smaller one: if the smaller line's text is
-  // contained in the bigger's, the smaller is a re-capture and hides (the
-  // bigger wraps over the full region, no text lost); otherwise the texts
-  // diverged (hallucination cluster) and the enclosing blob hides, keeping
-  // the precise small captures.
+  // Intra-block overlap handling: the detector sometimes re-captures the
+  // same ink region as several overlapping "lines" (a column alone AND a
+  // bigger quad spanning it plus its neighbors), which would render stacked.
+  // Two cases when one bbox covers most of a smaller one:
+  // 1. The smaller line's text is contained in the bigger's → true
+  //    re-capture; the smaller hides (bigger wraps the region, no text lost).
+  // 2. The texts diverged (hallucination cluster on dense/slanted regions):
+  //    the individual placements are garbage but every OCR line must remain
+  //    READABLE — the cluster's union bbox is partitioned into reading-order
+  //    bands (weighted by text length) and each line wraps in its own band.
   const bboxArea = (b: MeasuredLine['bbox']) => (b.maxX - b.minX) * (b.maxY - b.minY);
+  const overlapsHeavily = (a: MeasuredLine['bbox'], b: MeasuredLine['bbox']) => {
+    const ox = Math.max(0, Math.min(a.maxX, b.maxX) - Math.max(a.minX, b.minX));
+    const oy = Math.max(0, Math.min(a.maxY, b.maxY) - Math.max(a.minY, b.minY));
+    const smallArea = Math.min(bboxArea(a), bboxArea(b));
+    return smallArea > 0 && ox * oy >= RECAPTURE_OVERLAP * smallArea;
+  };
+  // Pass 1: hide true re-captures (text-subsumed duplicates).
   for (let i = 0; i < measured.length; i++) {
     if (measured[i].hidden) continue;
     for (let j = i + 1; j < measured.length; j++) {
       if (measured[i].hidden) break;
       if (measured[j].hidden) continue;
-      const a = measured[i].bbox;
-      const b = measured[j].bbox;
-      const ox = Math.max(0, Math.min(a.maxX, b.maxX) - Math.max(a.minX, b.minX));
-      const oy = Math.max(0, Math.min(a.maxY, b.maxY) - Math.max(a.minY, b.minY));
-      const smallArea = Math.min(bboxArea(a), bboxArea(b));
-      if (smallArea <= 0 || ox * oy < RECAPTURE_OVERLAP * smallArea) continue;
-      const smaller = bboxArea(a) <= bboxArea(b) ? i : j;
+      if (!overlapsHeavily(measured[i].bbox, measured[j].bbox)) continue;
+      const smaller = bboxArea(measured[i].bbox) <= bboxArea(measured[j].bbox) ? i : j;
       const bigger = smaller === i ? j : i;
       const smallText = processedLines[smaller].trim();
-      const dropSmaller = smallText.length > 0 && processedLines[bigger].includes(smallText);
-      measured[dropSmaller ? smaller : bigger].hidden = true;
+      if (smallText.length > 0 && processedLines[bigger].includes(smallText)) {
+        measured[smaller].hidden = true;
+      }
+    }
+  }
+  // Pass 2: cluster the remaining diverged overlaps (connected components)
+  // and partition each cluster's union bbox into reading-order bands.
+  const clusterOf = measured.map(() => -1);
+  let clusterCount = 0;
+  for (let i = 0; i < measured.length; i++) {
+    if (measured[i].hidden) continue;
+    for (let j = i + 1; j < measured.length; j++) {
+      if (measured[j].hidden) continue;
+      if (!overlapsHeavily(measured[i].bbox, measured[j].bbox)) continue;
+      if (clusterOf[i] < 0 && clusterOf[j] < 0) {
+        clusterOf[i] = clusterOf[j] = clusterCount++;
+      } else if (clusterOf[i] < 0) {
+        clusterOf[i] = clusterOf[j];
+      } else if (clusterOf[j] < 0) {
+        clusterOf[j] = clusterOf[i];
+      } else if (clusterOf[i] !== clusterOf[j]) {
+        const from = clusterOf[j];
+        for (let k = 0; k < clusterOf.length; k++)
+          if (clusterOf[k] === from) clusterOf[k] = clusterOf[i];
+      }
+    }
+  }
+  for (let c = 0; c < clusterCount; c++) {
+    const members = [];
+    for (let i = 0; i < measured.length; i++) if (clusterOf[i] === c) members.push(i);
+    if (members.length < 2) continue;
+    const union = {
+      minX: Math.min(...members.map((i) => measured[i].bbox.minX)),
+      minY: Math.min(...members.map((i) => measured[i].bbox.minY)),
+      maxX: Math.max(...members.map((i) => measured[i].bbox.maxX)),
+      maxY: Math.max(...members.map((i) => measured[i].bbox.maxY))
+    };
+    const weights = members.map((i) => Math.max(measured[i].advanceEm, 0.5));
+    const totalWeight = weights.reduce((a, b) => a + b, 0);
+    // vertical text: bands right→left along x; horizontal: top→bottom along y
+    let offset = 0;
+    for (let k = 0; k < members.length; k++) {
+      const frac = weights[k] / totalWeight;
+      const m = measured[members[k]];
+      if (block.vertical) {
+        const bandW = (union.maxX - union.minX) * frac;
+        m.slice = {
+          minX: union.maxX - offset - bandW,
+          maxX: union.maxX - offset,
+          minY: union.minY,
+          maxY: union.maxY
+        };
+        offset += bandW;
+      } else {
+        const bandH = (union.maxY - union.minY) * frac;
+        m.slice = {
+          minX: union.minX,
+          maxX: union.maxX,
+          minY: union.minY + offset,
+          maxY: union.minY + offset + bandH
+        };
+        offset += bandH;
+      }
     }
   }
 
@@ -276,9 +343,9 @@ export function layoutLines(
   // their quad ink area: a big base line must not be outvoted by the small
   // ruby fragments split around it (Killing Bites 01 p42 「百獣王」).
   const area = (m: MeasuredLine) => m.extents.main * m.extents.cross;
-  const visible = measured.filter((m) => !m.hidden);
+  const visible = measured.filter((m) => !m.hidden && !m.slice);
   const clean = visible.filter((m) => !m.suspect);
-  const refPool = clean.length ? clean : visible;
+  const refPool = clean.length ? clean : visible.length ? visible : measured;
   const refBase = weightedMedian(
     refPool.map((m) => m.candidate),
     refPool.map(area)
@@ -297,6 +364,7 @@ export function layoutLines(
   const wraps = measured.map(
     (m) =>
       !m.hidden &&
+      !m.slice &&
       m.suspect &&
       (m.fitted < WRAP_SHRINK * referenceSize || !hasCleanLines) &&
       wrapFitSize(wrapStart, m.advanceEm, m.extents.main, m.extents.cross) >= WRAP_GAIN * m.fitted
@@ -341,6 +409,28 @@ export function layoutLines(
         width,
         height,
         hidden: true
+      });
+      continue;
+    }
+
+    const slice = measured[i].slice;
+    if (slice) {
+      // overlap-cluster member: wrap the text inside its band of the union
+      const sliceW = slice.maxX - slice.minX;
+      const sliceH = slice.maxY - slice.minY;
+      const main = block.vertical ? sliceH : sliceW;
+      const cross = block.vertical ? sliceW : sliceH;
+      const fontSize = Math.max(
+        MIN_FONT_SIZE,
+        wrapFitSize(Number.POSITIVE_INFINITY, advanceEm, main, cross)
+      );
+      layouts.push({
+        left: slice.minX - block.box[0],
+        top: slice.minY - block.box[1],
+        fontSize,
+        wrap: true,
+        width: sliceW,
+        height: sliceH
       });
       continue;
     }

--- a/src/lib/reader/line-coords-layout.ts
+++ b/src/lib/reader/line-coords-layout.ts
@@ -83,7 +83,7 @@ function median(values: number[]): number {
  */
 function wrapFitSize(startSize: number, advanceEm: number, main: number, cross: number): number {
   let best = 0;
-  for (let n = 1; n <= 8; n++) {
+  for (let n = 1; n <= 12; n++) {
     const size = Math.min(startSize, cross / n, (n * main) / advanceEm);
     if (size > best) best = size;
   }
@@ -215,12 +215,16 @@ export function layoutLines(
     .map((m) => m.candidate);
   const referenceSize = consensusSizes.length ? median(consensusSizes) : refBase;
 
+  // With no clean lines (e.g. a whole balloon captured as ONE quad+line),
+  // the reference derives from the suspect line itself, so it cannot gate
+  // the wrap — let geometry find the optimal column layout instead.
+  const hasCleanLines = cleanSizes.length > 0;
+  const wrapStart = hasCleanLines ? referenceSize : Number.POSITIVE_INFINITY;
   const wraps = measured.map(
     (m) =>
       m.suspect &&
-      m.fitted < WRAP_SHRINK * referenceSize &&
-      wrapFitSize(referenceSize, m.advanceEm, m.extents.main, m.extents.cross) >=
-        WRAP_GAIN * m.fitted
+      (m.fitted < WRAP_SHRINK * referenceSize || !hasCleanLines) &&
+      wrapFitSize(wrapStart, m.advanceEm, m.extents.main, m.extents.cross) >= WRAP_GAIN * m.fitted
   );
 
   // When ≥2 clean lines agree on the size, that consensus IS the block size.
@@ -258,7 +262,7 @@ export function layoutLines(
     if (wraps[i]) {
       const fontSize = Math.max(
         MIN_FONT_SIZE,
-        wrapFitSize(uniformSize, advanceEm, extents.main, extents.cross)
+        wrapFitSize(hasCleanLines ? uniformSize : wrapStart, advanceEm, extents.main, extents.cross)
       );
       layouts.push({ left: minX, top: minY, fontSize, wrap: true, width, height });
       continue;

--- a/src/lib/reader/line-coords-layout.ts
+++ b/src/lib/reader/line-coords-layout.ts
@@ -56,6 +56,15 @@ const MIN_FONT_SIZE = 0.5;
  */
 const WRAP_SHRINK = 0.7;
 const WRAP_WIDTH = 1.6;
+/** A quad ≥ this many times its own fitted size is merged-columns suspect
+ * and excluded from the block reference computation. */
+const SUSPECT_RATIO = 1.6;
+/** A line fitting below this fraction of the reference is deliberately small
+ * print (standalone furigana, asides): it keeps its own size. */
+const SMALL_OUTLIER = 0.7;
+/** Lines may run this much past their own quad's length at the uniform size —
+ * quad slack varies line to line while print size is constant. */
+const OVERFLOW_TOL = 1.15;
 
 function median(values: number[]): number {
   const sorted = [...values].sort((a, b) => a - b);
@@ -65,16 +74,17 @@ function median(values: number[]): number {
 
 /**
  * Largest font size ≤ startSize at which `advanceEm` ems wrap into columns of
- * length `main` without the column count overflowing `cross`.
+ * length `main` without the column count overflowing `cross`. For each column
+ * count n, the size is bounded by the column pitch (cross / n) and by the text
+ * capacity (n × main / advance); take the best n.
  */
 function wrapFitSize(startSize: number, advanceEm: number, main: number, cross: number): number {
-  let size = Math.min(startSize, cross);
-  for (let iter = 0; iter < 6; iter++) {
-    const cols = Math.max(1, Math.ceil((advanceEm * size) / main));
-    if (cols * size <= cross) break;
-    size = cross / cols;
+  let best = 0;
+  for (let n = 1; n <= 8; n++) {
+    const size = Math.min(startSize, cross / n, (n * main) / advanceEm);
+    if (size > best) best = size;
   }
-  return size;
+  return best;
 }
 
 /**
@@ -180,15 +190,50 @@ export function layoutLines(
     if (!extents) return null;
     const advanceEm = measure(processedLines[i]);
     const fitted = advanceEm > 0 ? extents.main / advanceEm : extents.cross;
-    measured.push({ extents, advanceEm, fitted, candidate: Math.min(extents.cross, fitted) });
+    measured.push({
+      extents,
+      advanceEm,
+      fitted,
+      candidate: Math.min(extents.cross, fitted),
+      // quad wide enough for 1.6+ columns of its own fitted size: likely
+      // multiple print columns captured as one OCR "line"
+      suspect: advanceEm > 0 && extents.cross >= SUSPECT_RATIO * fitted
+    });
   }
-  // Reference size: what a typical line of this block runs at. Robust to a
-  // corrupted line (merged furigana, mask slack) in a multi-line block.
-  const referenceSize = median(measured.map((m) => m.candidate));
+
+  // Block reference size: print keeps one size per balloon, so all lines
+  // render uniformly at the size the trustworthy lines agree on. Exclude
+  // merged-columns suspects (their fitted size is artificially small), then
+  // deliberately-small lines (standalone furigana, asides).
+  const cleanSizes = measured.filter((m) => !m.suspect).map((m) => m.candidate);
+  const refBase = median(cleanSizes.length ? cleanSizes : measured.map((m) => m.candidate));
+  const consensusSizes = measured
+    .filter((m) => !m.suspect && m.candidate >= SMALL_OUTLIER * refBase)
+    .map((m) => m.candidate);
+  const referenceSize = consensusSizes.length ? median(consensusSizes) : refBase;
+
+  // Wrapped lines may need to step below the reference to fit their quad;
+  // the whole block follows so every line still shares one size.
+  const wraps = measured.map(
+    (m) =>
+      m.suspect &&
+      m.fitted < WRAP_SHRINK * referenceSize &&
+      m.extents.cross >= WRAP_WIDTH * referenceSize
+  );
+  let uniformSize = referenceSize;
+  for (let i = 0; i < measured.length; i++) {
+    if (wraps[i]) {
+      const m = measured[i];
+      uniformSize = Math.min(
+        uniformSize,
+        wrapFitSize(referenceSize, m.advanceEm, m.extents.main, m.extents.cross)
+      );
+    }
+  }
 
   const layouts: LineLayout[] = [];
   for (let i = 0; i < coords.length; i++) {
-    const { extents, advanceEm, fitted } = measured[i];
+    const { extents, advanceEm, fitted, candidate } = measured[i];
     const xs = coords[i].map((p) => p[0]);
     const ys = coords[i].map((p) => p[1]);
     const minX = Math.min(...xs) - block.box[0];
@@ -198,25 +243,25 @@ export function layoutLines(
     const width = maxX - minX;
     const height = maxY - minY;
 
-    // Multiple print columns captured as one OCR "line" (base + furigana):
-    // the quad has room for 2+ columns at the block's typical size, and the
-    // text would have to shrink far below it to fit on one line. Wrap it
-    // inside the quad at (near) the reference size instead.
-    const wrap =
-      advanceEm > 0 &&
-      fitted < WRAP_SHRINK * referenceSize &&
-      extents.cross >= WRAP_WIDTH * referenceSize;
-
-    if (wrap) {
+    if (wraps[i]) {
       const fontSize = Math.max(
         MIN_FONT_SIZE,
-        wrapFitSize(referenceSize, advanceEm, extents.main, extents.cross)
+        wrapFitSize(uniformSize, advanceEm, extents.main, extents.cross)
       );
       layouts.push({ left: minX, top: minY, fontSize, wrap: true, width, height });
       continue;
     }
 
-    const fontSize = Math.max(MIN_FONT_SIZE, Math.min(extents.cross, fitted));
+    // Use the uniform size when this line's quad can carry it (allowing for
+    // per-quad slack); otherwise fall back to the line's own fitted size
+    // (deliberately-small print such as furigana lines, or quads far too
+    // tight for the block consensus).
+    const fitsUniform =
+      uniformSize * advanceEm <= extents.main * OVERFLOW_TOL &&
+      uniformSize <= extents.cross * 1.2 &&
+      candidate >= SMALL_OUTLIER * refBase;
+    const fontSize = Math.max(MIN_FONT_SIZE, fitsUniform ? uniformSize : candidate);
+
     // Reading axis: anchor at the quad start (top for vertical, left for
     // horizontal). Cross axis: center the rendered column/row in the quad —
     // quads are often wider than the glyphs (attached ruby, mask slack, empty

--- a/src/lib/reader/line-coords-layout.ts
+++ b/src/lib/reader/line-coords-layout.ts
@@ -69,10 +69,20 @@ const SMALL_OUTLIER = 0.7;
  * quad slack varies line to line while print size is constant. */
 const OVERFLOW_TOL = 1.15;
 
-function median(values: number[]): number {
-  const sorted = [...values].sort((a, b) => a - b);
-  const mid = sorted.length >> 1;
-  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+/**
+ * Median of `values` where each value counts proportionally to its weight.
+ * The block reference weights lines by quad ink area so a big base line is
+ * not outvoted by small ruby fragments split around it.
+ */
+function weightedMedian(values: number[], weights: number[]): number {
+  const order = values.map((v, i) => i).sort((a, b) => values[a] - values[b]);
+  const total = weights.reduce((s, w) => s + w, 0);
+  let cumulative = 0;
+  for (const i of order) {
+    cumulative += weights[i];
+    if (cumulative >= total / 2) return values[i];
+  }
+  return values[order[order.length - 1]];
 }
 
 /**
@@ -187,7 +197,14 @@ export function layoutLines(
   if (!coords || coords.length !== processedLines.length || coords.length === 0) return null;
 
   // First pass: per-line geometry and single-line fitted sizes.
-  const measured = [];
+  interface MeasuredLine {
+    extents: { main: number; cross: number };
+    advanceEm: number;
+    fitted: number;
+    candidate: number;
+    suspect: boolean;
+  }
+  const measured: MeasuredLine[] = [];
   for (let i = 0; i < coords.length; i++) {
     const extents = quadExtents(coords[i], block.vertical);
     if (!extents) return null;
@@ -207,18 +224,26 @@ export function layoutLines(
   // Block reference size: print keeps one size per balloon, so all lines
   // render uniformly at the size the trustworthy lines agree on. Exclude
   // merged-columns suspects (their fitted size is artificially small), then
-  // deliberately-small lines (standalone furigana, asides).
-  const cleanSizes = measured.filter((m) => !m.suspect).map((m) => m.candidate);
-  const refBase = median(cleanSizes.length ? cleanSizes : measured.map((m) => m.candidate));
-  const consensusSizes = measured
-    .filter((m) => !m.suspect && m.candidate >= SMALL_OUTLIER * refBase)
-    .map((m) => m.candidate);
-  const referenceSize = consensusSizes.length ? median(consensusSizes) : refBase;
+  // deliberately-small lines (standalone furigana, asides). Lines vote with
+  // their quad ink area: a big base line must not be outvoted by the small
+  // ruby fragments split around it (Killing Bites 01 p42 「百獣王」).
+  const area = (m: MeasuredLine) => m.extents.main * m.extents.cross;
+  const clean = measured.filter((m) => !m.suspect);
+  const refPool = clean.length ? clean : measured;
+  const refBase = weightedMedian(
+    refPool.map((m) => m.candidate),
+    refPool.map(area)
+  );
+  const consensus = measured.filter((m) => !m.suspect && m.candidate >= SMALL_OUTLIER * refBase);
+  const consensusSizes = consensus.map((m) => m.candidate);
+  const referenceSize = consensus.length
+    ? weightedMedian(consensusSizes, consensus.map(area))
+    : refBase;
 
   // With no clean lines (e.g. a whole balloon captured as ONE quad+line),
   // the reference derives from the suspect line itself, so it cannot gate
   // the wrap — let geometry find the optimal column layout instead.
-  const hasCleanLines = cleanSizes.length > 0;
+  const hasCleanLines = clean.length > 0;
   const wrapStart = hasCleanLines ? referenceSize : Number.POSITIVE_INFINITY;
   const wraps = measured.map(
     (m) =>

--- a/src/lib/reader/line-coords-layout.ts
+++ b/src/lib/reader/line-coords-layout.ts
@@ -1,0 +1,146 @@
+/**
+ * Per-line layout for original-mode text rendering, derived from the
+ * `lines_coords` quadrilaterals that mokuro emits for every OCR line.
+ *
+ * mokuro's block-level `font_size` is the mean detected line-quad width, which
+ * for vertical Japanese includes furigana and mask slack — median 1.2x (p95 2x)
+ * larger than the true character size — so rendering `font_size`px overflows
+ * the block box. The quads themselves are reliable: each line's quad gives its
+ * exact position and extent, and `extent / text advance` recovers the true
+ * per-line font size. See docs/superpowers/specs/
+ * 2026-07-04-original-mode-line-coords-design.md.
+ */
+
+/** One OCR line quad: 4 corner points, [x, y] each, in page pixels. */
+export type Quad = number[][];
+
+/** Advance of a text string in em units (width at font-size 1). */
+export type TextMeasurer = (text: string) => number;
+
+export interface LayoutBlock {
+  box: number[];
+  vertical: boolean;
+  font_size: number;
+  lines: string[];
+  lines_coords?: Quad[];
+}
+
+export interface LineLayout {
+  /** px, relative to the block box origin */
+  left: number;
+  top: number;
+  fontSize: number;
+}
+
+/**
+ * Guard against zero/NaN font sizes, not readability: hallucinated OCR lines
+ * (text far longer than the quad) must stay contained in their quad, so the
+ * computed size may be legitimately sub-pixel.
+ */
+const MIN_FONT_SIZE = 0.5;
+
+/**
+ * Fallback measurer for environments without canvas (tests, SSR): fullwidth
+ * characters advance 1em, halfwidth/ASCII roughly half.
+ */
+export function heuristicMeasurer(text: string): number {
+  let advance = 0;
+  for (const ch of text) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code < 0x2000 || (code >= 0xff61 && code <= 0xff9f)) {
+      advance += 0.55;
+    } else {
+      advance += 1;
+    }
+  }
+  return advance;
+}
+
+/**
+ * Canvas-based measurer using the reader's text font. Memoized per string;
+ * falls back to the heuristic when canvas is unavailable.
+ *
+ * Vertical text approximation: upright CJK advances ~1em vertically, which
+ * matches its horizontal measure; rotated Latin advances by its horizontal
+ * width. Residual error is bounded by the quad-cross cap in layoutLines.
+ */
+export function createCanvasMeasurer(fontFamily = "'Noto Sans JP', sans-serif"): TextMeasurer {
+  let ctx: CanvasRenderingContext2D | null = null;
+  try {
+    ctx = document.createElement('canvas').getContext('2d');
+    if (ctx) ctx.font = `100px ${fontFamily}`;
+  } catch {
+    ctx = null;
+  }
+  if (!ctx || typeof ctx.measureText !== 'function') return heuristicMeasurer;
+  const canvasCtx = ctx;
+  const cache = new Map<string, number>();
+  return (text: string) => {
+    let advance = cache.get(text);
+    if (advance === undefined) {
+      advance = canvasCtx.measureText(text).width / 100;
+      if (!Number.isFinite(advance) || advance < 0) advance = heuristicMeasurer(text);
+      cache.set(text, advance);
+    }
+    return advance;
+  };
+}
+
+/**
+ * Extents of a quad along the writing direction (main) and across it (cross),
+ * via edge-midpoint vectors — the same construction comic-text-detector uses,
+ * so it tolerates rotated quads.
+ */
+function quadExtents(quad: Quad, vertical: boolean): { main: number; cross: number } | null {
+  if (!Array.isArray(quad) || quad.length !== 4) return null;
+  for (const p of quad) {
+    if (!Array.isArray(p) || p.length < 2 || !Number.isFinite(p[0]) || !Number.isFinite(p[1])) {
+      return null;
+    }
+  }
+  const [p0, p1, p2, p3] = quad;
+  const hx = (p1[0] + p2[0]) / 2 - (p0[0] + p3[0]) / 2;
+  const hy = (p1[1] + p2[1]) / 2 - (p0[1] + p3[1]) / 2;
+  const vx = (p2[0] + p3[0]) / 2 - (p0[0] + p1[0]) / 2;
+  const vy = (p2[1] + p3[1]) / 2 - (p0[1] + p1[1]) / 2;
+  const h = Math.hypot(hx, hy);
+  const v = Math.hypot(vx, vy);
+  if (h <= 0 || v <= 0) return null;
+  return vertical ? { main: v, cross: h } : { main: h, cross: v };
+}
+
+/**
+ * Compute per-line positions and font sizes for a block.
+ *
+ * @param block the OCR block (box, vertical, lines_coords)
+ * @param processedLines the text actually rendered (post ellipsis substitution);
+ *   must be parallel to block.lines_coords
+ * @param measure text advance measurer in em units
+ * @returns one layout per line, or null when the block has no usable
+ *   lines_coords — callers fall back to legacy block-level rendering
+ */
+export function layoutLines(
+  block: LayoutBlock,
+  processedLines: string[],
+  measure: TextMeasurer
+): LineLayout[] | null {
+  const coords = block.lines_coords;
+  if (!coords || coords.length !== processedLines.length || coords.length === 0) return null;
+
+  const layouts: LineLayout[] = [];
+  for (let i = 0; i < coords.length; i++) {
+    const extents = quadExtents(coords[i], block.vertical);
+    if (!extents) return null;
+    const advanceEm = measure(processedLines[i]);
+    const fitted = advanceEm > 0 ? extents.main / advanceEm : extents.cross;
+    const fontSize = Math.max(MIN_FONT_SIZE, Math.min(extents.cross, fitted));
+    const xs = coords[i].map((p) => p[0]);
+    const ys = coords[i].map((p) => p[1]);
+    layouts.push({
+      left: Math.min(...xs) - block.box[0],
+      top: Math.min(...ys) - block.box[1],
+      fontSize
+    });
+  }
+  return layouts;
+}

--- a/src/lib/reader/line-coords-layout.ts
+++ b/src/lib/reader/line-coords-layout.ts
@@ -86,6 +86,14 @@ export function createCanvasMeasurer(fontFamily = "'Noto Sans JP', sans-serif"):
   };
 }
 
+let defaultMeasurer: TextMeasurer | null = null;
+
+/** Shared memoized canvas measurer (heuristic fallback outside the browser). */
+export function getDefaultMeasurer(): TextMeasurer {
+  if (!defaultMeasurer) defaultMeasurer = createCanvasMeasurer();
+  return defaultMeasurer;
+}
+
 /**
  * Extents of a quad along the writing direction (main) and across it (cross),
  * via edge-midpoint vectors — the same construction comic-text-detector uses,

--- a/src/lib/reader/line-coords-layout.ts
+++ b/src/lib/reader/line-coords-layout.ts
@@ -50,12 +50,15 @@ export interface LineLayout {
 const MIN_FONT_SIZE = 0.5;
 
 /**
- * A line wraps when it would need to shrink below WRAP_SHRINK × reference to
- * fit on one line AND its quad is at least WRAP_WIDTH × reference wide
- * (room for 2+ columns at the block's typical size).
+ * A merged-columns suspect wraps when it would need to shrink below
+ * WRAP_SHRINK × reference to fit on one line AND wrapping actually buys at
+ * least WRAP_GAIN × the single-line size inside its quad.
  */
 const WRAP_SHRINK = 0.7;
-const WRAP_WIDTH = 1.6;
+const WRAP_GAIN = 1.25;
+/** ≥2 clean lines whose sizes agree within this spread fix the block size —
+ * a wrapped line's lower fit no longer pulls the whole block down. */
+const CONSENSUS_SPREAD = 1.25;
 /** A quad ≥ this many times its own fitted size is merged-columns suspect
  * and excluded from the block reference computation. */
 const SUSPECT_RATIO = 1.6;
@@ -212,22 +215,31 @@ export function layoutLines(
     .map((m) => m.candidate);
   const referenceSize = consensusSizes.length ? median(consensusSizes) : refBase;
 
-  // Wrapped lines may need to step below the reference to fit their quad;
-  // the whole block follows so every line still shares one size.
   const wraps = measured.map(
     (m) =>
       m.suspect &&
       m.fitted < WRAP_SHRINK * referenceSize &&
-      m.extents.cross >= WRAP_WIDTH * referenceSize
+      wrapFitSize(referenceSize, m.advanceEm, m.extents.main, m.extents.cross) >=
+        WRAP_GAIN * m.fitted
   );
+
+  // When ≥2 clean lines agree on the size, that consensus IS the block size.
+  // Otherwise (0-1 clean lines: low information), wrapped lines may need to
+  // step below the reference to fit their quad, and the block follows so
+  // every line still shares one size.
+  const trustConsensus =
+    consensusSizes.length >= 2 &&
+    Math.max(...consensusSizes) <= CONSENSUS_SPREAD * Math.min(...consensusSizes);
   let uniformSize = referenceSize;
-  for (let i = 0; i < measured.length; i++) {
-    if (wraps[i]) {
-      const m = measured[i];
-      uniformSize = Math.min(
-        uniformSize,
-        wrapFitSize(referenceSize, m.advanceEm, m.extents.main, m.extents.cross)
-      );
+  if (!trustConsensus) {
+    for (let i = 0; i < measured.length; i++) {
+      if (wraps[i]) {
+        const m = measured[i];
+        uniformSize = Math.min(
+          uniformSize,
+          wrapFitSize(referenceSize, m.advanceEm, m.extents.main, m.extents.cross)
+        );
+      }
     }
   }
 

--- a/src/lib/reader/line-coords-layout.ts
+++ b/src/lib/reader/line-coords-layout.ts
@@ -144,9 +144,18 @@ export function layoutLines(
     const fontSize = Math.max(MIN_FONT_SIZE, Math.min(extents.cross, fitted));
     const xs = coords[i].map((p) => p[0]);
     const ys = coords[i].map((p) => p[1]);
+    // Reading axis: anchor at the quad start (top for vertical, left for
+    // horizontal). Cross axis: center the rendered column/row in the quad —
+    // quads are often wider than the glyphs (attached ruby, mask slack, empty
+    // margin) and the base glyphs sit near the middle; edge-anchoring can
+    // shove a column into its neighbor's space.
+    const minX = Math.min(...xs) - block.box[0];
+    const minY = Math.min(...ys) - block.box[1];
+    const maxX = Math.max(...xs) - block.box[0];
+    const maxY = Math.max(...ys) - block.box[1];
     layouts.push({
-      left: Math.min(...xs) - block.box[0],
-      top: Math.min(...ys) - block.box[1],
+      left: block.vertical ? (minX + maxX) / 2 - fontSize / 2 : minX,
+      top: block.vertical ? minY : (minY + maxY) / 2 - fontSize / 2,
       fontSize
     });
   }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -3,6 +3,10 @@ export type Block = {
   vertical: boolean;
   font_size: number;
   lines: string[];
+  /** Per-line quadrilaterals (4 corner points each) from mokuro; present in
+   * standard .mokuro output and stored verbatim, but optional because
+   * image-only volumes and older imports may lack it. */
+  lines_coords?: number[][][];
 };
 
 export type Page = {


### PR DESCRIPTION
Follow-up to #243: restores z-index:11 box stacking and drops the positionedLine z-index lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)