### PR TITLE
feat(reader): page gap for dual-page spreads + ctrl+shift+scroll (#234)

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: verify
+description: Verify reader features end-to-end by importing a synthetic volume through the real upload modal and driving the reader with Playwright. Use when a change needs runtime observation in the actual app (not unit tests).
+---
+
+# Verifying mokuro-reader changes end-to-end
+
+## Launch
+
+```bash
+npm run dev -- --port 5199 --strictPort   # dedicated port; NEVER bare 5173 (other worktrees own it)
+```
+
+Browser: Playwright from `node_modules`, executablePath
+`~/.cache/ms-playwright/chromium-1208/chrome-linux64/chrome` (note `chrome-linux64`, not `chrome-linux`).
+Headless is fine. Don't drive the user's Chrome (stale service worker, port collisions, hidden-window rAF freeze).
+
+## Synthetic volume fixture
+
+The import needs a `.mokuro` + matching `.cbz` (same basename):
+
+- Pages: ImageMagick solid-color portraits with page numbers:
+  `magick -size 1400x2000 xc:"#d8f0ff" -bordercolor black -border 8 -resize 1400x2000\! -gravity center -pointsize 400 -annotate 0 "1" 001.png`
+- `vol1.cbz`: `zip -j vol1.cbz *.png`
+- `vol1.mokuro` (all fields required): `{version, title, title_uuid, volume, volume_uuid, chars, pages: [{version, img_width, img_height, blocks: [], img_path}]}`
+
+## Import through the real UI
+
+1. Navbar icon cluster: `div.flex.gap-5 > button` — nth(2) is the upload icon → opens the Import modal (`<dialog>`).
+2. **Gotcha:** `getByRole()` fails to match buttons inside the flowbite modal `<dialog>` — use CSS locators (`page.locator('dialog button', { hasText: ... })`) or `page.evaluate` with `textContent.trim()` matching.
+3. `waitForEvent('filechooser')` + click the `choose files` button, `setFiles([vol1.mokuro, vol1.cbz])`, then click the exact-text `Import` button.
+4. Wait for `text=GapTest` in the catalog, click series → volume → reader (`#/reader/<title>/<uuid>`).
+
+## Driving the reader
+
+- RTL default: `ArrowLeft` = forward. Auto view mode pairs pages (cover shows alone first).
+- Page elements: `#manga-panel [data-page-index]` — measure `getBoundingClientRect()` for gap/scale/pan assertions (natural page width 1400 → scale = rect.width/1400).
+- Wheel with modifiers: `page.keyboard.down('Control'/'Shift')` + `page.mouse.wheel(0, ±100)` — Playwright applies held modifiers to the wheel event. CDP does NOT swap deltaY→deltaX under shift the way real input does; handlers reading `deltaY || deltaX` cover both.
+- Reader toast: search text nodes for the notification string.
+- Reader settings drawer: `button.reader-hud.right-3` (there are 3 `.reader-hud` buttons; `.first()` is the page-counter). Toggle labels (e.g. "Continuous scroll") are clickable once the drawer opens; close by clicking far from the drawer.
+- Persisted settings check: `JSON.parse(localStorage.getItem('profiles'))[currentProfile]`.
+
+## Known noise
+
+- `[pageerror] Unexpected token '<'` on first dev-server load — pre-existing dev artifact, unrelated to features.

--- a/docs/INPUT-CONTRACTS.md
+++ b/docs/INPUT-CONTRACTS.md
@@ -112,7 +112,14 @@ Zoom settles carry a `SettleReason` (`zoom-controller.ts`): only
 | Pinch survivor | keeps panning                     | ignored until fresh press               |
 | Tap commit     | immediate                         | deferred (300 ms)                       |
 | Swipe-to-flip  | yes (mobile setting, edge-gated)  | no (panning is the scroll)              |
-| Wheel          | zoom or camera glide              | zoom or (native/strip) scroll           |
+| Wheel          | zoom, gap, or camera glide        | zoom, gap, or (native/strip) scroll     |
+
+Ctrl/meta+shift+wheel is the page-gap adjustment chord on every surface
+(paged writes `pagedGap`; scroll readers write `scrollGap` and sync
+`pageDividers`), checked before the zoom intent. Binding rule: wheel combos
+with a native browser meaning keep that meaning tuned for the reader
+(ctrl+wheel zooms, shift+wheel stays a horizontal pan); the gap chord is
+deliberately one no browser binds.
 
 ## Testing
 

--- a/docs/superpowers/plans/2026-07-05-page-gap-234.md
+++ b/docs/superpowers/plans/2026-07-05-page-gap-234.md
@@ -1,0 +1,649 @@
+# Paged Page Gap + Ctrl+Shift+Scroll Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adjustable gap between the two pages of a paged-mode spread (issue #234), plus a ctrl+shift+scroll chord that live-adjusts the gap in all three reader surfaces.
+
+**Architecture:** A new `pagedGap` profile setting renders as CSS `column-gap` on the paged flex row (image-pixel space, scales with zoom) and is added to the fit-math content size via a pure `spreadContentSize` helper. A gap-adjust wheel intent (`ctrl/meta+shift+wheel`) is claimed ahead of the zoom intent in each surface's `handleWheel`, reusing the existing `WheelAccumulator` for notch/trackpad normalization. Paged surface writes `pagedGap`; scroll surfaces write `scrollGap` and sync `pageDividers`. Reader shows a keyed toast via its existing `showNotification`.
+
+**Tech Stack:** SvelteKit 5 (runes + stores), Vitest, existing reader zoom modules.
+
+**Spec:** `docs/superpowers/specs/2026-07-05-page-gap-234-design.md`
+
+## Global Constraints
+
+- Worktree root (run ALL commands here): `/home/nathan/Projects/mokuro-reader-worktrees/feat/page-gap-234`
+- `src/lib/reader/zoom-math.ts` and `src/lib/reader/paged-zoom-layout.ts` are imported by the Playwright e2e suite through the Vite dev server — keep them free of Svelte and DOM access (type-only `Pick<WheelEvent, …>` is fine).
+- Gap range: 0–100 px, both settings. Chord: `(ctrlKey || metaKey) && shiftKey`. Scroll up widens.
+- With shift held, Chromium reports the wheel notch in `deltaX` (deltaY = 0); Firefox keeps `deltaY`. Read whichever axis is nonzero, preferring `deltaY`.
+- Commit messages: conventional commits, terse (repo style, e.g. `feat(reader): …`).
+- Svelte 5 runes (`$props`, `$derived`, `$state`); settings access via the `settings` store and `updateSetting` from `$lib/settings`.
+- Run single test files with `npx vitest run <path>`; full suite `npx vitest run`.
+
+---
+
+### Task 1: `pagedGap` setting
+
+**Files:**
+- Modify: `src/lib/settings/settings.ts:166` (type), `src/lib/settings/settings.ts:313` (default)
+- Test: `src/lib/settings/settings.test.ts`
+
+**Interfaces:**
+- Produces: `Settings.pagedGap: number` (default `0`) — read by Tasks 4, 5, 7 as `$settings.pagedGap`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/lib/settings/settings.test.ts`, `migrateProfiles` is already imported by the theme-migration tests (check the import block at the top; add it to the import list from `./settings` if absent). Add:
+
+```typescript
+describe('pagedGap migration', () => {
+  it('fills pagedGap with its default for profiles saved before the setting existed', () => {
+    const legacy = { Default: { dark: true } } as any;
+    const migrated = migrateProfiles(legacy);
+    expect(migrated.Default.pagedGap).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/settings/settings.test.ts -t pagedGap`
+Expected: FAIL — `expected undefined to be 0`
+
+- [ ] **Step 3: Add the setting**
+
+In `src/lib/settings/settings.ts`, after the `scrollGap` type field (line ~166):
+
+```typescript
+  scrollGap: number; // Pixels of padding between pages in scroll modes
+  pagedGap: number; // Gap between a paged-mode spread's two pages (image px, scales with zoom)
+```
+
+In `defaultSettings` after `scrollGap: 0,` (line ~313):
+
+```typescript
+  scrollGap: 0,
+  pagedGap: 0,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/settings/settings.test.ts`
+Expected: PASS (all — new test and existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/settings/settings.ts src/lib/settings/settings.test.ts
+git commit -m "feat(settings): add pagedGap setting"
+```
+
+---
+
+### Task 2: `spreadContentSize` helper
+
+**Files:**
+- Modify: `src/lib/reader/paged-zoom-layout.ts` (append after `panEdgeState`)
+- Test: `src/lib/reader/paged-zoom-layout.test.ts`
+
+**Interfaces:**
+- Consumes: `Size` (already exported from this module).
+- Produces: `spreadContentSize(first: Size, second: Size | null, gap: number): Size` — used by Task 4 in `Reader.svelte`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/lib/reader/paged-zoom-layout.test.ts` (add `spreadContentSize` to the existing import from `./paged-zoom-layout`):
+
+```typescript
+describe('spreadContentSize', () => {
+  const a = { width: 700, height: 1000 };
+  const b = { width: 720, height: 980 };
+
+  it('passes a single page through untouched, ignoring the gap', () => {
+    expect(spreadContentSize(a, null, 24)).toEqual({ width: 700, height: 1000 });
+  });
+
+  it('sums pair widths plus the gap; height is the taller page', () => {
+    expect(spreadContentSize(a, b, 24)).toEqual({ width: 1444, height: 1000 });
+  });
+
+  it('zero gap renders the pair flush', () => {
+    expect(spreadContentSize(a, b, 0)).toEqual({ width: 1420, height: 1000 });
+  });
+
+  it('clamps a negative gap to flush', () => {
+    expect(spreadContentSize(a, b, -10)).toEqual({ width: 1420, height: 1000 });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/lib/reader/paged-zoom-layout.test.ts -t spreadContentSize`
+Expected: FAIL — `spreadContentSize is not a function` (import error).
+
+- [ ] **Step 3: Implement**
+
+Append to `src/lib/reader/paged-zoom-layout.ts`:
+
+```typescript
+/**
+ * Native-pixel content size of the displayed page or pair. The gap between a
+ * pair lives in image-pixel space (it scales with zoom like a physical
+ * gutter) and must be part of the content size, or fit modes, pan clamping,
+ * and swipe edge detection are all off by the gap width.
+ */
+export function spreadContentSize(first: Size, second: Size | null, gap: number): Size {
+  if (!second) return { width: first.width, height: first.height };
+  return {
+    width: first.width + second.width + Math.max(0, gap),
+    height: Math.max(first.height, second.height)
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/reader/paged-zoom-layout.test.ts`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/reader/paged-zoom-layout.ts src/lib/reader/paged-zoom-layout.test.ts
+git commit -m "feat(reader): spreadContentSize includes the pair gap in fit math"
+```
+
+---
+
+### Task 3: Gap wheel intent helpers
+
+**Files:**
+- Modify: `src/lib/reader/zoom-math.ts` (after `normalizeWheelDelta`, line ~120)
+- Test: `src/lib/reader/zoom-math.test.ts`
+- Modify: `docs/superpowers/specs/2026-07-05-page-gap-234-design.md` (amend helper section)
+
+**Interfaces:**
+- Consumes: `normalizeWheelDelta`, `WheelAccumulator` (same module).
+- Produces (used by Tasks 5–7):
+  - `MAX_PAGE_GAP = 100` (const)
+  - `GAP_WHEEL_STEP_SIZE = 20` (const)
+  - `wheelIntentIsGapAdjust(e: Pick<WheelEvent, 'ctrlKey' | 'metaKey' | 'shiftKey'>): boolean`
+  - `gapWheelSteps(e: Pick<WheelEvent, 'deltaX' | 'deltaY' | 'deltaMode' | 'timeStamp'>, acc: WheelAccumulator): number` — signed px of gap change; positive widens.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/lib/reader/zoom-math.test.ts` (extend the existing import from `./zoom-math` with `wheelIntentIsGapAdjust`, `gapWheelSteps`, `GAP_WHEEL_STEP_SIZE`):
+
+```typescript
+describe('wheelIntentIsGapAdjust', () => {
+  it('requires ctrl or meta plus shift', () => {
+    expect(wheelIntentIsGapAdjust({ ctrlKey: true, metaKey: false, shiftKey: true })).toBe(true);
+    expect(wheelIntentIsGapAdjust({ ctrlKey: false, metaKey: true, shiftKey: true })).toBe(true);
+  });
+
+  it('rejects partial chords', () => {
+    expect(wheelIntentIsGapAdjust({ ctrlKey: true, metaKey: false, shiftKey: false })).toBe(false);
+    expect(wheelIntentIsGapAdjust({ ctrlKey: false, metaKey: false, shiftKey: true })).toBe(false);
+    expect(wheelIntentIsGapAdjust({ ctrlKey: false, metaKey: false, shiftKey: false })).toBe(false);
+  });
+});
+
+describe('gapWheelSteps', () => {
+  it('one mouse notch widens by 5px when shift swaps the delta to deltaX (Chromium)', () => {
+    const acc = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+    const px = gapWheelSteps({ deltaX: -100, deltaY: 0, deltaMode: 0, timeStamp: 1000 }, acc);
+    expect(px).toBe(5);
+  });
+
+  it('prefers deltaY when the browser keeps it there (Firefox)', () => {
+    const acc = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+    const px = gapWheelSteps({ deltaX: 7, deltaY: -100, deltaMode: 0, timeStamp: 1000 }, acc);
+    expect(px).toBe(5);
+  });
+
+  it('scroll down narrows', () => {
+    const acc = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+    const px = gapWheelSteps({ deltaX: 0, deltaY: 100, deltaMode: 0, timeStamp: 1000 }, acc);
+    expect(px).toBe(-5);
+  });
+
+  it('accumulates a trackpad stream of sub-step deltas into whole px', () => {
+    const acc = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+    let total = 0;
+    for (let i = 0; i < 4; i++) {
+      total += gapWheelSteps({ deltaX: 0, deltaY: -6, deltaMode: 0, timeStamp: 1000 + i * 16 }, acc);
+    }
+    expect(total).toBe(1); // 24 wheel px accumulated -> one 20px step
+  });
+
+  it('normalizes line-mode deltas (Firefox wheel)', () => {
+    const acc = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+    const px = gapWheelSteps({ deltaX: 0, deltaY: -3, deltaMode: 1, timeStamp: 1000 }, acc);
+    expect(px).toBe(6); // 3 lines * 40px = 120 wheel px -> six 20px steps
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/lib/reader/zoom-math.test.ts -t "gapWheelSteps"`
+Expected: FAIL — missing exports.
+
+- [ ] **Step 3: Implement**
+
+Insert into `src/lib/reader/zoom-math.ts` directly after `normalizeWheelDelta` (line ~120, before the `WheelAccumulator` doc comment):
+
+```typescript
+/** Upper bound shared by the gap sliders and the wheel chord (px). */
+export const MAX_PAGE_GAP = 100;
+
+/** Wheel px per 1px of gap: one classic ~100px notch adjusts by 5px. */
+export const GAP_WHEEL_STEP_SIZE = 20;
+
+/**
+ * Whether a wheel event means "adjust the page gap": ctrl/meta+shift+wheel.
+ * Checked BEFORE the zoom intent — combos with a native browser meaning
+ * (ctrl+wheel zoom, shift+wheel horizontal scroll) keep that meaning tuned
+ * for the reader; the gap chord is unbound in every major browser.
+ */
+export function wheelIntentIsGapAdjust(
+  e: Pick<WheelEvent, 'ctrlKey' | 'metaKey' | 'shiftKey'>
+): boolean {
+  return (e.ctrlKey || e.metaKey) && e.shiftKey;
+}
+
+/**
+ * Signed gap change (px) for a gap-adjust wheel event; positive widens
+ * (wheel up). With shift held Chromium reports the notch in deltaX while
+ * Firefox keeps deltaY — read whichever is nonzero. Feed each surface's own
+ * WheelAccumulator(GAP_WHEEL_STEP_SIZE) so trackpad streams accumulate
+ * instead of stalling below one step.
+ */
+export function gapWheelSteps(
+  e: Pick<WheelEvent, 'deltaX' | 'deltaY' | 'deltaMode' | 'timeStamp'>,
+  acc: WheelAccumulator
+): number {
+  const raw = e.deltaY !== 0 ? e.deltaY : e.deltaX;
+  return acc.add(normalizeWheelDelta(raw, e.deltaMode), e.timeStamp);
+}
+```
+
+(`WheelAccumulator` is declared later in the file — fine, `export function` hoisting is irrelevant here since usage is at call time.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/reader/zoom-math.test.ts`
+Expected: PASS (all).
+
+- [ ] **Step 5: Amend the spec's helper section**
+
+In `docs/superpowers/specs/2026-07-05-page-gap-234-design.md`, replace the "Wheel-to-gap helper" bullet list body with:
+
+```markdown
+- `wheelIntentIsGapAdjust` + `gapWheelSteps` live in
+  `src/lib/reader/zoom-math.ts` next to `normalizeWheelDelta`/
+  `wheelIntentIsZoom`, reusing the existing `WheelAccumulator`
+  (idle + direction-flip resets) at `GAP_WHEEL_STEP_SIZE = 20` wheel px per
+  1px of gap — one ~100px notch = 5px, trackpad streams accumulate.
+- Sign flipped so scroll-up widens; result clamped 0–`MAX_PAGE_GAP` (100) at
+  the write site.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/reader/zoom-math.ts src/lib/reader/zoom-math.test.ts docs/superpowers/specs/2026-07-05-page-gap-234-design.md
+git commit -m "feat(reader): gap-adjust wheel intent helpers"
+```
+
+---
+
+### Task 4: Paged rendering + fit math
+
+**Files:**
+- Modify: `src/lib/components/Reader/Reader.svelte:376-389` (pagedContentSize), `:1204-1211` (flex row), imports at top of `<script>`.
+
+**Interfaces:**
+- Consumes: `spreadContentSize` (Task 2), `$settings.pagedGap` (Task 1).
+- Produces: paged spread renders with `column-gap`; `pagedContentSize` includes the gap (PagedViewport re-fits automatically via its `contentSize` signature).
+
+- [ ] **Step 1: Wire the gap into the content size**
+
+In `src/lib/components/Reader/Reader.svelte`, add `spreadContentSize` to the existing import from `$lib/reader/paged-zoom-layout` (or add the import if the module isn't imported yet — check the script block; `Size` may already come from there):
+
+```typescript
+import { spreadContentSize } from '$lib/reader/paged-zoom-layout';
+```
+
+Replace the body of the `pagedContentSize` derived (line ~376):
+
+```typescript
+let pagedContentSize = $derived.by(() => {
+  const pgs = pages;
+  const idx = index;
+  if (!pgs || pgs.length === 0 || !pgs[idx]) return { width: 0, height: 0 };
+  const first = { width: pgs[idx].img_width, height: pgs[idx].img_height };
+  const second =
+    showSecondPage() && pgs[idx + 1]
+      ? { width: pgs[idx + 1].img_width, height: pgs[idx + 1].img_height }
+      : null;
+  return spreadContentSize(first, second, $settings.pagedGap ?? 0);
+});
+```
+
+- [ ] **Step 2: Render the gap**
+
+On the paged flex row (line ~1206), add the `column-gap` style:
+
+```svelte
+<div
+  class="col-start-1 row-start-1 flex flex-row"
+  class:flex-row-reverse={!volumeSettings.rightToLeft}
+  style:column-gap={`${$settings.pagedGap ?? 0}px`}
+  in:pageIn={{ direction: pageDirection }}
+  out:pageOut={{ direction: pageDirection }}
+>
+```
+
+(`column-gap` is inert with a single child and applies between flex items in both row and row-reverse directions.)
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run check`
+Expected: 0 errors (same warnings count as before the change, if any).
+Run: `npx vitest run`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/components/Reader/Reader.svelte
+git commit -m "feat(reader): render pagedGap between spread pages (#234)"
+```
+
+---
+
+### Task 5: Paged surface wheel chord + toast
+
+**Files:**
+- Modify: `src/lib/components/Reader/PagedViewport.svelte` (Props, imports, `handleWheel`)
+- Modify: `src/lib/components/Reader/Reader.svelte` (`handleGapChange` near `showNotification` line ~887; `onGapChange` prop at the `<PagedViewport` usage line ~1171)
+
+**Interfaces:**
+- Consumes: `wheelIntentIsGapAdjust`, `gapWheelSteps`, `WheelAccumulator`, `GAP_WHEEL_STEP_SIZE`, `MAX_PAGE_GAP` (Task 3); `updateSetting` from `$lib/settings`.
+- Produces: `PagedViewport` prop `onGapChange?: (px: number) => void`; Reader's `handleGapChange(px: number)` (reused by Task 6).
+
+- [ ] **Step 1: Add the gap branch to PagedViewport**
+
+In `src/lib/components/Reader/PagedViewport.svelte`:
+
+Extend the zoom-math import (currently `normalizeWheelDelta, wheelIntentIsZoom`):
+
+```typescript
+import {
+  GAP_WHEEL_STEP_SIZE,
+  MAX_PAGE_GAP,
+  WheelAccumulator,
+  gapWheelSteps,
+  normalizeWheelDelta,
+  wheelIntentIsGapAdjust,
+  wheelIntentIsZoom
+} from '$lib/reader/zoom-math';
+```
+
+Extend the settings import: `import { settings, updateSetting } from '$lib/settings';`
+
+Add to `interface Props` (after `onOverlayToggle`):
+
+```typescript
+    /** The gap-adjust wheel chord changed the page gap to this value (px). */
+    onGapChange?: (px: number) => void;
+```
+
+and add `onGapChange` to the destructuring.
+
+Above `handleWheel`, add:
+
+```typescript
+  const gapAccumulator = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+
+  function adjustGap(delta: number) {
+    if (delta === 0) return;
+    const next = Math.max(0, Math.min(MAX_PAGE_GAP, ($settings.pagedGap ?? 0) + delta));
+    updateSetting('pagedGap', next);
+    onGapChange?.(next);
+  }
+```
+
+At the TOP of `handleWheel` (before `const modifier = …`):
+
+```typescript
+    if (wheelIntentIsGapAdjust(e)) {
+      e.preventDefault();
+      adjustGap(gapWheelSteps(e, gapAccumulator));
+      return;
+    }
+```
+
+- [ ] **Step 2: Wire the toast in Reader**
+
+In `src/lib/components/Reader/Reader.svelte`, after the `showNotification` function (line ~901):
+
+```typescript
+  function handleGapChange(px: number) {
+    showNotification(`Page gap: ${px}px`, 'page-gap');
+  }
+```
+
+At the `<PagedViewport` usage (line ~1171), add the prop:
+
+```svelte
+      <PagedViewport
+        contentSize={pagedContentSize}
+        pageKey={page}
+        rtl={volumeSettings.rightToLeft ?? true}
+        onPageFlip={(side) => (side === 'left' ? left(null, true) : right(null, true))}
+        onOverlayToggle={() => (overlaysVisible = !overlaysVisible)}
+        onGapChange={handleGapChange}
+      >
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run check`
+Expected: 0 errors.
+Run: `npx vitest run`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/components/Reader/PagedViewport.svelte src/lib/components/Reader/Reader.svelte
+git commit -m "feat(reader): ctrl+shift+scroll adjusts pagedGap in paged mode"
+```
+
+---
+
+### Task 6: Scroll surfaces wheel chord
+
+**Files:**
+- Modify: `src/lib/components/Reader/HorizontalScrollReader.svelte` (Props line ~21, imports, `handleWheel` line ~346)
+- Modify: `src/lib/components/Reader/VerticalScrollReader.svelte` (Props line ~21, imports, `handleWheel` line ~343)
+- Modify: `src/lib/components/Reader/Reader.svelte` (pass `onGapChange={handleGapChange}` to both usages, lines ~1140-1166)
+
+**Interfaces:**
+- Consumes: Task 3 helpers; Reader's `handleGapChange` (Task 5); `updateSetting` from `$lib/settings` (both files already import `settings`; extend that import).
+- Produces: both scroll readers accept `onGapChange?: (px: number) => void`; the chord writes `scrollGap` and syncs `pageDividers = gap > 0`.
+
+- [ ] **Step 1: Add the branch to BOTH scroll readers (identical code)**
+
+In each of `HorizontalScrollReader.svelte` and `VerticalScrollReader.svelte`:
+
+Extend the zoom-math import (currently `normalizeWheelDelta, wheelIntentIsZoom`) exactly as in Task 5 Step 1. Extend the settings import with `updateSetting`.
+
+Add to `interface Props` (after `onOverlayToggle?`) and to the `$props()` destructuring:
+
+```typescript
+    /** The gap-adjust wheel chord changed the divider gap to this value (px). */
+    onGapChange?: (px: number) => void;
+```
+
+Add above `handleWheel`:
+
+```typescript
+  const gapAccumulator = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+
+  // The chord drives the continuous-mode dividers: gap > 0 means dividers on,
+  // reaching 0 turns them off (the M toggle keeps working independently).
+  function adjustGap(delta: number) {
+    if (delta === 0) return;
+    const next = Math.max(0, Math.min(MAX_PAGE_GAP, $settings.scrollGap + delta));
+    updateSetting('scrollGap', next);
+    const dividers = next > 0;
+    if ($settings.pageDividers !== dividers) updateSetting('pageDividers', dividers);
+    onGapChange?.(next);
+  }
+```
+
+In `handleWheel`, directly after the `if (!scrollContainer) return;` guard (both files):
+
+```typescript
+    if (wheelIntentIsGapAdjust(e)) {
+      e.preventDefault();
+      adjustGap(gapWheelSteps(e, gapAccumulator));
+      return;
+    }
+```
+
+(In VerticalScrollReader the `preventDefault` matters doubly: the surface scrolls natively, and without it the browser would treat ctrl+wheel as page zoom.)
+
+- [ ] **Step 2: Wire Reader**
+
+In `Reader.svelte`, add `onGapChange={handleGapChange}` to the `<VerticalScrollReader` (line ~1140) and `<HorizontalScrollReader` (line ~1155) usages, alongside their existing `onOverlayToggle` props.
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run check`
+Expected: 0 errors.
+Run: `npx vitest run`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/components/Reader/HorizontalScrollReader.svelte src/lib/components/Reader/VerticalScrollReader.svelte src/lib/components/Reader/Reader.svelte
+git commit -m "feat(reader): ctrl+shift+scroll adjusts dividers in continuous modes"
+```
+
+---
+
+### Task 7: Settings UI
+
+**Files:**
+- Modify: `src/lib/components/Settings/Reader/ReaderSettings.svelte` (isPaged block line ~90-104; divider slider label line ~127)
+
+**Interfaces:**
+- Consumes: `$settings.pagedGap`, `updateSetting` (already imported), `MAX_PAGE_GAP` (Task 3), `Range`/`Label` (already imported).
+
+- [ ] **Step 1: Add the paged gap slider**
+
+Add `import { MAX_PAGE_GAP } from '$lib/reader/zoom-math';` to the script block.
+
+Inside the `{#if isPaged}` block, after the page-view-mode `</div>` (line ~103), add:
+
+```svelte
+      {#if $settings.singlePageView !== 'single'}
+        <div>
+          <Label class="text-gray-900 dark:text-white">
+            Page gap: {$settings.pagedGap}px
+            <span class="ml-2 text-xs text-gray-500 dark:text-gray-400">(Ctrl+Shift+Scroll)</span>
+          </Label>
+          <Range
+            min={0}
+            max={MAX_PAGE_GAP}
+            value={$settings.pagedGap}
+            onchange={(e) => updateSetting('pagedGap', Number((e.target as HTMLInputElement).value))}
+          />
+        </div>
+      {/if}
+```
+
+- [ ] **Step 2: Add the chord hint to the continuous divider slider**
+
+Change the divider-size label (line ~127) to:
+
+```svelte
+          <Label class="text-gray-900 dark:text-white">
+            Divider size: {$settings.scrollGap}px
+            <span class="ml-2 text-xs text-gray-500 dark:text-gray-400">(Ctrl+Shift+Scroll)</span>
+          </Label>
+```
+
+and change that slider's `max={100}` to `max={MAX_PAGE_GAP}`.
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run check`
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/components/Settings/Reader/ReaderSettings.svelte
+git commit -m "feat(settings): page gap slider + chord hints"
+```
+
+---
+
+### Task 8: Input contracts doc + full verification
+
+**Files:**
+- Modify: `docs/INPUT-CONTRACTS.md:115` (wheel row) + new paragraph after the matrix
+
+- [ ] **Step 1: Update the contracts doc**
+
+Change the wheel row of the per-surface policy matrix:
+
+```markdown
+| Wheel          | zoom, gap, or camera glide        | zoom, gap, or (native/strip) scroll     |
+```
+
+After the matrix table, add:
+
+```markdown
+Ctrl/meta+shift+wheel is the page-gap adjustment chord on every surface
+(paged writes `pagedGap`; scroll readers write `scrollGap` and sync
+`pageDividers`), checked before the zoom intent. Binding rule: wheel combos
+with a native browser meaning keep that meaning tuned for the reader
+(ctrl+wheel zooms, shift+wheel stays a horizontal pan); the gap chord is
+deliberately one no browser binds.
+```
+
+- [ ] **Step 2: Full verification suite**
+
+```bash
+npx vitest run
+npm run check
+npm run lint
+```
+
+Expected: all pass. (`npm run lint` may flag pre-existing issues in files this branch never touched — only new complaints in touched files block.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/INPUT-CONTRACTS.md
+git commit -m "docs: record gap-adjust wheel chord in input contracts"
+```
+
+- [ ] **Step 4: Manual browser verification (dev server)**
+
+Start `npm run dev` in the worktree (use a free port if 5173 is owned by another worktree: `npm run dev -- --port 5180`). With a dual-page volume:
+
+1. Settings → paged + dual: "Page gap" slider appears; dragging it opens a visible gap that re-fits the spread. Single view mode: slider hidden.
+2. Ctrl+shift+scroll over the spread: gap widens/narrows live, toast "Page gap: Npx" shows, fit-to-screen keeps the whole spread visible at gap 100.
+3. RTL and LTR volumes both render the gap between pages.
+4. Ctrl+wheel still zooms; shift+wheel still pans horizontally; plain wheel unchanged.
+5. Continuous vertical + horizontal: chord adjusts divider size, toast shows, dividers auto-enable from 0 and auto-disable at 0; M toggle still works.
+6. Zoomed into a spread: gap scales with the zoom (gutter effect).

--- a/docs/superpowers/plans/2026-07-05-page-gap-234.md
+++ b/docs/superpowers/plans/2026-07-05-page-gap-234.md
@@ -25,10 +25,12 @@
 ### Task 1: `pagedGap` setting
 
 **Files:**
+
 - Modify: `src/lib/settings/settings.ts:166` (type), `src/lib/settings/settings.ts:313` (default)
 - Test: `src/lib/settings/settings.test.ts`
 
 **Interfaces:**
+
 - Produces: `Settings.pagedGap: number` (default `0`) — read by Tasks 4, 5, 7 as `$settings.pagedGap`.
 
 - [ ] **Step 1: Write the failing test**
@@ -55,8 +57,8 @@ Expected: FAIL — `expected undefined to be 0`
 In `src/lib/settings/settings.ts`, after the `scrollGap` type field (line ~166):
 
 ```typescript
-  scrollGap: number; // Pixels of padding between pages in scroll modes
-  pagedGap: number; // Gap between a paged-mode spread's two pages (image px, scales with zoom)
+scrollGap: number; // Pixels of padding between pages in scroll modes
+pagedGap: number; // Gap between a paged-mode spread's two pages (image px, scales with zoom)
 ```
 
 In `defaultSettings` after `scrollGap: 0,` (line ~313):
@@ -83,10 +85,12 @@ git commit -m "feat(settings): add pagedGap setting"
 ### Task 2: `spreadContentSize` helper
 
 **Files:**
+
 - Modify: `src/lib/reader/paged-zoom-layout.ts` (append after `panEdgeState`)
 - Test: `src/lib/reader/paged-zoom-layout.test.ts`
 
 **Interfaces:**
+
 - Consumes: `Size` (already exported from this module).
 - Produces: `spreadContentSize(first: Size, second: Size | null, gap: number): Size` — used by Task 4 in `Reader.svelte`.
 
@@ -159,11 +163,13 @@ git commit -m "feat(reader): spreadContentSize includes the pair gap in fit math
 ### Task 3: Gap wheel intent helpers
 
 **Files:**
+
 - Modify: `src/lib/reader/zoom-math.ts` (after `normalizeWheelDelta`, line ~120)
 - Test: `src/lib/reader/zoom-math.test.ts`
 - Modify: `docs/superpowers/specs/2026-07-05-page-gap-234-design.md` (amend helper section)
 
 **Interfaces:**
+
 - Consumes: `normalizeWheelDelta`, `WheelAccumulator` (same module).
 - Produces (used by Tasks 5–7):
   - `MAX_PAGE_GAP = 100` (const)
@@ -212,7 +218,10 @@ describe('gapWheelSteps', () => {
     const acc = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
     let total = 0;
     for (let i = 0; i < 4; i++) {
-      total += gapWheelSteps({ deltaX: 0, deltaY: -6, deltaMode: 0, timeStamp: 1000 + i * 16 }, acc);
+      total += gapWheelSteps(
+        { deltaX: 0, deltaY: -6, deltaMode: 0, timeStamp: 1000 + i * 16 },
+        acc
+      );
     }
     expect(total).toBe(1); // 24 wheel px accumulated -> one 20px step
   });
@@ -302,9 +311,11 @@ git commit -m "feat(reader): gap-adjust wheel intent helpers"
 ### Task 4: Paged rendering + fit math
 
 **Files:**
+
 - Modify: `src/lib/components/Reader/Reader.svelte:376-389` (pagedContentSize), `:1204-1211` (flex row), imports at top of `<script>`.
 
 **Interfaces:**
+
 - Consumes: `spreadContentSize` (Task 2), `$settings.pagedGap` (Task 1).
 - Produces: paged spread renders with `column-gap`; `pagedContentSize` includes the gap (PagedViewport re-fits automatically via its `contentSize` signature).
 
@@ -367,10 +378,12 @@ git commit -m "feat(reader): render pagedGap between spread pages (#234)"
 ### Task 5: Paged surface wheel chord + toast
 
 **Files:**
+
 - Modify: `src/lib/components/Reader/PagedViewport.svelte` (Props, imports, `handleWheel`)
 - Modify: `src/lib/components/Reader/Reader.svelte` (`handleGapChange` near `showNotification` line ~887; `onGapChange` prop at the `<PagedViewport` usage line ~1171)
 
 **Interfaces:**
+
 - Consumes: `wheelIntentIsGapAdjust`, `gapWheelSteps`, `WheelAccumulator`, `GAP_WHEEL_STEP_SIZE`, `MAX_PAGE_GAP` (Task 3); `updateSetting` from `$lib/settings`.
 - Produces: `PagedViewport` prop `onGapChange?: (px: number) => void`; Reader's `handleGapChange(px: number)` (reused by Task 6).
 
@@ -406,24 +419,24 @@ and add `onGapChange` to the destructuring.
 Above `handleWheel`, add:
 
 ```typescript
-  const gapAccumulator = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+const gapAccumulator = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
 
-  function adjustGap(delta: number) {
-    if (delta === 0) return;
-    const next = Math.max(0, Math.min(MAX_PAGE_GAP, ($settings.pagedGap ?? 0) + delta));
-    updateSetting('pagedGap', next);
-    onGapChange?.(next);
-  }
+function adjustGap(delta: number) {
+  if (delta === 0) return;
+  const next = Math.max(0, Math.min(MAX_PAGE_GAP, ($settings.pagedGap ?? 0) + delta));
+  updateSetting('pagedGap', next);
+  onGapChange?.(next);
+}
 ```
 
 At the TOP of `handleWheel` (before `const modifier = …`):
 
 ```typescript
-    if (wheelIntentIsGapAdjust(e)) {
-      e.preventDefault();
-      adjustGap(gapWheelSteps(e, gapAccumulator));
-      return;
-    }
+if (wheelIntentIsGapAdjust(e)) {
+  e.preventDefault();
+  adjustGap(gapWheelSteps(e, gapAccumulator));
+  return;
+}
 ```
 
 - [ ] **Step 2: Wire the toast in Reader**
@@ -431,9 +444,9 @@ At the TOP of `handleWheel` (before `const modifier = …`):
 In `src/lib/components/Reader/Reader.svelte`, after the `showNotification` function (line ~901):
 
 ```typescript
-  function handleGapChange(px: number) {
-    showNotification(`Page gap: ${px}px`, 'page-gap');
-  }
+function handleGapChange(px: number) {
+  showNotification(`Page gap: ${px}px`, 'page-gap');
+}
 ```
 
 At the `<PagedViewport` usage (line ~1171), add the prop:
@@ -468,11 +481,13 @@ git commit -m "feat(reader): ctrl+shift+scroll adjusts pagedGap in paged mode"
 ### Task 6: Scroll surfaces wheel chord
 
 **Files:**
+
 - Modify: `src/lib/components/Reader/HorizontalScrollReader.svelte` (Props line ~21, imports, `handleWheel` line ~346)
 - Modify: `src/lib/components/Reader/VerticalScrollReader.svelte` (Props line ~21, imports, `handleWheel` line ~343)
 - Modify: `src/lib/components/Reader/Reader.svelte` (pass `onGapChange={handleGapChange}` to both usages, lines ~1140-1166)
 
 **Interfaces:**
+
 - Consumes: Task 3 helpers; Reader's `handleGapChange` (Task 5); `updateSetting` from `$lib/settings` (both files already import `settings`; extend that import).
 - Produces: both scroll readers accept `onGapChange?: (px: number) => void`; the chord writes `scrollGap` and syncs `pageDividers = gap > 0`.
 
@@ -492,28 +507,28 @@ Add to `interface Props` (after `onOverlayToggle?`) and to the `$props()` destru
 Add above `handleWheel`:
 
 ```typescript
-  const gapAccumulator = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+const gapAccumulator = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
 
-  // The chord drives the continuous-mode dividers: gap > 0 means dividers on,
-  // reaching 0 turns them off (the M toggle keeps working independently).
-  function adjustGap(delta: number) {
-    if (delta === 0) return;
-    const next = Math.max(0, Math.min(MAX_PAGE_GAP, $settings.scrollGap + delta));
-    updateSetting('scrollGap', next);
-    const dividers = next > 0;
-    if ($settings.pageDividers !== dividers) updateSetting('pageDividers', dividers);
-    onGapChange?.(next);
-  }
+// The chord drives the continuous-mode dividers: gap > 0 means dividers on,
+// reaching 0 turns them off (the M toggle keeps working independently).
+function adjustGap(delta: number) {
+  if (delta === 0) return;
+  const next = Math.max(0, Math.min(MAX_PAGE_GAP, $settings.scrollGap + delta));
+  updateSetting('scrollGap', next);
+  const dividers = next > 0;
+  if ($settings.pageDividers !== dividers) updateSetting('pageDividers', dividers);
+  onGapChange?.(next);
+}
 ```
 
 In `handleWheel`, directly after the `if (!scrollContainer) return;` guard (both files):
 
 ```typescript
-    if (wheelIntentIsGapAdjust(e)) {
-      e.preventDefault();
-      adjustGap(gapWheelSteps(e, gapAccumulator));
-      return;
-    }
+if (wheelIntentIsGapAdjust(e)) {
+  e.preventDefault();
+  adjustGap(gapWheelSteps(e, gapAccumulator));
+  return;
+}
 ```
 
 (In VerticalScrollReader the `preventDefault` matters doubly: the surface scrolls natively, and without it the browser would treat ctrl+wheel as page zoom.)
@@ -541,9 +556,11 @@ git commit -m "feat(reader): ctrl+shift+scroll adjusts dividers in continuous mo
 ### Task 7: Settings UI
 
 **Files:**
+
 - Modify: `src/lib/components/Settings/Reader/ReaderSettings.svelte` (isPaged block line ~90-104; divider slider label line ~127)
 
 **Interfaces:**
+
 - Consumes: `$settings.pagedGap`, `updateSetting` (already imported), `MAX_PAGE_GAP` (Task 3), `Range`/`Label` (already imported).
 
 - [ ] **Step 1: Add the paged gap slider**
@@ -574,10 +591,10 @@ Inside the `{#if isPaged}` block, after the page-view-mode `</div>` (line ~103),
 Change the divider-size label (line ~127) to:
 
 ```svelte
-          <Label class="text-gray-900 dark:text-white">
-            Divider size: {$settings.scrollGap}px
-            <span class="ml-2 text-xs text-gray-500 dark:text-gray-400">(Ctrl+Shift+Scroll)</span>
-          </Label>
+<Label class="text-gray-900 dark:text-white">
+  Divider size: {$settings.scrollGap}px
+  <span class="ml-2 text-xs text-gray-500 dark:text-gray-400">(Ctrl+Shift+Scroll)</span>
+</Label>
 ```
 
 and change that slider's `max={100}` to `max={MAX_PAGE_GAP}`.
@@ -599,6 +616,7 @@ git commit -m "feat(settings): page gap slider + chord hints"
 ### Task 8: Input contracts doc + full verification
 
 **Files:**
+
 - Modify: `docs/INPUT-CONTRACTS.md:115` (wheel row) + new paragraph after the matrix
 
 - [ ] **Step 1: Update the contracts doc**
@@ -606,7 +624,7 @@ git commit -m "feat(settings): page gap slider + chord hints"
 Change the wheel row of the per-surface policy matrix:
 
 ```markdown
-| Wheel          | zoom, gap, or camera glide        | zoom, gap, or (native/strip) scroll     |
+| Wheel | zoom, gap, or camera glide | zoom, gap, or (native/strip) scroll |
 ```
 
 After the matrix table, add:

--- a/docs/superpowers/specs/2026-07-05-page-gap-234-design.md
+++ b/docs/superpowers/specs/2026-07-05-page-gap-234-design.md
@@ -76,13 +76,13 @@ native meaning in any major browser: ctrl+shift+wheel.
 
 ### Wheel-to-gap helper
 
-- `gapWheelStep` lives in `src/lib/reader/zoom-math.ts` next to
-  `normalizeWheelDelta`/`wheelIntentIsZoom`.
-- Converts a wheel event to a gap delta: ~5px per standard wheel notch,
-  normalized by `deltaMode`, sign flipped so scroll-up widens.
-- Fractional deltas accumulate across events (surface-local accumulator) so
-  trackpad streams of tiny deltas don't stall at zero; result clamped 0–100
-  and rounded on write.
+- `wheelIntentIsGapAdjust` + `gapWheelSteps` live in
+  `src/lib/reader/zoom-math.ts` next to `normalizeWheelDelta`/
+  `wheelIntentIsZoom`, reusing the existing `WheelAccumulator`
+  (idle + direction-flip resets) at `GAP_WHEEL_STEP_SIZE = 20` wheel px per
+  1px of gap — one ~100px notch = 5px, trackpad streams accumulate.
+- Sign flipped so scroll-up widens; result clamped 0–`MAX_PAGE_GAP` (100) at
+  the write site.
 
 ### Feedback toast
 
@@ -95,8 +95,8 @@ native meaning in any major browser: ctrl+shift+wheel.
 ### Settings UI
 
 - `ReaderSettings.svelte`, inside the `isPaged` block: "Page gap: Npx" label
-  + `Range` slider (0–100), shown when `$settings.singlePageView !== 'single'`.
-  No toggle — 0 means off.
+  - `Range` slider (0–100), shown when `$settings.singlePageView !== 'single'`.
+    No toggle — 0 means off.
 - Both the new paged slider and the existing continuous divider slider get a
   "(Ctrl+Shift+Scroll)" hint, like the existing "(M)"/"(P)" hints.
 

--- a/docs/superpowers/specs/2026-07-05-page-gap-234-design.md
+++ b/docs/superpowers/specs/2026-07-05-page-gap-234-design.md
@@ -1,0 +1,132 @@
+# Page gap for paged dual-page mode + ctrl+shift+scroll adjustment (issue #234)
+
+**Date:** 2026-07-05
+**Issue:** [#234](https://github.com/Gnathonic/mokuro-reader/issues/234) — Page gap for Dual Page mode
+**Branch:** `feat/page-gap-234`
+
+## Problem
+
+Many manga scans don't align cleanly across a two-page spread. Continuous
+modes already offer a gap ("Page dividers" toggle + `scrollGap` slider), but
+paged dual-page mode renders the two pages flush, so misaligned spreads read
+as one broken image. Users want an adjustable gap in paged mode too — and a
+quick way to tune it without opening the settings panel.
+
+## Design
+
+### New setting: `pagedGap`
+
+- `pagedGap: number` added to `Settings` (`src/lib/settings/settings.ts`),
+  default `0`, range 0–100.
+- Independent from `scrollGap`: the two live in different coordinate spaces
+  (continuous gap is layout px at fit scale; paged gap is image-pixel space)
+  and users may want different tuning per mode.
+- Persisted and synced like every other profile setting; profiles without the
+  key fall back to the default.
+
+### Rendering (paged mode)
+
+- `Reader.svelte` adds `column-gap: {$settings.pagedGap}px` to the paged flex
+  row (the `col-start-1 row-start-1 flex flex-row` div holding the one or two
+  `MangaPage`s).
+- The gap lives in image-pixel space, pre-camera-transform: it scales with
+  zoom like a physical gutter. The reader background (`var(--reader-bg)`)
+  shows through, matching continuous mode.
+- With a single page displayed `column-gap` is inert — no markup conditionals.
+- Works with both `flex-row` and `flex-row-reverse` (RTL/LTR).
+
+### Fit math
+
+- `pagedContentSize` (`Reader.svelte`) must include the gap when a second
+  page is shown, or fit-to-screen/width, pan clamping, and swipe edge
+  detection are off by the gap width.
+- Extract a pure helper into `src/lib/reader/paged-zoom-layout.ts`:
+  `spreadContentSize(first: Size, second: Size | null, gap: number): Size` —
+  width = sum + gap when `second` present, plain page size otherwise.
+- `PagedViewport` re-applies its base on `contentSize` changes, so adjusting
+  the gap mid-read re-fits automatically. Zoom anchoring measures DOM rects
+  (`[data-page-index]`), so it stays consistent with whatever CSS renders.
+
+### Hotkey: ctrl+shift+scroll (all three reader surfaces)
+
+**Binding principle** (why ctrl+shift): combos with a native browser meaning
+are overridden only with the same action tuned for the reader — ctrl+wheel
+is zoom, wheel is scroll, shift+wheel is horizontal scroll (paged wheel-pan
+already feeds `deltaX`). Gap adjustment therefore takes a combo with no
+native meaning in any major browser: ctrl+shift+wheel.
+
+- Each surface's `handleWheel` (`PagedViewport`, `HorizontalScrollReader`,
+  `VerticalScrollReader`) checks `(ctrlKey || metaKey) && shiftKey` FIRST —
+  before `wheelIntentIsZoom` — and treats it as gap-adjust intent with
+  `preventDefault()`.
+- Scroll up widens, scroll down narrows (mirrors ctrl+wheel-up = zoom in).
+- **Axis quirk:** with shift held, browsers report the wheel delta in
+  `deltaX`, not `deltaY`. The helper reads whichever axis is nonzero.
+- **Which setting:**
+  - Paged surface → `pagedGap`. Works in dual and auto view modes; if a
+    single page is currently displayed the value still updates and applies
+    on the next spread.
+  - Both continuous surfaces → `scrollGap`, and sync
+    `pageDividers = gap > 0` (scrolling up from zero enables dividers,
+    reaching zero disables them; the M toggle keeps working).
+- **Non-collisions:** trackpad pinch arrives as synthetic ctrl+wheel without
+  `shiftKey` — never misread. macOS accessibility screen-zoom (Control+scroll,
+  off by default) swallows the chord at the OS level, but it equally breaks
+  the existing ctrl+wheel zoom, so nothing regresses.
+
+### Wheel-to-gap helper
+
+- `gapWheelStep` lives in `src/lib/reader/zoom-math.ts` next to
+  `normalizeWheelDelta`/`wheelIntentIsZoom`.
+- Converts a wheel event to a gap delta: ~5px per standard wheel notch,
+  normalized by `deltaMode`, sign flipped so scroll-up widens.
+- Fractional deltas accumulate across events (surface-local accumulator) so
+  trackpad streams of tiny deltas don't stall at zero; result clamped 0–100
+  and rounded on write.
+
+### Feedback toast
+
+- Each surface gets an `onGapChange?: (px: number) => void` callback prop
+  (consistent with the existing intent-callback pattern; Reader owns
+  notifications).
+- Reader wires it to the existing keyed `showNotification`:
+  "Page gap: 24px" — 2s timeout and Migaku-safe `{#key}` handling for free.
+
+### Settings UI
+
+- `ReaderSettings.svelte`, inside the `isPaged` block: "Page gap: Npx" label
+  + `Range` slider (0–100), shown when `$settings.singlePageView !== 'single'`.
+  No toggle — 0 means off.
+- Both the new paged slider and the existing continuous divider slider get a
+  "(Ctrl+Shift+Scroll)" hint, like the existing "(M)"/"(P)" hints.
+
+### Docs
+
+- `docs/INPUT-CONTRACTS.md`: wheel row updated — wheel intent is now
+  zoom / gap-adjust / scroll, and the binding principle above recorded.
+
+## Performance
+
+Live adjustment costs the same as dragging the existing sliders: both
+continuous readers already key layout on `scrollGap`; the paged surface
+re-fits via the `contentSize` signature. Settings writes hit the
+localStorage-synced store per step — same as slider drags today.
+
+## Testing
+
+- Unit: `spreadContentSize` (gap only when second page present, zero-gap
+  passthrough, height = max of pair).
+- Unit: `gapWheelStep` (shift axis-swap, direction, deltaMode normalization,
+  clamping at 0 and 100, trackpad accumulation reaching whole px).
+- Existing paged-zoom-layout unit + e2e suites are unaffected: they treat
+  `contentSize` as opaque input.
+- Manual (dev server): dual mode gap renders and re-fits; single page
+  unaffected; RTL and LTR; ctrl+shift+scroll in all three surfaces with
+  toast; continuous divider auto-toggle at zero; ctrl+wheel zoom and
+  shift+wheel horizontal pan unchanged.
+
+## Out of scope
+
+- Per-volume gap overrides (profile-level setting only).
+- A visible divider line (background showthrough only, as in continuous).
+- Keyboard-key binding for gap (wheel chord + slider suffice).

--- a/src/lib/components/Reader/HorizontalScrollReader.svelte
+++ b/src/lib/components/Reader/HorizontalScrollReader.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Page, VolumeMetadata } from '$lib/types';
   import type { VolumeSettings } from '$lib/settings/volume-data';
-  import { settings, imageFilter } from '$lib/settings';
+  import { settings, imageFilter, updateSetting } from '$lib/settings';
   import { matchFilesToPages } from '$lib/reader/image-cache';
   import { getCharCount } from '$lib/util/count-chars';
   import { activityTracker } from '$lib/util/activity-tracker';
@@ -10,7 +10,15 @@
   import { ContinuousZoomController, type SettleReason } from '$lib/reader/zoom-controller';
   import { applyHorizontalAlignment, applyHorizontalZoomLayout } from '$lib/reader/zoom-layout';
   import { detectHorizontalPage, horizontalVisibilityRatio } from '$lib/reader/page-detection';
-  import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
+  import {
+    GAP_WHEEL_STEP_SIZE,
+    MAX_PAGE_GAP,
+    WheelAccumulator,
+    gapWheelSteps,
+    normalizeWheelDelta,
+    wheelIntentIsGapAdjust,
+    wheelIntentIsZoom
+  } from '$lib/reader/zoom-math';
   import { gestureTargetRole, keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
   import { volumeEdgeNav } from '$lib/reader/page-nav';
   import { PointerGestureTracker, zoomGestureConfig } from '$lib/reader/input/pointer-tracker';
@@ -27,6 +35,8 @@
     onPageChange: (newPage: number, charCount: number, isComplete: boolean) => void;
     onVolumeNav: (direction: 'prev' | 'next') => void;
     onOverlayToggle?: () => void;
+    /** The gap-adjust wheel chord changed the divider gap to this value (px). */
+    onGapChange?: (px: number) => void;
     onVisibleCountChange?: (count: number) => void;
     onContextMenu?: (data: any) => void;
   }
@@ -40,6 +50,7 @@
     onPageChange,
     onVolumeNav,
     onOverlayToggle,
+    onGapChange,
     onVisibleCountChange,
     onContextMenu
   }: Props = $props();
@@ -343,8 +354,26 @@
   // Wheel — scroll along strip or zoom
   // ============================================================
 
+  const gapAccumulator = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+
+  // The chord drives the continuous-mode dividers: gap > 0 means dividers on,
+  // reaching 0 turns them off (the M toggle keeps working independently).
+  function adjustGap(delta: number) {
+    if (delta === 0) return;
+    const next = Math.max(0, Math.min(MAX_PAGE_GAP, $settings.scrollGap + delta));
+    updateSetting('scrollGap', next);
+    const dividers = next > 0;
+    if ($settings.pageDividers !== dividers) updateSetting('pageDividers', dividers);
+    onGapChange?.(next);
+  }
+
   function handleWheel(e: WheelEvent) {
     if (!scrollContainer) return;
+    if (wheelIntentIsGapAdjust(e)) {
+      e.preventDefault();
+      adjustGap(gapWheelSteps(e, gapAccumulator));
+      return;
+    }
     const modifier = e.ctrlKey || e.metaKey;
 
     if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {

--- a/src/lib/components/Reader/PagedViewport.svelte
+++ b/src/lib/components/Reader/PagedViewport.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { onDestroy, onMount } from 'svelte';
-  import { settings } from '$lib/settings';
+  import { settings, updateSetting } from '$lib/settings';
   import { PagedCamera } from '$lib/reader/paged-camera';
   import { ContinuousZoomController } from '$lib/reader/zoom-controller';
   import type { Size } from '$lib/reader/paged-zoom-layout';
@@ -11,7 +11,15 @@
     doubleTapTarget,
     pagedLevels
   } from '$lib/reader/paged-zoom-session';
-  import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
+  import {
+    GAP_WHEEL_STEP_SIZE,
+    MAX_PAGE_GAP,
+    WheelAccumulator,
+    gapWheelSteps,
+    normalizeWheelDelta,
+    wheelIntentIsGapAdjust,
+    wheelIntentIsZoom
+  } from '$lib/reader/zoom-math';
   import { pagedZoom, type PagedZoomApi } from '$lib/reader/paged-zoom';
   import { PointerGestureTracker, zoomGestureConfig } from '$lib/reader/input/pointer-tracker';
   import { gestureTargetRole } from '$lib/reader/input/gesture-target';
@@ -37,10 +45,13 @@
     onPageFlip?: (side: 'left' | 'right') => void;
     /** A lone tap on the page surface (not text box / chrome). */
     onOverlayToggle?: () => void;
+    /** The gap-adjust wheel chord changed the page gap to this value (px). */
+    onGapChange?: (px: number) => void;
     children?: Snippet;
   }
 
-  let { contentSize, pageKey, rtl, onPageFlip, onOverlayToggle, children }: Props = $props();
+  let { contentSize, pageKey, rtl, onPageFlip, onOverlayToggle, onGapChange, children }: Props =
+    $props();
 
   let wrapperEl: HTMLDivElement | undefined = $state();
   let viewportWidth = $state(typeof window !== 'undefined' ? window.innerWidth : 1024);
@@ -130,7 +141,21 @@
     // through the pageKey effect.
   };
 
+  const gapAccumulator = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+
+  function adjustGap(delta: number) {
+    if (delta === 0) return;
+    const next = Math.max(0, Math.min(MAX_PAGE_GAP, ($settings.pagedGap ?? 0) + delta));
+    updateSetting('pagedGap', next);
+    onGapChange?.(next);
+  }
+
   function handleWheel(e: WheelEvent) {
+    if (wheelIntentIsGapAdjust(e)) {
+      e.preventDefault();
+      adjustGap(gapWheelSteps(e, gapAccumulator));
+      return;
+    }
     const modifier = e.ctrlKey || e.metaKey;
     if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {
       e.preventDefault();

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -5,6 +5,7 @@
   import { currentSeries, currentVolume, currentVolumeData } from '$lib/catalog';
   import PagedViewport from './PagedViewport.svelte';
   import { pagedZoom } from '$lib/reader/paged-zoom';
+  import { spreadContentSize } from '$lib/reader/paged-zoom-layout';
   import { setInstantAnimations } from '$lib/reader/animator';
   import { keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
   import { toggleFullScreen } from '$lib/util/fullscreen';
@@ -377,15 +378,12 @@
     const pgs = pages;
     const idx = index;
     if (!pgs || pgs.length === 0 || !pgs[idx]) return { width: 0, height: 0 };
-    const first = pgs[idx];
-    if (showSecondPage() && pgs[idx + 1]) {
-      const second = pgs[idx + 1];
-      return {
-        width: first.img_width + second.img_width,
-        height: Math.max(first.img_height, second.img_height)
-      };
-    }
-    return { width: first.img_width, height: first.img_height };
+    const first = { width: pgs[idx].img_width, height: pgs[idx].img_height };
+    const second =
+      showSecondPage() && pgs[idx + 1]
+        ? { width: pgs[idx + 1].img_width, height: pgs[idx + 1].img_height }
+        : null;
+    return spreadContentSize(first, second, $settings.pagedGap ?? 0);
   });
 
   // Fire reader closed event when component is destroyed (navigating away)
@@ -1206,6 +1204,7 @@
             <div
               class="col-start-1 row-start-1 flex flex-row"
               class:flex-row-reverse={!volumeSettings.rightToLeft}
+              style:column-gap={`${$settings.pagedGap ?? 0}px`}
               in:pageIn={{ direction: pageDirection }}
               out:pageOut={{ direction: pageDirection }}
             >

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -898,6 +898,10 @@
     }, 2000);
   }
 
+  function handleGapChange(px: number) {
+    showNotification(`Page gap: ${px}px`, 'page-gap');
+  }
+
   // Shared toggle for the Manual/Scheduled display filters (night, invert,
   // B&W). When the schedule owns the filter we only notify; otherwise flip
   // the manual boolean and announce the state we just wrote. (The old code
@@ -1172,6 +1176,7 @@
         rtl={volumeSettings.rightToLeft ?? true}
         onPageFlip={(side) => (side === 'left' ? left(null, true) : right(null, true))}
         onOverlayToggle={() => (overlaysVisible = !overlaysVisible)}
+        onGapChange={handleGapChange}
       >
         <button
           aria-label="Previous page (left edge)"

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -1151,6 +1151,7 @@
         onPageChange={handleContinuousPageChange}
         onVolumeNav={handleContinuousVolumeNav}
         onOverlayToggle={() => (overlaysVisible = !overlaysVisible)}
+        onGapChange={handleGapChange}
         onContextMenu={handleTextBoxContextMenu}
       />
     {:else}
@@ -1164,6 +1165,7 @@
         onVolumeNav={handleContinuousVolumeNav}
         onVisibleCountChange={(count) => (continuousVisibleCount = count)}
         onOverlayToggle={() => (overlaysVisible = !overlaysVisible)}
+        onGapChange={handleGapChange}
         onContextMenu={handleTextBoxContextMenu}
       />
     {/if}

--- a/src/lib/components/Reader/VerticalScrollReader.svelte
+++ b/src/lib/components/Reader/VerticalScrollReader.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Page, VolumeMetadata } from '$lib/types';
   import type { VolumeSettings } from '$lib/settings/volume-data';
-  import { settings, imageFilter } from '$lib/settings';
+  import { settings, imageFilter, updateSetting } from '$lib/settings';
   import { matchFilesToPages } from '$lib/reader/image-cache';
   import { getCharCount } from '$lib/util/count-chars';
   import { activityTracker } from '$lib/util/activity-tracker';
@@ -10,7 +10,15 @@
   import { ContinuousZoomController, type SettleReason } from '$lib/reader/zoom-controller';
   import { applyVerticalZoomLayout } from '$lib/reader/zoom-layout';
   import { closestPageToCenter } from '$lib/reader/page-detection';
-  import { normalizeWheelDelta, wheelIntentIsZoom } from '$lib/reader/zoom-math';
+  import {
+    GAP_WHEEL_STEP_SIZE,
+    MAX_PAGE_GAP,
+    WheelAccumulator,
+    gapWheelSteps,
+    normalizeWheelDelta,
+    wheelIntentIsGapAdjust,
+    wheelIntentIsZoom
+  } from '$lib/reader/zoom-math';
   import { gestureTargetRole, keyboardShouldIgnore } from '$lib/reader/input/gesture-target';
   import { volumeEdgeNav } from '$lib/reader/page-nav';
   import { PointerGestureTracker, zoomGestureConfig } from '$lib/reader/input/pointer-tracker';
@@ -27,6 +35,8 @@
     onPageChange: (newPage: number, charCount: number, isComplete: boolean) => void;
     onVolumeNav: (direction: 'prev' | 'next') => void;
     onOverlayToggle?: () => void;
+    /** The gap-adjust wheel chord changed the divider gap to this value (px). */
+    onGapChange?: (px: number) => void;
     onContextMenu?: (data: any) => void;
   }
 
@@ -39,6 +49,7 @@
     onPageChange,
     onVolumeNav,
     onOverlayToggle,
+    onGapChange,
     onContextMenu
   }: Props = $props();
 
@@ -340,8 +351,26 @@
   // Wheel — scroll or zoom
   // ============================================================
 
+  const gapAccumulator = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+
+  // The chord drives the continuous-mode dividers: gap > 0 means dividers on,
+  // reaching 0 turns them off (the M toggle keeps working independently).
+  function adjustGap(delta: number) {
+    if (delta === 0) return;
+    const next = Math.max(0, Math.min(MAX_PAGE_GAP, $settings.scrollGap + delta));
+    updateSetting('scrollGap', next);
+    const dividers = next > 0;
+    if ($settings.pageDividers !== dividers) updateSetting('pageDividers', dividers);
+    onGapChange?.(next);
+  }
+
   function handleWheel(e: WheelEvent) {
     if (!scrollContainer) return;
+    if (wheelIntentIsGapAdjust(e)) {
+      e.preventDefault();
+      adjustGap(gapWheelSteps(e, gapAccumulator));
+      return;
+    }
     const modifier = e.ctrlKey || e.metaKey;
 
     if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {

--- a/src/lib/components/Settings/Reader/ReaderSettings.svelte
+++ b/src/lib/components/Settings/Reader/ReaderSettings.svelte
@@ -15,6 +15,7 @@
   } from '$lib/settings';
   import { isReader } from '$lib/util';
   import { routeParams } from '$lib/util/hash-router';
+  import { MAX_PAGE_GAP } from '$lib/reader/zoom-math';
 
   // Derived visibility flags
   let isContinuous = $derived($settings.continuousScroll);
@@ -101,6 +102,21 @@
           onchange={onPageViewModeChange}
         />
       </div>
+      {#if isDualOrAuto}
+        <div>
+          <Label class="text-gray-900 dark:text-white">
+            Page gap: {$settings.pagedGap}px
+            <span class="ml-2 text-xs text-gray-500 dark:text-gray-400">(Ctrl+Shift+Scroll)</span>
+          </Label>
+          <Range
+            min={0}
+            max={MAX_PAGE_GAP}
+            value={$settings.pagedGap}
+            onchange={(e) =>
+              updateSetting('pagedGap', Number((e.target as HTMLInputElement).value))}
+          />
+        </div>
+      {/if}
     {/if}
 
     <!-- 3. If continuous: Scroll mode dropdown + gap slider -->
@@ -126,10 +142,11 @@
         <div>
           <Label class="text-gray-900 dark:text-white">
             Divider size: {$settings.scrollGap}px
+            <span class="ml-2 text-xs text-gray-500 dark:text-gray-400">(Ctrl+Shift+Scroll)</span>
           </Label>
           <Range
             min={0}
-            max={100}
+            max={MAX_PAGE_GAP}
             value={$settings.scrollGap}
             onchange={(e) =>
               updateSetting('scrollGap', Number((e.target as HTMLInputElement).value))}

--- a/src/lib/reader/paged-zoom-layout.test.ts
+++ b/src/lib/reader/paged-zoom-layout.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { alignPosition, baseTransform, clampTranslate, panEdgeState } from './paged-zoom-layout';
+import {
+  alignPosition,
+  baseTransform,
+  clampTranslate,
+  panEdgeState,
+  spreadContentSize
+} from './paged-zoom-layout';
 
 const viewport = { width: 1600, height: 900 };
 
@@ -188,5 +194,26 @@ describe('panEdgeState', () => {
     const s = panEdgeState({ x: 200, y: 0 }, { width: 1200, height: 900 }, viewport);
     expect(s.canRevealLeft).toBe(false);
     expect(s.canRevealRight).toBe(false);
+  });
+});
+
+describe('spreadContentSize', () => {
+  const a = { width: 700, height: 1000 };
+  const b = { width: 720, height: 980 };
+
+  it('passes a single page through untouched, ignoring the gap', () => {
+    expect(spreadContentSize(a, null, 24)).toEqual({ width: 700, height: 1000 });
+  });
+
+  it('sums pair widths plus the gap; height is the taller page', () => {
+    expect(spreadContentSize(a, b, 24)).toEqual({ width: 1444, height: 1000 });
+  });
+
+  it('zero gap renders the pair flush', () => {
+    expect(spreadContentSize(a, b, 0)).toEqual({ width: 1420, height: 1000 });
+  });
+
+  it('clamps a negative gap to flush', () => {
+    expect(spreadContentSize(a, b, -10)).toEqual({ width: 1420, height: 1000 });
   });
 });

--- a/src/lib/reader/paged-zoom-layout.ts
+++ b/src/lib/reader/paged-zoom-layout.ts
@@ -186,3 +186,17 @@ export function panEdgeState(
     canRevealRight: translate.x > minX + EDGE_EPSILON
   };
 }
+
+/**
+ * Native-pixel content size of the displayed page or pair. The gap between a
+ * pair lives in image-pixel space (it scales with zoom like a physical
+ * gutter) and must be part of the content size, or fit modes, pan clamping,
+ * and swipe edge detection are all off by the gap width.
+ */
+export function spreadContentSize(first: Size, second: Size | null, gap: number): Size {
+  if (!second) return { width: first.width, height: first.height };
+  return {
+    width: first.width + second.width + Math.max(0, gap),
+    height: Math.max(first.height, second.height)
+  };
+}

--- a/src/lib/reader/zoom-math.test.ts
+++ b/src/lib/reader/zoom-math.test.ts
@@ -7,6 +7,9 @@ import {
   nearestZoomLevel,
   nextZoomLevel,
   wheelIntentIsZoom,
+  wheelIntentIsGapAdjust,
+  gapWheelSteps,
+  GAP_WHEEL_STEP_SIZE,
   normalizeWheelDelta,
   WheelAccumulator,
   pinchDistance,
@@ -225,5 +228,56 @@ describe('pinchDistance / pinchMidpoint', () => {
   it('returns safe values with fewer than two points', () => {
     expect(pinchDistance([{ x: 5, y: 5 }])).toBe(0);
     expect(pinchMidpoint([])).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe('wheelIntentIsGapAdjust', () => {
+  it('requires ctrl or meta plus shift', () => {
+    expect(wheelIntentIsGapAdjust({ ctrlKey: true, metaKey: false, shiftKey: true })).toBe(true);
+    expect(wheelIntentIsGapAdjust({ ctrlKey: false, metaKey: true, shiftKey: true })).toBe(true);
+  });
+
+  it('rejects partial chords', () => {
+    expect(wheelIntentIsGapAdjust({ ctrlKey: true, metaKey: false, shiftKey: false })).toBe(false);
+    expect(wheelIntentIsGapAdjust({ ctrlKey: false, metaKey: false, shiftKey: true })).toBe(false);
+    expect(wheelIntentIsGapAdjust({ ctrlKey: false, metaKey: false, shiftKey: false })).toBe(false);
+  });
+});
+
+describe('gapWheelSteps', () => {
+  it('one mouse notch widens by 5px when shift swaps the delta to deltaX (Chromium)', () => {
+    const acc = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+    const px = gapWheelSteps({ deltaX: -100, deltaY: 0, deltaMode: 0, timeStamp: 1000 }, acc);
+    expect(px).toBe(5);
+  });
+
+  it('prefers deltaY when the browser keeps it there (Firefox)', () => {
+    const acc = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+    const px = gapWheelSteps({ deltaX: 7, deltaY: -100, deltaMode: 0, timeStamp: 1000 }, acc);
+    expect(px).toBe(5);
+  });
+
+  it('scroll down narrows', () => {
+    const acc = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+    const px = gapWheelSteps({ deltaX: 0, deltaY: 100, deltaMode: 0, timeStamp: 1000 }, acc);
+    expect(px).toBe(-5);
+  });
+
+  it('accumulates a trackpad stream of sub-step deltas into whole px', () => {
+    const acc = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+    let total = 0;
+    for (let i = 0; i < 4; i++) {
+      total += gapWheelSteps(
+        { deltaX: 0, deltaY: -6, deltaMode: 0, timeStamp: 1000 + i * 16 },
+        acc
+      );
+    }
+    expect(total).toBe(1); // 24 wheel px accumulated -> one 20px step
+  });
+
+  it('normalizes line-mode deltas (Firefox wheel)', () => {
+    const acc = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
+    const px = gapWheelSteps({ deltaX: 0, deltaY: -3, deltaMode: 1, timeStamp: 1000 }, acc);
+    expect(px).toBe(6); // 3 lines * 40px = 120 wheel px -> six 20px steps
   });
 });

--- a/src/lib/reader/zoom-math.ts
+++ b/src/lib/reader/zoom-math.ts
@@ -119,6 +119,39 @@ export function normalizeWheelDelta(deltaY: number, deltaMode: number): number {
   return deltaY;
 }
 
+/** Upper bound shared by the gap sliders and the wheel chord (px). */
+export const MAX_PAGE_GAP = 100;
+
+/** Wheel px per 1px of gap: one classic ~100px notch adjusts by 5px. */
+export const GAP_WHEEL_STEP_SIZE = 20;
+
+/**
+ * Whether a wheel event means "adjust the page gap": ctrl/meta+shift+wheel.
+ * Checked BEFORE the zoom intent — combos with a native browser meaning
+ * (ctrl+wheel zoom, shift+wheel horizontal scroll) keep that meaning tuned
+ * for the reader; the gap chord is unbound in every major browser.
+ */
+export function wheelIntentIsGapAdjust(
+  e: Pick<WheelEvent, 'ctrlKey' | 'metaKey' | 'shiftKey'>
+): boolean {
+  return (e.ctrlKey || e.metaKey) && e.shiftKey;
+}
+
+/**
+ * Signed gap change (px) for a gap-adjust wheel event; positive widens
+ * (wheel up). With shift held Chromium reports the notch in deltaX while
+ * Firefox keeps deltaY — read whichever is nonzero. Feed each surface's own
+ * WheelAccumulator(GAP_WHEEL_STEP_SIZE) so trackpad streams accumulate
+ * instead of stalling below one step.
+ */
+export function gapWheelSteps(
+  e: Pick<WheelEvent, 'deltaX' | 'deltaY' | 'deltaMode' | 'timeStamp'>,
+  acc: WheelAccumulator
+): number {
+  const raw = e.deltaY !== 0 ? e.deltaY : e.deltaX;
+  return acc.add(normalizeWheelDelta(raw, e.deltaMode), e.timeStamp);
+}
+
 /**
  * Accumulates normalized wheel deltas into discrete zoom level steps.
  *

--- a/src/lib/settings/settings.test.ts
+++ b/src/lib/settings/settings.test.ts
@@ -40,6 +40,13 @@ describe('theme migration', () => {
   });
 });
 
+describe('pagedGap migration', () => {
+  it('fills pagedGap with its default for profiles saved before the setting existed', () => {
+    const migrated = migrateProfiles({ Default: { dark: true } } as any);
+    expect(migrated.Default.pagedGap).toBe(0);
+  });
+});
+
 describe('grayscaleActive', () => {
   beforeEach(() => {
     // Known baseline: manual mode, filter off

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -164,6 +164,7 @@ export type Settings = {
   continuousZoomDefault: ContinuousZoomMode;
   pageDividers: boolean; // Enable dividers between pages in continuous scroll modes
   scrollGap: number; // Pixels of padding between pages in scroll modes
+  pagedGap: number; // Gap between a paged-mode spread's two pages (image px, scales with zoom)
   /** @deprecated Removed — kept for settings migration compatibility */
   seamlessSpreads?: boolean;
   scrollSnap: boolean;
@@ -311,6 +312,7 @@ const defaultSettings: Settings = {
   continuousZoomDefault: 'zoomFitToScreen',
   pageDividers: false,
   scrollGap: 0,
+  pagedGap: 0,
   seamlessSpreads: undefined,
   scrollSnap: true,
   volumeDefaults: {


### PR DESCRIPTION
Resolves #234.

## What

- **New \`pagedGap\` setting** (0–100): renders as \`column-gap\` between the two pages of a paged-mode spread. The gap lives in image-pixel space, so it scales with zoom like a physical gutter. Slider appears in reader settings when page view mode is dual/auto.
- **Fit math stays exact**: new pure \`spreadContentSize()\` helper includes the gap in the paged content size, so fit-to-screen/width, pan clamping, and swipe edge detection account for it.
- **Ctrl+shift+scroll** live-adjusts the gap on all three reader surfaces: paged writes \`pagedGap\`; continuous modes write \`scrollGap\` and auto-sync \`pageDividers\` (0 = off). Keyed toast shows the current value.

## Binding rationale

Wheel combos with a native browser meaning keep that meaning tuned for the reader (ctrl+wheel = zoom, shift+wheel = horizontal pan); gap adjustment takes ctrl+shift+wheel, which no browser binds. Recorded in \`docs/INPUT-CONTRACTS.md\`. Handles the browser quirk where shift moves the wheel delta into \`deltaX\`.

## Verification

- 947 unit tests pass (new: \`spreadContentSize\`, \`gapWheelSteps\`/\`wheelIntentIsGapAdjust\`, \`pagedGap\` migration); svelte-check and lint clean.
- Playwright end-to-end against the dev build: imported a synthetic volume, verified flush baseline, toast + visual gap at 25px/100px (scaled by fit exactly), clamping at both bounds, ctrl+wheel zoom and shift+wheel pan unaffected, continuous-mode chord enabling dividers from zero, and per-mode setting independence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)