### PR TITLE
fix: heal dropped metadata pushes via the catalog refresh

### DIFF
--- a/src/lib/metadata/catalog-index-sync.heal.test.ts
+++ b/src/lib/metadata/catalog-index-sync.heal.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import type { CloudFileMetadata } from '$lib/util/sync/provider-interface';
+
+/**
+ * The local→cloud half of a catalog refresh: HEALING. A local fact edit that
+ * never reached the cloud (a silently dropped best-effort push) leaves the
+ * catalog's per-entry facts stamp behind the local one forever — the cloud
+ * file's own stamp never moves, so a heal that only ran "when the catalog
+ * changed" would never run at all. The refresh therefore compares stamps on
+ * EVERY listing, schedules a series.json write for each series whose local
+ * facts are strictly newer (or missing from the catalog entirely), and then
+ * schedules a catalog write for providers where this client is the producer.
+ */
+
+vi.mock('$lib/catalog/thumbnails', () => ({ generateThumbnail: vi.fn() }));
+vi.mock('$lib/util/progress-tracker', () => ({
+  progressTrackerStore: { addProcess: vi.fn(), updateProcess: vi.fn(), removeProcess: vi.fn() }
+}));
+
+vi.mock('$lib/catalog/db', async () => {
+  const { default: Dexie } = await import('dexie');
+  const db = new Dexie('catalog-index-sync-heal-test');
+  db.version(1).stores({ series_metadata: 'series_key', catalog_index: 'id' });
+  return { db };
+});
+
+const {
+  getActiveProvider,
+  scheduleSeriesFileWrite,
+  scheduleCatalogFileWrite,
+  cloudVolumeTitlesFor
+} = vi.hoisted(() => ({
+  getActiveProvider: vi.fn(),
+  scheduleSeriesFileWrite: vi.fn(),
+  scheduleCatalogFileWrite: vi.fn(),
+  cloudVolumeTitlesFor: vi.fn()
+}));
+vi.mock('$lib/util/sync/provider-manager', () => ({ providerManager: { getActiveProvider } }));
+vi.mock('./series-file-sync', () => ({ scheduleSeriesFileWrite }));
+vi.mock('./catalog-file-sync', () => ({ scheduleCatalogFileWrite }));
+vi.mock('$lib/util/sync/unified-cloud-manager', () => ({
+  unifiedCloudManager: { cloudVolumeTitlesFor }
+}));
+
+import { db } from '$lib/catalog/db';
+import { refreshCatalogIndex } from './catalog-index-sync';
+
+const CATALOG_STAMP = 'Wed, 27 Aug 2026 10:00:00 GMT';
+
+function catalogFile(entries: Array<Record<string, unknown>>) {
+  return {
+    version: 1,
+    updated_at: '2026-08-27T10:00:00.000Z',
+    series: entries
+  };
+}
+
+function entry(series_title: string, updated_at: string, extra: Record<string, unknown> = {}) {
+  return { series_title, updated_at, external_ids: { anilist: 1 }, ...extra };
+}
+
+function listing(catalog: unknown): Map<string, CloudFileMetadata[]> {
+  const file = (path: string): CloudFileMetadata => ({
+    provider: 'webdav',
+    fileId: path,
+    path,
+    modifiedTime: CATALOG_STAMP,
+    size: JSON.stringify(catalog).length
+  });
+  return new Map([['catalog.json', [file('catalog.json')]]]);
+}
+
+function provider(catalog: unknown, serverCompilesMetadata: boolean) {
+  return {
+    type: 'webdav',
+    serverCompilesMetadata,
+    downloadFile: vi.fn(async () => new Blob([JSON.stringify(catalog)]))
+  };
+}
+
+async function seedLocal(series_title: string, facts_updated_at: string) {
+  await db.series_metadata.put({
+    series_key: series_title.toLowerCase(),
+    folded_key: series_title.toLowerCase(),
+    series_title,
+    external_ids: { anilist: 99 },
+    titles: { native: `${series_title} 日本語` },
+    synonyms: [],
+    updated_at: facts_updated_at,
+    facts_updated_at
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cloudVolumeTitlesFor.mockReturnValue(new Set(['Volume 01']));
+});
+
+afterEach(async () => {
+  await db.series_metadata.clear();
+  await db.catalog_index.clear();
+});
+
+describe('facts healing from the catalog refresh', () => {
+  it('schedules a series write when local facts are strictly newer than the entry', async () => {
+    const catalog = catalogFile([entry('Dr Stone', '2026-08-20T00:00:00.000Z')]);
+    getActiveProvider.mockReturnValue(provider(catalog, true));
+    await seedLocal('Dr Stone', '2026-08-25T00:00:00.000Z');
+
+    await refreshCatalogIndex(listing(catalog), 'webdav');
+
+    expect(scheduleSeriesFileWrite).toHaveBeenCalledWith('Dr Stone', { fromCloudListing: true });
+  });
+
+  it('schedules a series write when the catalog lacks the series entirely', async () => {
+    const catalog = catalogFile([entry('Other Series', '2026-08-20T00:00:00.000Z')]);
+    getActiveProvider.mockReturnValue(provider(catalog, true));
+    await seedLocal('Dr Stone', '2026-08-25T00:00:00.000Z');
+
+    await refreshCatalogIndex(listing(catalog), 'webdav');
+
+    expect(scheduleSeriesFileWrite).toHaveBeenCalledWith('Dr Stone', { fromCloudListing: true });
+  });
+
+  it('does not heal when the entry stamp equals or beats the local one', async () => {
+    const catalog = catalogFile([
+      entry('Equal', '2026-08-25T00:00:00.000Z'),
+      entry('Newer', '2026-08-26T00:00:00.000Z')
+    ]);
+    getActiveProvider.mockReturnValue(provider(catalog, true));
+    await seedLocal('Equal', '2026-08-25T00:00:00.000Z');
+    await seedLocal('Newer', '2026-08-25T00:00:00.000Z');
+
+    await refreshCatalogIndex(listing(catalog), 'webdav');
+
+    expect(scheduleSeriesFileWrite).not.toHaveBeenCalled();
+    expect(scheduleCatalogFileWrite).not.toHaveBeenCalled();
+  });
+
+  it('never heals a series the cloud holds no volumes for — facts get no folder', async () => {
+    const catalog = catalogFile([entry('Other Series', '2026-08-20T00:00:00.000Z')]);
+    getActiveProvider.mockReturnValue(provider(catalog, true));
+    await seedLocal('Local Only', '2026-08-25T00:00:00.000Z');
+    cloudVolumeTitlesFor.mockReturnValue(new Set());
+
+    await refreshCatalogIndex(listing(catalog), 'webdav');
+
+    expect(scheduleSeriesFileWrite).not.toHaveBeenCalled();
+  });
+
+  it('heals on a listing whose catalog stamp has NOT changed — the dropped-push case', async () => {
+    const catalog = catalogFile([entry('Dr Stone', '2026-08-20T00:00:00.000Z')]);
+    getActiveProvider.mockReturnValue(provider(catalog, true));
+
+    // First refresh caches the catalog; no local facts yet, nothing to heal.
+    await refreshCatalogIndex(listing(catalog), 'webdav');
+    expect(scheduleSeriesFileWrite).not.toHaveBeenCalled();
+
+    // A local edit lands... and its push is silently dropped. The cloud stamp
+    // is untouched, so the next refresh takes the needs-no-refresh path — the
+    // heal must still run there, off the cached copy.
+    await seedLocal('Dr Stone', '2026-08-25T00:00:00.000Z');
+    await refreshCatalogIndex(listing(catalog), 'webdav');
+
+    expect(scheduleSeriesFileWrite).toHaveBeenCalledWith('Dr Stone', { fromCloudListing: true });
+  });
+
+  it('finishes by scheduling a catalog write, which is a producer-side concern', async () => {
+    const catalog = catalogFile([entry('Dr Stone', '2026-08-20T00:00:00.000Z')]);
+    getActiveProvider.mockReturnValue(provider(catalog, false));
+    await seedLocal('Dr Stone', '2026-08-25T00:00:00.000Z');
+
+    await refreshCatalogIndex(listing(catalog), 'webdav');
+
+    expect(scheduleSeriesFileWrite).toHaveBeenCalledTimes(1);
+    expect(scheduleCatalogFileWrite).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/metadata/catalog-index-sync.ts
+++ b/src/lib/metadata/catalog-index-sync.ts
@@ -95,7 +95,14 @@ async function runRefresh(
 
   const stamp = { size: cloudFile.size ?? 0, modifiedTime: cloudFile.modifiedTime ?? '' };
   const cached = await getCatalogIndex();
-  if (!catalogNeedsRefresh(cached, stamp, provider.type)) return;
+  if (!catalogNeedsRefresh(cached, stamp, provider.type)) {
+    // The catalog didn't change — which is exactly what a silently dropped
+    // local push looks like from here (the cloud stamp never moves). Healing
+    // therefore runs on EVERY listing, off the cached copy when the file is
+    // current.
+    if (cached) await healFactsBehindCatalog(cached.file, provider);
+    return;
+  }
 
   const parsed = await downloadCatalog(provider, cloudFile);
   if (!parsed) return;
@@ -186,6 +193,70 @@ async function runRefresh(
     await putCatalogIndex({ file: parsed, source, fetched_at: now });
   } catch (error) {
     console.warn('[catalog-index-sync] could not store the refreshed catalog:', error);
+  }
+
+  await healFactsBehindCatalog(parsed, provider);
+}
+
+/**
+ * The local→cloud half of the refresh: HEAL what the catalog shows is behind.
+ *
+ * The cloud→local upsert above trusts strictly-newer catalog facts; this is
+ * its mirror. For every locally stored series that carries facts, compare the
+ * local facts stamp against the catalog entry's (the same clock `series.json`
+ * merges by): a local stamp strictly ahead — or a series the catalog does not
+ * list at all — means a push was dropped somewhere, so schedule the standard
+ * per-series write (which re-reads the cloud file and merges, so a stale
+ * local copy still cannot clobber a newer cloud one). Facts only land in an
+ * existing cloud folder, same as every other publish path. Finishes by
+ * scheduling a catalog write — a no-op on servers that compile their own.
+ *
+ * Best-effort by contract, like everything else on this path: a heal that
+ * fails to schedule is retried by the next listing.
+ */
+async function healFactsBehindCatalog(file: CatalogFile, provider: SyncProvider): Promise<void> {
+  try {
+    if (file.series.length === 0) return;
+    const [{ db }, { hasSeriesFacts }, { factsStamp }, { normalizeVolumeTitleKey }] =
+      await Promise.all([
+        import('$lib/catalog/db'),
+        import('./series-file'),
+        import('./store'),
+        import('./series-key')
+      ]);
+    const locals = (await db.series_metadata.toArray()).filter((record) => hasSeriesFacts(record));
+    if (locals.length === 0) return;
+
+    const entryStampByKey = new Map(
+      file.series.map((entry) => [normalizeVolumeTitleKey(entry.series_title), entry.updated_at])
+    );
+    const { unifiedCloudManager } = await import('$lib/util/sync/unified-cloud-manager');
+
+    const behind: string[] = [];
+    for (const record of locals) {
+      const localStamp = factsStamp(record);
+      if (!localStamp) continue;
+      const cloudStamp = entryStampByKey.get(normalizeVolumeTitleKey(record.series_title));
+      if (cloudStamp !== undefined && cloudStamp >= localStamp) continue;
+      if (unifiedCloudManager.cloudVolumeTitlesFor(record.series_title).size === 0) continue;
+      behind.push(record.series_title);
+    }
+    if (behind.length === 0) return;
+
+    console.log(
+      `[catalog-index-sync] catalog is behind local facts for ${behind.length} series — healing`
+    );
+    const { scheduleSeriesFileWrite } = await import('./series-file-sync');
+    for (const title of behind) {
+      scheduleSeriesFileWrite(title, { fromCloudListing: true });
+    }
+    // Producer-side catch-all: on a client-compiled backend this republishes
+    // catalog.json once the series writes land; `scheduleCatalogFileWrite`
+    // itself refuses on a server that compiles its own.
+    const { scheduleCatalogFileWrite } = await import('./catalog-file-sync');
+    scheduleCatalogFileWrite();
+  } catch (error) {
+    console.debug('[catalog-index-sync] facts heal skipped:', error);
   }
 }
 


### PR DESCRIPTION
## Summary

Link ids / alt names / tags edited locally sometimes never reached the cloud — every push on that path is best-effort and fails silently by design (listing refresh failures, gating when a series isn't in the cached listing, etc.). Server side was verified healthy (bunko merges every PUT it receives), so per the agreed design this adds healing to the sync process:

- On every catalog refresh (including when the cloud catalog's stamp is unchanged — which is exactly what a dropped push looks like), compare each locally stored series' facts stamp against the catalog entry's.
- A local stamp strictly ahead, or a facts-bearing series the catalog doesn't list, schedules the standard per-series `series.json` write (re-read + merge, so stale local state can't clobber newer cloud state). Facts only land in existing cloud folders.
- Finishes with one catalog write — self-refused on servers that compile their own (bunko republishes automatically).

## Test plan
- 6 new heal tests against a real Dexie, including the unchanged-stamp dropped-push case
- Full suite: 2,877 pass; svelte-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)