### PR TITLE
fix(sw): don't proxy cross-origin downloads through the service worker (#177, #261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed Firefox downloads failing after ~30s from catalog/cloud (#177, #261)
+
 ## [1.8.2] - 2026-07-09
 
 ### Fixed

--- a/src/__mocks__/service-worker-env.ts
+++ b/src/__mocks__/service-worker-env.ts
@@ -1,0 +1,7 @@
+// Test stand-in for SvelteKit's `$service-worker` virtual module.
+// Wired up via `test.alias` in vite.config.ts.
+export const build = ['/_app/immutable/entry/app.js'];
+export const files = ['/favicon.png'];
+export const version = 'test-version';
+export const base = '';
+export const prerendered: string[] = [];

--- a/src/lib/import/html-download-provider.ts
+++ b/src/lib/import/html-download-provider.ts
@@ -191,15 +191,16 @@ export function parseHtmlDownloadRequest(params: URLSearchParams): HtmlDownloadR
     }
   }
 
+  const source = params.get('source');
   const manga = params.get('manga');
   const volume = params.get('volume');
-  if (!manga || !volume) return null;
+  if (!source || !manga || !volume) return null;
 
   const type = (params.get('type') || 'directory').toLowerCase();
   if (type !== 'directory' && type !== 'cbz') return null;
 
   return {
-    source: (params.get('source') || 'https://mokuro.moe/manga').replace(/\/$/, ''),
+    source: source.replace(/\/$/, ''),
     manga,
     volume,
     type,

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -44,6 +44,11 @@ self.addEventListener('activate', (event) => {
   self.clients.claim();
 });
 
+// Cross-origin hosts the service worker may still handle: small, fast
+// requests whose responses are worth keeping in the offline cache (the
+// Noto Sans JP webfont loaded from app.html).
+const CROSS_ORIGIN_CACHE_ALLOWLIST = ['https://fonts.googleapis.com', 'https://fonts.gstatic.com'];
+
 self.addEventListener('fetch', (event) => {
   // ignore POST requests etc
   if (event.request.method !== 'GET') return;
@@ -57,7 +62,9 @@ self.addEventListener('fetch', (event) => {
   // as "Error in input stream" / "A ServiceWorker intercepted the request and
   // encountered an unexpected error" (#177, #261). Not calling respondWith()
   // lets the browser perform the fetch natively with the SW out of the path.
-  if (url.origin !== self.location.origin) return;
+  if (url.origin !== self.location.origin && !CROSS_ORIGIN_CACHE_ALLOWLIST.includes(url.origin)) {
+    return;
+  }
 
   async function respond() {
     const cache = await caches.open(CACHE);

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -48,8 +48,18 @@ self.addEventListener('fetch', (event) => {
   // ignore POST requests etc
   if (event.request.method !== 'GET') return;
 
+  const url = new URL(event.request.url);
+
+  // Never proxy cross-origin requests (external catalogs, Google Drive,
+  // WebDAV, OneDrive, MEGA, ...) through the service worker. Firefox tears
+  // down an idle service worker ~30s after respondWith() settles, which
+  // aborts any large response body still streaming through it and surfaces
+  // as "Error in input stream" / "A ServiceWorker intercepted the request and
+  // encountered an unexpected error" (#177, #261). Not calling respondWith()
+  // lets the browser perform the fetch natively with the SW out of the path.
+  if (url.origin !== self.location.origin) return;
+
   async function respond() {
-    const url = new URL(event.request.url);
     const cache = await caches.open(CACHE);
 
     // `build`/`files` can always be served from the cache
@@ -66,15 +76,8 @@ self.addEventListener('fetch', (event) => {
     try {
       const response = await fetch(event.request);
 
-      // Only cache if:
-      // 1. Response is successful (status 200)
-      // 2. It's not a Google Drive API request
-      // 3. It's not a large file (>10MB)
-      if (
-        response.status === 200 &&
-        !event.request.url.includes('googleapis.com/drive') &&
-        !event.request.url.includes('alt=media')
-      ) {
+      // Only cache successful (status 200) responses smaller than 10MB
+      if (response.status === 200) {
         // Check response size before caching
         const contentLength = response.headers.get('content-length');
         const sizeInMB = contentLength ? parseInt(contentLength) / (1024 * 1024) : 0;

--- a/src/service-worker.test.ts
+++ b/src/service-worker.test.ts
@@ -60,6 +60,16 @@ describe('service worker fetch interception', () => {
     expect(respondWith).toHaveBeenCalledTimes(1);
   });
 
+  // Google Fonts requests are small and fast, and the font files were the one
+  // cross-origin resource the offline cache genuinely served — keep them.
+  it.each([
+    'https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap',
+    'https://fonts.gstatic.com/s/notosansjp/v53/abc.woff2'
+  ])('still handles allowlisted Google Fonts request %s', (url) => {
+    const respondWith = dispatch(url);
+    expect(respondWith).toHaveBeenCalledTimes(1);
+  });
+
   it('ignores non-GET requests', () => {
     const respondWith = dispatch(`${self.location.origin}/api/x`, 'POST');
     expect(respondWith).not.toHaveBeenCalled();

--- a/src/service-worker.test.ts
+++ b/src/service-worker.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+type FetchHandler = (event: {
+  request: Request;
+  respondWith: (p: Promise<Response> | Response) => void;
+}) => void;
+
+let fetchHandler: FetchHandler;
+
+beforeAll(async () => {
+  const listeners = new Map<string, EventListener>();
+  vi.spyOn(self, 'addEventListener').mockImplementation(((type: string, cb: EventListener) => {
+    listeners.set(type, cb);
+  }) as typeof self.addEventListener);
+
+  const cacheStore = new Map<string, Response>();
+  const cache = {
+    addAll: vi.fn(async () => {}),
+    match: vi.fn(async (key: string | Request) => {
+      const k = typeof key === 'string' ? key : new URL(key.url).pathname;
+      return cacheStore.get(k);
+    }),
+    put: vi.fn(async (req: Request, res: Response) => {
+      cacheStore.set(new URL(req.url).pathname, res);
+    })
+  };
+  vi.stubGlobal('caches', {
+    open: vi.fn(async () => cache),
+    keys: vi.fn(async () => []),
+    delete: vi.fn(async () => true)
+  });
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response('ok', { status: 200 }))
+  );
+
+  // Non-literal specifier: keeps service-worker.js out of the main TS program
+  // (SvelteKit excludes it there because it needs the WebWorker lib), while
+  // vitest still resolves it relative to this file at runtime.
+  const swModule = './service-worker.js';
+  await import(/* @vite-ignore */ swModule);
+  fetchHandler = listeners.get('fetch') as unknown as FetchHandler;
+  expect(fetchHandler).toBeTypeOf('function');
+});
+
+function dispatch(url: string, method = 'GET') {
+  const respondWith = vi.fn();
+  fetchHandler({ request: new Request(url, { method }), respondWith });
+  return respondWith;
+}
+
+describe('service worker fetch interception', () => {
+  it('handles same-origin app asset requests', () => {
+    const respondWith = dispatch(`${self.location.origin}/_app/immutable/entry/app.js`);
+    expect(respondWith).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles same-origin navigation requests', () => {
+    const respondWith = dispatch(`${self.location.origin}/`);
+    expect(respondWith).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores non-GET requests', () => {
+    const respondWith = dispatch(`${self.location.origin}/api/x`, 'POST');
+    expect(respondWith).not.toHaveBeenCalled();
+  });
+
+  // Cross-origin downloads (external catalogs, Google Drive alt=media, WebDAV,
+  // OneDrive, MEGA) must NOT be proxied through the service worker. Firefox
+  // terminates an idle service worker ~30s after respondWith() settles, which
+  // aborts any response body still streaming through it ("Error in input
+  // stream" / "A ServiceWorker intercepted the request and encountered an
+  // unexpected error"). Not calling respondWith() lets the browser fetch
+  // natively with the SW out of the data path.
+  it.each([
+    'https://catalog.example.net/manga/Foo/Vol%201.cbz',
+    'https://www.googleapis.com/drive/v3/files/abc?alt=media',
+    'https://www.googleapis.com/drive/v3/files/abc?fields=size',
+    'https://cloud.example.com/remote.php/dav/files/u/manga/v1.cbz',
+    'https://graph.microsoft.com/v1.0/me/drive/items/x/content',
+    'https://g.api.mega.co.nz/cs'
+  ])('does not intercept cross-origin request %s', (url) => {
+    const respondWith = dispatch(url);
+    expect(respondWith).not.toHaveBeenCalled();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,6 +40,12 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test-setup.ts'],
+    // `$service-worker` is a SvelteKit virtual module; vitest can't mock it
+    // directly (SvelteKit's import guard rejects the re-resolved virtual id),
+    // so point it at a static stand-in for tests only.
+    alias: {
+      '$service-worker': new URL('./src/__mocks__/service-worker-env.ts', import.meta.url).pathname
+    },
     // Resolve Svelte 5 for browser/client context in tests
     server: { deps: { inline: ['svelte'] } }
   },


### PR DESCRIPTION
Fixes #261, fixes #177.

## Problem

`src/service-worker.js` called `event.respondWith(fetch(request))` for **every** GET — including cross-origin downloads from external catalogs, Google Drive (`alt=media`), WebDAV, OneDrive and MEGA — so entire multi-hundred-MB bodies streamed *through* the service worker.

Firefox terminates an idle service worker ~30 s after the `respondWith()` promise settles (`dom.serviceWorkers.idle_timeout`), i.e. once response **headers** arrive, and that teardown aborts any body still streaming through it. Users on slower connections therefore saw every large download die at a bandwidth-dependent size (~50 MB in #261) with:

- `TypeError: Error in input stream` (fetch/stream path — catalog)
- `A ServiceWorker intercepted the request and encountered an unexpected error` + XHR `onabort` → `Download aborted` (Google Drive path)

Chromium is unaffected, and fast connections finish before the timeout, which is why it never reproduced locally. Firefox's Network-panel throttle can't reproduce it either: the wire request is the SW's own `fetch()`, which has no browsing context and is invisible to the tab's throttler. Same class of bug as immich-app/immich#21490.

## Fix

Return early (no `respondWith`) for requests whose origin differs from the SW's, so the browser performs those fetches natively with the SW out of the data path. Same-origin app assets / navigations keep the existing cache-first / network-first behaviour. The now-redundant `googleapis` / `alt=media` cache exclusions are dropped.

Exception: `fonts.googleapis.com` / `fonts.gstatic.com` stay on the SW path — small, fast requests (no 30 s streaming exposure) and the Noto Sans JP font files were the one cross-origin resource the offline cache genuinely served.

Also: deep-link imports (`#/upload?manga=..&volume=..`) now require an explicit `source` param instead of falling back to a hardcoded host.

## Verification

Playwright Firefox with `dom.serviceWorkers.idle_timeout=3000` against a production build (`vite build` + `vite preview`) and a slow cross-origin stream (8 MiB over 10 s):

| path | old SW | fixed SW |
|---|---|---|
| page `fetch` + stream read | ✗ `Error in input stream` @ 3.0 s | ✓ 8388608 bytes |
| dedicated-worker `fetch` (app's real path) | ✗ `Error in input stream` @ 3.0 s | ✓ 8388608 bytes |
| dedicated-worker XHR (Google Drive path) | ✗ `abort` @ 3.2 s | ✓ 8388608 bytes |

Also:
- New `src/service-worker.test.ts` — unit tests on the SW fetch listener (same-origin intercepted; cross-origin catalog/Drive/WebDAV/OneDrive/MEGA URLs not intercepted). Uses a vitest-only `test.alias` for the `$service-worker` virtual module (SvelteKit's import guard rejects `vi.mock` of it).
- `npm test` 971/971, `npm run lint` 0 errors, `npm run check` clean.

**Manual repro on the current site:** `about:config` → `dom.serviceWorkers.idle_timeout` and `dom.serviceWorkers.idle_extended_timeout` = `3000` (Debugger panel closed), start any catalog download → dies at ~3 s. Reset prefs afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

