### PR TITLE
Release v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.9.1] - 2026-08-30
+
+### Fixed
+
+- Trackpad zoom is now smooth instead of lurching (#259)
+- Trackpad pinch zooms even with wheel swap on (#259)
+- Night mode tints extension popups and menus again
+
 ## [1.9.0] - 2026-08-29
 
 ### Added

--- a/docs/INPUT-CONTRACTS.md
+++ b/docs/INPUT-CONTRACTS.md
@@ -82,6 +82,34 @@ Every handler that starts motion opens with the gate call matching its
 intent. Never call `finishNow`/`stop`/`stopPan` combinations inline — add
 to the gate if a new intent appears.
 
+### Wheel granularity decides the zoom's shape (#259)
+
+A wheel stream is classified as **fine** (trackpad, precision wheel,
+synthetic pinch) or **notched** by `WheelStreamClassifier` — once per event,
+at the top of each surface's `handleWheel`, shared by the intent check and
+the zoom so the stateful classifier is never asked twice.
+
+- **Fine streams zoom continuously** at the cursor, through the same
+  anchored path a pinch uses. Stepping a ladder on a device that reports
+  every millimetre of travel is what #259 reported: nothing, nothing,
+  nothing, lurch.
+- **Notched streams keep the level ladder** — one notch is one deliberate
+  step, and mouse users are untouched.
+- **A fine ctrl/meta+wheel is a pinch, so it always zooms**, whatever
+  `swapWheelBehavior` says. Chrome and Firefox deliver trackpad pinch as a
+  synthetic ctrl+wheel; only Safari has real pinch events. Without this a
+  Mac user with the swap on has no working pinch at all. A _notched_
+  ctrl+wheel is a genuine keyboard chord and keeps the swap semantics.
+- Classification is **sticky per stream** and only ever upgrades to fine:
+  trackpad momentum reports large round deltas indistinguishable from
+  notches, while a mouse never reports the small ones. Erring toward fine
+  costs a precision-wheel owner a smooth zoom, which is what they wanted;
+  erring the other way is the bug.
+
+Wheel zoom has no release event, so a fine stream settles on an idle
+timeout (`WHEEL_ZOOM_SETTLE_MS`) — that settle is what clamps the paged
+camera into bounds and reports reading progress.
+
 ### Swipe-to-flip is edge-gated (#186)
 
 A touch swipe flips the page only if no pannable content was hidden in the
@@ -104,15 +132,16 @@ Zoom settles carry a `SettleReason` (`zoom-controller.ts`): only
 
 ## Per-surface policy matrix
 
-| Policy         | PagedViewport                     | Scroll readers                          |
-| -------------- | --------------------------------- | --------------------------------------- |
-| Capture        | deferred (at drag threshold)      | immediate (at pan press)                |
-| Pan deltas     | incremental → `camera.adjustView` | totals → absolute scroll from baselines |
-| Text-box pan   | suppressed for mouse/pen only     | suppressed for all pointer types        |
-| Pinch survivor | keeps panning                     | ignored until fresh press               |
-| Tap commit     | immediate                         | deferred (300 ms)                       |
-| Swipe-to-flip  | yes (mobile setting, edge-gated)  | no (panning is the scroll)              |
-| Wheel          | zoom, gap, or camera glide        | zoom, gap, or (native/strip) scroll     |
+| Policy         | PagedViewport                        | Scroll readers                          |
+| -------------- | ------------------------------------ | --------------------------------------- |
+| Capture        | deferred (at drag threshold)         | immediate (at pan press)                |
+| Pan deltas     | incremental → `camera.adjustView`    | totals → absolute scroll from baselines |
+| Text-box pan   | suppressed for mouse/pen only        | suppressed for all pointer types        |
+| Pinch survivor | keeps panning                        | ignored until fresh press               |
+| Tap commit     | immediate                            | deferred (300 ms)                       |
+| Swipe-to-flip  | yes (mobile setting, edge-gated)     | no (panning is the scroll)              |
+| Wheel          | zoom, gap, or camera glide           | zoom, gap, or (native/strip) scroll     |
+| Wheel zoom     | continuous (fine) / ladder (notched) | continuous (fine) / ladder (notched)    |
 
 Ctrl/meta+shift+wheel is the page-gap adjustment chord on every surface
 (paged writes `pagedGap`; scroll readers write `scrollGap` and sync

--- a/e2e/night-mode.spec.ts
+++ b/e2e/night-mode.spec.ts
@@ -1,0 +1,267 @@
+import { test, expect, type Page } from '@playwright/test';
+import http from 'node:http';
+
+/**
+ * E2E coverage for the night-mode red filter.
+ *
+ * Night mode has to tint EVERY pixel the user can see, including surfaces that
+ * a `filter` on the root element never reaches:
+ *
+ *   - content a browser extension injects into <body> or <html>,
+ *   - a cross-origin iframe (how Yomitan renders its dictionary popup),
+ *   - the top layer: modal dialogs, popovers (every Flowbite dropdown), and
+ *     ::backdrop,
+ *   - the propagated canvas background.
+ *
+ * It also has to tint each of them exactly ONCE. The transform is
+ * luminance -> red channel, which is not idempotent: a second pass multiplies
+ * the red channel by 0.2126 and the surface renders ~5x too dark. Non-modal
+ * dialogs (Flowbite's Drawer calls show(), not showModal()) stay in normal flow
+ * and so are already covered by the page-level overlays — filtering them again
+ * via a bare `dialog` selector is the specific bug this asserts against.
+ *
+ * NOTE on the cross-origin case: Chrome only started refusing to paint SVG
+ * reference filters onto cross-origin frames in 151, and Playwright's bundled
+ * Chromium is older, so that assertion only has teeth when E2E_CHROMIUM points
+ * at a real Chrome >= 151. Every other assertion here reproduces on the bundled
+ * build.
+ */
+
+const FRAME_PORT = 8673;
+
+// White and mid-grey patches, so we can check the tint value and not just "is red".
+const FRAME_HTML = `<!doctype html><html><body style="margin:0">
+<div style="position:absolute;left:0;top:0;width:60px;height:60px;background:#ffffff"></div>
+<div style="position:absolute;left:60px;top:0;width:60px;height:60px;background:#808080"></div>
+</body></html>`;
+
+let frameServer: http.Server;
+
+test.beforeAll(async () => {
+  frameServer = http.createServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(FRAME_HTML);
+  });
+  await new Promise<void>((resolve) => frameServer.listen(FRAME_PORT, '127.0.0.1', resolve));
+});
+
+test.afterAll(async () => {
+  await new Promise((resolve) => frameServer.close(resolve));
+});
+
+/** Injects the surfaces an extension (and the app itself) can put on screen. */
+async function injectSurfaces(page: Page, framePort: number) {
+  await page.evaluate((port) => {
+    const box = 'position:fixed;top:0;width:60px;height:60px;z-index:2147483647;';
+    const mk = (id: string, css: string, parent: Element) => {
+      const el = document.createElement('div');
+      el.id = id;
+      el.style.cssText = css;
+      parent.appendChild(el);
+      return el;
+    };
+
+    mk('probe-body', box + 'left:0;background:#ffffff', document.body);
+    mk('probe-html', box + 'left:60px;background:#ffffff', document.documentElement);
+
+    const frame = document.createElement('iframe');
+    frame.id = 'probe-frame';
+    frame.style.cssText = box + 'left:120px;width:120px;border:0';
+    frame.src = `http://127.0.0.1:${port}/`;
+    document.documentElement.appendChild(frame);
+
+    const pop = mk(
+      'probe-popover',
+      box + 'left:240px;background:#ffffff;margin:0;border:0',
+      document.body
+    );
+    pop.setAttribute('popover', 'manual');
+    pop.showPopover();
+
+    const modal = document.createElement('dialog');
+    modal.id = 'probe-modal';
+    modal.style.cssText =
+      'position:fixed;top:80px;left:0;margin:0;padding:0;border:0;width:60px;height:60px;background:#ffffff';
+    document.body.appendChild(modal);
+    modal.showModal();
+
+    const nonModal = document.createElement('dialog');
+    nonModal.id = 'probe-nonmodal';
+    nonModal.style.cssText =
+      'position:fixed;top:80px;left:60px;margin:0;padding:0;border:0;width:60px;height:60px;background:#ffffff;z-index:2147483647';
+    document.body.appendChild(nonModal);
+    nonModal.show();
+  }, framePort);
+  // let the cross-origin frame paint
+  await page.waitForTimeout(600);
+}
+
+/**
+ * Mirrors NightModeFilter.svelte: two max-z-index blend layers kept as the last
+ * two children of <html>, plus the variable that drives the top-layer rules.
+ */
+async function setNightMode(page: Page, on: boolean) {
+  await page.evaluate((active) => {
+    const root = document.documentElement;
+    root.querySelectorAll('.night-mode-layer').forEach((el) => el.remove());
+    if (active) {
+      for (const kind of ['desaturate', 'redden']) {
+        const el = document.createElement('div');
+        el.className = `night-mode-layer night-mode-${kind}`;
+        root.appendChild(el);
+      }
+    }
+    root.classList.toggle('night-mode', active);
+    root.style.setProperty('--night-mode-filter', active ? 'url(#night-mode-filter)' : 'none');
+  }, on);
+  await page.waitForTimeout(300);
+}
+
+type Rgb = [number, number, number];
+
+async function pixel(page: Page, x: number, y: number): Promise<Rgb> {
+  const shot = await page.screenshot({ clip: { x, y, width: 1, height: 1 } });
+  // A 1x1 PNG: decode via the browser rather than shipping a decoder.
+  const data = await page.evaluate(async (b64) => {
+    const img = new Image();
+    img.src = 'data:image/png;base64,' + b64;
+    await img.decode();
+    const c = document.createElement('canvas');
+    c.width = c.height = 1;
+    const ctx = c.getContext('2d')!;
+    ctx.drawImage(img, 0, 0);
+    const d = ctx.getImageData(0, 0, 1, 1).data;
+    return [d[0], d[1], d[2]];
+  }, shot.toString('base64'));
+  return data as Rgb;
+}
+
+const SURFACES: Array<{ name: string; x: number; y: number }> = [
+  { name: 'div injected into <body>', x: 30, y: 30 },
+  { name: 'div injected into <html>', x: 90, y: 30 },
+  { name: 'cross-origin iframe (white)', x: 150, y: 30 },
+  { name: 'cross-origin iframe (grey)', x: 210, y: 30 },
+  { name: 'popover (top layer)', x: 270, y: 30 },
+  { name: 'modal dialog (top layer)', x: 30, y: 110 },
+  { name: 'non-modal dialog', x: 90, y: 110 },
+  { name: 'page background', x: 700, y: 600 }
+];
+
+test('night mode tints every visible surface exactly once', async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await page.goto('/');
+  await page.waitForTimeout(1200);
+  await injectSurfaces(page, FRAME_PORT);
+
+  await setNightMode(page, false);
+  const before: Record<string, Rgb> = {};
+  for (const s of SURFACES) before[s.name] = await pixel(page, s.x, s.y);
+
+  await setNightMode(page, true);
+
+  for (const s of SURFACES) {
+    const [r, g, b] = await pixel(page, s.x, s.y);
+    const [r0, g0, b0] = before[s.name];
+    // Rec.709 luma of the untinted colour is what the red channel must become.
+    const luma = 0.2126 * r0 + 0.7152 * g0 + 0.0722 * b0;
+
+    expect(g, `${s.name}: green channel must be removed`).toBeLessThan(40);
+    expect(b, `${s.name}: blue channel must be removed`).toBeLessThan(40);
+    // Catches BOTH "not tinted at all" and "tinted twice" (~0.21x too dark).
+    expect(
+      Math.abs(r - luma),
+      `${s.name}: red channel should be the luma of ${r0},${g0},${b0} (${luma.toFixed(0)}), got ${r}`
+    ).toBeLessThan(20);
+  }
+});
+
+test('turning night mode off restores the original colours', async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await page.goto('/');
+  await page.waitForTimeout(1200);
+  await injectSurfaces(page, FRAME_PORT);
+
+  await setNightMode(page, false);
+  const before = await pixel(page, 30, 30);
+  await setNightMode(page, true);
+  await setNightMode(page, false);
+  const after = await pixel(page, 30, 30);
+
+  expect(after).toEqual(before);
+});
+
+/**
+ * The desaturation and red passes are separate layers, so anything that paints
+ * BETWEEN them gets reddened without being desaturated — greens and blues
+ * collapse to black instead of becoming mid-red. Extensions routinely inject at
+ * z-index 2147483647 (Yomitan included), which is exactly the value that used to
+ * land in that gap. Saturated colours are the only probe that detects this:
+ * white and grey render correctly either way.
+ */
+test('extension content at a maximal z-index is desaturated, not just reddened', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 500, height: 400 });
+  await page.goto('/');
+  await page.waitForTimeout(1200);
+
+  await page.evaluate((port) => {
+    for (const [i, z] of [1000, 2147483646, 2147483647].entries()) {
+      const f = document.createElement('iframe');
+      f.className = 'probe-z';
+      f.style.cssText = `position:fixed;left:0;top:${i * 50}px;width:240px;height:44px;border:0;z-index:${z}`;
+      f.src = `http://127.0.0.1:${port}/`;
+      document.documentElement.appendChild(f);
+    }
+  }, FRAME_PORT);
+  await page.waitForTimeout(700);
+  await setNightMode(page, true);
+
+  // The served frame is white then mid-grey; add a saturated strip of our own by
+  // sampling a green patch we inject alongside at the same z-index.
+  await page.evaluate(() => {
+    for (const [i, z] of [1000, 2147483646, 2147483647].entries()) {
+      const d = document.createElement('div');
+      d.style.cssText = `position:fixed;left:260px;top:${i * 50}px;width:44px;height:44px;background:#00ff00;z-index:${z}`;
+      document.documentElement.appendChild(d);
+    }
+  });
+  // Re-assert the layers the way the component's MutationObserver does.
+  await setNightMode(page, true);
+
+  for (let i = 0; i < 3; i++) {
+    const [r, g, b] = await pixel(page, 282, i * 50 + 22);
+    // Rec.601 desaturation of #00ff00 is 150; only-multiply would give 0.
+    expect(r, `green patch ${i} must be desaturated before being reddened`).toBeGreaterThan(100);
+    expect(g).toBeLessThan(40);
+    expect(b).toBeLessThan(40);
+  }
+});
+
+test('night mode does not unpin position:fixed elements', async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await page.goto('/');
+  await page.waitForTimeout(1200);
+
+  // A filter on <body> (rather than the root) would re-anchor this to the
+  // document and scroll it away — that is why the page-level tint is a blend
+  // overlay pair on the root's pseudo-elements, not a filter on a wrapper.
+  await page.evaluate(() => {
+    const tall = document.createElement('div');
+    tall.style.cssText = 'height:4000px';
+    document.body.appendChild(tall);
+    const hud = document.createElement('div');
+    hud.id = 'probe-hud';
+    hud.style.cssText = 'position:fixed;bottom:0;left:0;width:100px;height:40px;background:#fff';
+    document.body.appendChild(hud);
+  });
+
+  await setNightMode(page, true);
+  await page.evaluate(() => window.scrollTo(0, 1500));
+  await page.waitForTimeout(300);
+
+  const top = await page.evaluate(
+    () => document.getElementById('probe-hud')!.getBoundingClientRect().top
+  );
+  expect(Math.round(top)).toBe(660); // 700px viewport - 40px element
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mokuro-reader",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mokuro-reader",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "dependencies": {
         "@azure/msal-browser": "^5.8.0",
         "@types/gapi": "^0.0.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mokuro-reader",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/app.html
+++ b/src/app.html
@@ -18,18 +18,82 @@
     <script src="https://accounts.google.com/gsi/client"></script>
     %sveltekit.head%
     <style>
-      /* CSS Variables for night mode */
+      /*
+       * Night mode: turn the whole page into a red monochrome image.
+       *
+       * Two mechanisms, because no single one reaches everything:
+       *
+       * 1. BLEND LAYERS for the document. A `saturation` pass strips colour, then
+       *    a `multiply` pass against pure red keeps only the red channel.
+       *    Blending — unlike `filter` — still composites over cross-origin
+       *    iframes, which is what a browser extension's popup is (Yomitan
+       *    renders its dictionary popup as a chrome-extension:// frame).
+       *    Chrome 151 refuses to paint SVG reference filters onto such frames at
+       *    all (csswg-drafts#13846), and Firefox has never painted a url() filter
+       *    on the root element (Bugzilla 1769223), so
+       *    `html { filter: url(#night-mode-filter) }` covers the extension popup
+       *    in neither engine. The blend layers behave identically in both.
+       *
+       *    They sit on the ROOT rather than on a wrapper, so they blend against
+       *    the canvas background too, and nothing gains a containing block —
+       *    putting a `filter` on <body> instead would re-anchor every
+       *    position:fixed descendant to the document and unpin the reader HUD.
+       *
+       * 2. The SVG matrix for TOP-LAYER content. Modal dialogs, popovers
+       *    (Flowbite dropdowns/tooltips) and fullscreen elements paint as
+       *    siblings of the root, above the blend layers, so blending cannot
+       *    reach them. A url() filter does work on non-root elements in both
+       *    engines.
+       *
+       * The two agree exactly on the whole grey ramp (#000000 -> 0,0,0 and
+       * #ffffff -> 255,0,0 in both) and differ only on fully saturated colours,
+       * where the CSS blending spec's luma function is Rec.601 and the SVG
+       * matrix is Rec.709. On real pages that is a mean error of ~1/255.
+       */
       :root {
         --night-mode-filter: none; /* Default: no filter */
       }
 
-      /* Apply the filter to the html element */
-      html {
-        filter: var(--night-mode-filter);
+      /*
+       * BOTH layers carry the maximum z-index, and NightModeFilter.svelte keeps
+       * them the last two children of <html>.
+       *
+       * This is load-bearing, not belt-and-braces. Extensions routinely inject at
+       * z-index 2147483647 (Yomitan included). Ties are broken by tree order, so
+       * anything at that z-index painting between the two layers would be
+       * multiplied but never desaturated — its greens and blues would collapse to
+       * black. Equal z-index plus last-in-tree-order puts both layers above such
+       * an element. This is also why they cannot be html::before/::after: a
+       * ::before box is the FIRST child and loses every tie.
+       */
+      html.night-mode > .night-mode-layer {
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 2147483647;
       }
 
-      /* Also apply to dialog elements in the top layer (showModal promotes dialogs outside the html filter) */
-      dialog {
+      /* Paint order within the pair comes from tree order: desaturate, then redden. */
+      html.night-mode > .night-mode-desaturate {
+        background-color: #000;
+        mix-blend-mode: saturation;
+      }
+
+      html.night-mode > .night-mode-redden {
+        background-color: #f00;
+        mix-blend-mode: multiply;
+      }
+
+      /*
+       * Top layer. `dialog:modal` — not bare `dialog` — because a non-modal
+       * dialog (Flowbite's Drawer calls show(), not showModal()) stays in normal
+       * flow, where the overlays already cover it; filtering it as well would
+       * apply the transform twice and the matrix is not idempotent.
+       */
+      dialog:modal,
+      :popover-open,
+      :fullscreen:not(:root),
+      ::backdrop {
         filter: var(--night-mode-filter);
       }
     </style>
@@ -37,7 +101,7 @@
     <svg width="0" height="0" style="position: absolute; z-index: -9999; visibility: hidden">
       <defs>
         <filter id="night-mode-filter" color-interpolation-filters="sRGB">
-          <!-- Convert to grayscale first -->
+          <!-- Luminance -> red channel, everything else zeroed -->
           <feColorMatrix
             type="matrix"
             values="0.2126 0.7152 0.0722 0 0

--- a/src/lib/components/NightModeFilter.svelte
+++ b/src/lib/components/NightModeFilter.svelte
@@ -3,163 +3,69 @@
   import { browser } from '$app/environment';
   import { onDestroy } from 'svelte';
 
-  // Elements for Firefox overlay approach
-  let grayscaleLayer: HTMLDivElement | null = null;
-  let redOverlay: HTMLDivElement | null = null;
-  let dialogObserver: MutationObserver | null = null;
-  let isFirefox = browser && navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+  // The colour maths lives in the <style> block in src/app.html, which explains
+  // why night mode is a blend-layer pair plus a top-layer filter rather than one
+  // filter on the root. This component owns the two layer elements.
+  //
+  // Both engines take the same path now: the Firefox-specific overlay branch is
+  // gone, because the layers it used are what every browser uses.
 
-  // Firefox: Apply overlays inside a dialog for top-layer support
-  function applyFirefoxOverlaysToDialog(dialog: HTMLDialogElement, active: boolean) {
-    const existingGrayscale = dialog.querySelector('#dialog-grayscale-layer');
-    const existingRed = dialog.querySelector('#dialog-red-overlay');
+  let desaturate: HTMLDivElement | null = null;
+  let redden: HTMLDivElement | null = null;
+  let observer: MutationObserver | null = null;
 
-    if (active) {
-      if (!existingGrayscale) {
-        const grayscale = document.createElement('div');
-        grayscale.id = 'dialog-grayscale-layer';
-        grayscale.style.position = 'fixed';
-        grayscale.style.top = '0';
-        grayscale.style.left = '0';
-        grayscale.style.width = '100vw';
-        grayscale.style.height = '100vh';
-        grayscale.style.backgroundColor = 'rgba(0, 0, 0, 1)';
-        grayscale.style.pointerEvents = 'none';
-        grayscale.style.zIndex = '999998';
-        grayscale.style.mixBlendMode = 'saturation';
-        dialog.appendChild(grayscale);
-      }
-      if (!existingRed) {
-        const red = document.createElement('div');
-        red.id = 'dialog-red-overlay';
-        red.style.position = 'fixed';
-        red.style.top = '0';
-        red.style.left = '0';
-        red.style.width = '100vw';
-        red.style.height = '100vh';
-        red.style.backgroundColor = 'rgba(255, 0, 0, 1)';
-        red.style.pointerEvents = 'none';
-        red.style.zIndex = '999999';
-        red.style.mixBlendMode = 'multiply';
-        dialog.appendChild(red);
-      }
-    } else {
-      existingGrayscale?.remove();
-      existingRed?.remove();
-    }
+  function makeLayer(kind: 'desaturate' | 'redden') {
+    const el = document.createElement('div');
+    el.className = `night-mode-layer night-mode-${kind}`;
+    el.setAttribute('aria-hidden', 'true');
+    return el;
   }
 
-  // Firefox: Update all open dialogs
-  function updateFirefoxDialogs(active: boolean) {
-    document.querySelectorAll('dialog[open]').forEach((dialog) => {
-      applyFirefoxOverlaysToDialog(dialog as HTMLDialogElement, active);
-    });
+  /**
+   * Keep the pair as the last two children of <html>, in this order.
+   *
+   * Both layers sit at the maximum z-index, so paint order against an extension
+   * that injects at the same z-index is decided by tree order. If an extension
+   * appends its popup after us, it would land above the desaturation layer and
+   * render with its colour channels crushed instead of tinted, so we move back
+   * on top whenever the root's children change.
+   */
+  function ensureOnTop() {
+    const root = document.documentElement;
+    if (!desaturate || !redden) return;
+    if (root.lastElementChild === redden && redden.previousElementSibling === desaturate) return;
+    root.appendChild(desaturate);
+    root.appendChild(redden);
   }
 
-  // Firefox: Set up observer to watch for dialog open/close
-  function setupDialogObserver(active: boolean) {
-    if (!isFirefox || !browser) return;
-
-    // Clean up existing observer
-    dialogObserver?.disconnect();
-
-    if (active) {
-      dialogObserver = new MutationObserver((mutations) => {
-        mutations.forEach((mutation) => {
-          if (mutation.type === 'attributes' && mutation.attributeName === 'open') {
-            const dialog = mutation.target as HTMLDialogElement;
-            if (dialog.tagName === 'DIALOG') {
-              applyFirefoxOverlaysToDialog(dialog, dialog.hasAttribute('open'));
-            }
-          }
-          // Also check for new dialogs being added to the DOM
-          mutation.addedNodes.forEach((node) => {
-            if (node instanceof HTMLDialogElement && node.hasAttribute('open')) {
-              applyFirefoxOverlaysToDialog(node, true);
-            }
-          });
-        });
-      });
-
-      dialogObserver.observe(document.body, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        attributeFilter: ['open']
-      });
-
-      // Apply to any already-open dialogs
-      updateFirefoxDialogs(true);
-    } else {
-      // Remove overlays from all dialogs
-      updateFirefoxDialogs(false);
-    }
-  }
-
-  // Function to apply the night mode filter
   function applyNightModeFilter(active: boolean) {
     if (!browser) return;
+    const root = document.documentElement;
 
-    if (isFirefox) {
-      // Firefox approach: Use overlays with blend modes
-      if (active) {
-        // Create grayscale layer if it doesn't exist
-        if (!grayscaleLayer) {
-          grayscaleLayer = document.createElement('div');
-          grayscaleLayer.id = 'grayscale-saturation-layer';
-          grayscaleLayer.style.position = 'fixed';
-          grayscaleLayer.style.top = '0';
-          grayscaleLayer.style.left = '0';
-          grayscaleLayer.style.width = '100%';
-          grayscaleLayer.style.height = '100%';
-          grayscaleLayer.style.backgroundColor = 'rgba(0, 0, 0, 1)';
-          grayscaleLayer.style.pointerEvents = 'none';
-          grayscaleLayer.style.zIndex = '999998';
-          grayscaleLayer.style.mixBlendMode = 'saturation'; // Removes color saturation
-          grayscaleLayer.style.display = 'block';
-          document.body.appendChild(grayscaleLayer);
-        }
+    if (active) {
+      desaturate ??= makeLayer('desaturate');
+      redden ??= makeLayer('redden');
+      ensureOnTop();
 
-        // Create red overlay if it doesn't exist
-        if (!redOverlay) {
-          redOverlay = document.createElement('div');
-          redOverlay.id = 'red-overlay';
-          redOverlay.style.position = 'fixed';
-          redOverlay.style.top = '0';
-          redOverlay.style.left = '0';
-          redOverlay.style.width = '100%';
-          redOverlay.style.height = '100%';
-          redOverlay.style.backgroundColor = 'rgba(255, 0, 0, 1)';
-          redOverlay.style.pointerEvents = 'none';
-          redOverlay.style.zIndex = '999999'; // Higher than grayscale
-          redOverlay.style.mixBlendMode = 'multiply';
-          redOverlay.style.display = 'block';
-          document.body.appendChild(redOverlay);
-        }
-      } else {
-        // Remove overlays if night mode is off
-        if (grayscaleLayer) {
-          grayscaleLayer.remove();
-          grayscaleLayer = null;
-        }
-        if (redOverlay) {
-          redOverlay.remove();
-          redOverlay = null;
-        }
-      }
-
-      // Also handle dialogs in top layer for Firefox
-      setupDialogObserver(active);
+      // Only observe the root's own child list — this fires on extension
+      // injection, not on anything the app renders inside <body>.
+      observer ??= new MutationObserver(ensureOnTop);
+      observer.observe(root, { childList: true });
     } else {
-      // Non-Firefox approach: Use CSS variables with SVG filter
-      const rootElement = document.documentElement;
-
-      if (active) {
-        rootElement.style.setProperty('--night-mode-filter', 'url(#night-mode-filter)');
-      } else {
-        rootElement.style.setProperty('--night-mode-filter', 'none');
-      }
+      observer?.disconnect();
+      observer = null;
+      desaturate?.remove();
+      redden?.remove();
+      desaturate = null;
+      redden = null;
     }
+
+    // Gates the layer styles.
+    root.classList.toggle('night-mode', active);
+
+    // Drives the top-layer rules (modal dialogs, popovers, fullscreen,
+    // ::backdrop) — those paint above the layers, so they filter themselves.
+    root.style.setProperty('--night-mode-filter', active ? 'url(#night-mode-filter)' : 'none');
   }
 
   // React to nightModeActive store changes (includes schedule-based activation)
@@ -167,22 +73,9 @@
     applyNightModeFilter($nightModeActive);
   }
 
-  // Clean up
   onDestroy(() => {
-    if (browser) {
-      if (grayscaleLayer) {
-        grayscaleLayer.remove();
-      }
-      if (redOverlay) {
-        redOverlay.remove();
-      }
-      dialogObserver?.disconnect();
-      // Clean up dialog overlays
-      document.querySelectorAll('#dialog-grayscale-layer, #dialog-red-overlay').forEach((el) => {
-        el.remove();
-      });
-    }
+    if (browser) applyNightModeFilter(false);
   });
 </script>
 
-<!-- No visible elements - just applies the filter via CSS variables or overlays -->
+<!-- No markup: the two blend layers are appended to <html>, above everything. -->

--- a/src/lib/components/Reader/HorizontalScrollReader.svelte
+++ b/src/lib/components/Reader/HorizontalScrollReader.svelte
@@ -14,6 +14,7 @@
     GAP_WHEEL_STEP_SIZE,
     MAX_PAGE_GAP,
     WheelAccumulator,
+    WheelStreamClassifier,
     gapWheelSteps,
     normalizeWheelDelta,
     wheelIntentIsGapAdjust,
@@ -356,6 +357,13 @@
 
   const gapAccumulator = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
 
+  /**
+   * Trackpad vs notched wheel, per stream (#259). Classified once per event
+   * and shared by the intent check and the zoom itself: the classifier is
+   * stateful, so asking it twice would double-count the stream.
+   */
+  const wheelStream = new WheelStreamClassifier();
+
   // The chord drives the continuous-mode dividers: gap > 0 means dividers on,
   // reaching 0 turns them off (the M toggle keeps working independently).
   function adjustGap(delta: number) {
@@ -369,6 +377,7 @@
 
   function handleWheel(e: WheelEvent) {
     if (!scrollContainer) return;
+    const fine = wheelStream.classify(e);
     if (wheelIntentIsGapAdjust(e)) {
       e.preventDefault();
       adjustGap(gapWheelSteps(e, gapAccumulator));
@@ -376,10 +385,10 @@
     }
     const modifier = e.ctrlKey || e.metaKey;
 
-    if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {
+    if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior, fine)) {
       e.preventDefault();
       motion.beforeZoom();
-      zoomController.wheelZoom(e);
+      zoomController.wheelZoom(e, fine);
       return;
     }
 

--- a/src/lib/components/Reader/PagedViewport.svelte
+++ b/src/lib/components/Reader/PagedViewport.svelte
@@ -15,6 +15,7 @@
     GAP_WHEEL_STEP_SIZE,
     MAX_PAGE_GAP,
     WheelAccumulator,
+    WheelStreamClassifier,
     gapWheelSteps,
     normalizeWheelDelta,
     wheelIntentIsGapAdjust,
@@ -143,6 +144,13 @@
 
   const gapAccumulator = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
 
+  /**
+   * Trackpad vs notched wheel, per stream (#259). Classified once per event
+   * and shared by the intent check and the zoom itself: the classifier is
+   * stateful, so asking it twice would double-count the stream.
+   */
+  const wheelStream = new WheelStreamClassifier();
+
   function adjustGap(delta: number) {
     if (delta === 0) return;
     const next = Math.max(0, Math.min(MAX_PAGE_GAP, ($settings.pagedGap ?? 0) + delta));
@@ -151,16 +159,17 @@
   }
 
   function handleWheel(e: WheelEvent) {
+    const fine = wheelStream.classify(e);
     if (wheelIntentIsGapAdjust(e)) {
       e.preventDefault();
       adjustGap(gapWheelSteps(e, gapAccumulator));
       return;
     }
     const modifier = e.ctrlKey || e.metaKey;
-    if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {
+    if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior, fine)) {
       e.preventDefault();
       motion.beforeZoom();
-      controller.wheelZoom(e);
+      controller.wheelZoom(e, fine);
       return;
     }
     e.preventDefault();

--- a/src/lib/components/Reader/VerticalScrollReader.svelte
+++ b/src/lib/components/Reader/VerticalScrollReader.svelte
@@ -14,6 +14,7 @@
     GAP_WHEEL_STEP_SIZE,
     MAX_PAGE_GAP,
     WheelAccumulator,
+    WheelStreamClassifier,
     gapWheelSteps,
     normalizeWheelDelta,
     wheelIntentIsGapAdjust,
@@ -353,6 +354,13 @@
 
   const gapAccumulator = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
 
+  /**
+   * Trackpad vs notched wheel, per stream (#259). Classified once per event
+   * and shared by the intent check and the zoom itself: the classifier is
+   * stateful, so asking it twice would double-count the stream.
+   */
+  const wheelStream = new WheelStreamClassifier();
+
   // The chord drives the continuous-mode dividers: gap > 0 means dividers on,
   // reaching 0 turns them off (the M toggle keeps working independently).
   function adjustGap(delta: number) {
@@ -366,6 +374,7 @@
 
   function handleWheel(e: WheelEvent) {
     if (!scrollContainer) return;
+    const fine = wheelStream.classify(e);
     if (wheelIntentIsGapAdjust(e)) {
       e.preventDefault();
       adjustGap(gapWheelSteps(e, gapAccumulator));
@@ -373,10 +382,10 @@
     }
     const modifier = e.ctrlKey || e.metaKey;
 
-    if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {
+    if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior, fine)) {
       e.preventDefault();
       motion.beforeZoom();
-      zoomController.wheelZoom(e);
+      zoomController.wheelZoom(e, fine);
       return;
     }
 

--- a/src/lib/reader/zoom-controller.test.ts
+++ b/src/lib/reader/zoom-controller.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { ContinuousZoomController } from './zoom-controller';
-import type { RectLike } from './zoom-math';
+import { ContinuousZoomController, WHEEL_ZOOM_SETTLE_MS } from './zoom-controller';
+import { WHEEL_ZOOM_SENSITIVITY, type RectLike } from './zoom-math';
 
 /**
  * Fake layout world simulating the browser geometry the controller corrects
@@ -321,6 +321,164 @@ describe('ContinuousZoomController — wheel', () => {
     c.wheelZoom({ deltaY: -120, deltaMode: 0, clientX: 500, clientY: 400, timeStamp: 2000 });
     pump();
     expect(c.currentZoom).toBe(3);
+  });
+});
+
+/**
+ * The trackpad path (#259): a fine wheel stream zooms continuously at the
+ * cursor instead of stepping the ladder. Only setTimeout is faked — the
+ * suite's rAF pump and performance.now stubs drive the Animator.
+ */
+describe('ContinuousZoomController — fine wheel (trackpad)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const fineWheel = (deltaY: number, timeStamp: number, x = 500, y = 400) => ({
+    deltaY,
+    deltaMode: 0,
+    clientX: x,
+    clientY: y,
+    timeStamp
+  });
+
+  it('zooms immediately by the event ratio, anchored at the cursor', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.wheelZoom(fineWheel(-20, 1000), true);
+
+    const expected = Math.exp(20 * WHEEL_ZOOM_SENSITIVITY);
+    expect(c.currentZoom).toBeCloseTo(expected, 10);
+    expect(world.zoom).toBeCloseTo(expected, 10);
+    // Content under the cursor (500, 400) → content (500, 700) stays there.
+    expect(world.scrollLeft).toBeCloseTo(500 * expected - 500, 3);
+    expect(world.scrollTop).toBeCloseTo(700 * expected - 400, 3);
+  });
+
+  it('compounds across the stream instead of snapping to a level', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.wheelZoom(fineWheel(-20, 1000), true);
+    c.wheelZoom(fineWheel(-20, 1016), true);
+
+    expect(c.currentZoom).toBeCloseTo(Math.exp(40 * WHEEL_ZOOM_SENSITIVITY), 10);
+  });
+
+  it('scrolling back down undoes the zoom exactly', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.wheelZoom(fineWheel(-37, 1000), true);
+    c.wheelZoom(fineWheel(37, 1016), true);
+
+    expect(c.currentZoom).toBeCloseTo(1, 10);
+    expect(world.scrollTop).toBeCloseTo(300, 3);
+  });
+
+  it('clamps to the ladder ends', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.wheelZoom(fineWheel(-4000, 1000), true);
+    expect(c.currentZoom).toBe(3);
+
+    c.wheelZoom(fineWheel(4000, 1016), true);
+    expect(c.currentZoom).toBe(1);
+  });
+
+  it('stays active through the stream, then settles once when it goes idle', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const c = makeController(world, { settled });
+
+    c.wheelZoom(fineWheel(-20, 1000), true);
+    c.wheelZoom(fineWheel(-20, 1016), true);
+    expect(c.isActive).toBe(true);
+    expect(settled).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(WHEEL_ZOOM_SETTLE_MS);
+
+    expect(settled).toHaveBeenCalledTimes(1);
+    expect(settled).toHaveBeenCalledWith(c.currentZoom, 'gesture');
+    expect(c.zoomTarget).toBe(c.currentZoom);
+    expect(c.isActive).toBe(false);
+  });
+
+  it('an interrupting gesture settles the stream once, not twice', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const c = makeController(world, { settled });
+
+    c.wheelZoom(fineWheel(-20, 1000), true);
+    c.finishNow();
+
+    expect(settled).toHaveBeenCalledTimes(1);
+    expect(settled).toHaveBeenCalledWith(c.currentZoom, 'interrupt');
+
+    vi.advanceTimersByTime(WHEEL_ZOOM_SETTLE_MS * 2);
+    expect(settled).toHaveBeenCalledTimes(1);
+  });
+
+  it('a following notch steps to the adjacent level from the off-level zoom', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.wheelZoom(fineWheel(-20, 1000), true); // ~1.105
+    vi.advanceTimersByTime(WHEEL_ZOOM_SETTLE_MS);
+
+    c.wheelZoom(fineWheel(-120, 2000), false);
+    pump();
+    expect(c.currentZoom).toBe(1.5);
+  });
+
+  it('reports the zoomed state as the stream moves', () => {
+    const world = tallPageWorld();
+    const zoomed = vi.fn();
+    const c = makeController(world, { zoomed });
+
+    c.wheelZoom(fineWheel(-20, 1000), true);
+    expect(zoomed).toHaveBeenLastCalledWith(true);
+
+    c.wheelZoom(fineWheel(20, 1016), true);
+    expect(zoomed).toHaveBeenLastCalledWith(false);
+  });
+
+  it('re-anchors when the cursor moves mid-stream', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.wheelZoom(fineWheel(-20, 1000, 500, 400), true);
+
+    // Content sitting under the cursor's NEW position, before the next event.
+    const before = c.currentZoom;
+    const content = {
+      x: (world.scrollLeft + 200) / before,
+      y: (world.scrollTop + 600) / before
+    };
+
+    c.wheelZoom(fineWheel(-20, 1016, 200, 600), true);
+
+    const after = c.currentZoom;
+    expect(content.x * after - world.scrollLeft).toBeCloseTo(200, 3);
+    expect(content.y * after - world.scrollTop).toBeCloseTo(600, 3);
+  });
+
+  it('a stalled stream that leaves the timer pending is cleaned up by destroy', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const c = makeController(world, { settled });
+
+    c.wheelZoom(fineWheel(-20, 1000), true);
+    c.destroy();
+
+    vi.advanceTimersByTime(WHEEL_ZOOM_SETTLE_MS * 2);
+    expect(settled).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/reader/zoom-controller.ts
+++ b/src/lib/reader/zoom-controller.ts
@@ -26,6 +26,7 @@ import {
   pinchDistance,
   pinchMidpoint,
   WheelAccumulator,
+  wheelZoomRatio,
   zoomProgress,
   type Point,
   type RectLike
@@ -39,6 +40,13 @@ const SNAP_TO_ONE_BELOW = 1.05;
 const DOUBLE_TAP_ZOOM = 2;
 
 const CONTINUOUS_ZOOM_LEVELS: readonly number[] = [1, 1.5, 2, 3];
+
+/**
+ * Idle gap (ms) that ends a continuous wheel-zoom stream. Wheels have no
+ * release event, so the settle — which clamps the paged camera into bounds
+ * and reports reading progress — has to be timed out.
+ */
+export const WHEEL_ZOOM_SETTLE_MS = 250;
 
 /** Structural subset of HTMLElement the controller scrolls. */
 export interface ZoomContainer {
@@ -161,6 +169,9 @@ export class ContinuousZoomController {
   private anchorFy = 0;
 
   private pinching = false;
+  private wheelZooming = false;
+  private wheelSettleTimer: ReturnType<typeof setTimeout> | null = null;
+  private wheelAnchor: Point | null = null;
   private pinchStartDist = 0;
   private pinchStartZoom = 1;
   private gestureBaseZoom = 1;
@@ -189,7 +200,7 @@ export class ContinuousZoomController {
   }
 
   get isActive(): boolean {
-    return this.pinching || this.animator.isAnimating;
+    return this.pinching || this.wheelZooming || this.animator.isAnimating;
   }
 
   /** True when the view is visibly zoomed in. */
@@ -201,9 +212,22 @@ export class ContinuousZoomController {
   // Gestures
   // ============================================================
 
-  /** Wheel event already classified as zoom intent by the caller. */
-  wheelZoom(e: ZoomWheelEventLike): void {
-    const steps = this.wheelAcc.add(normalizeWheelDelta(e.deltaY, e.deltaMode), e.timeStamp);
+  /**
+   * Wheel event already classified as zoom intent by the caller.
+   *
+   * `fine` marks a trackpad-grade stream (WheelStreamClassifier): those zoom
+   * continuously at the cursor, because a device reporting every millimetre
+   * of travel through a ladder of discrete levels is the #259 complaint —
+   * nothing, nothing, nothing, lurch. Notched wheels keep the ladder, where
+   * one notch is one deliberate step.
+   */
+  wheelZoom(e: ZoomWheelEventLike, fine = false): void {
+    const deltaPx = normalizeWheelDelta(e.deltaY, e.deltaMode);
+    if (fine) {
+      this.continuousWheelZoom(deltaPx, { x: e.clientX, y: e.clientY });
+      return;
+    }
+    const steps = this.wheelAcc.add(deltaPx, e.timeStamp);
     if (steps === 0) return;
     const direction = steps > 0 ? 1 : -1;
     let next = this.target;
@@ -211,6 +235,53 @@ export class ContinuousZoomController {
       next = nextZoomLevel(this.levels, next, direction);
     }
     this.stepTo(next, { x: e.clientX, y: e.clientY });
+  }
+
+  /**
+   * One event of a fine wheel stream: multiply the live zoom and pin the
+   * content under the cursor, exactly as a pinch move does.
+   *
+   * The anchor is re-captured only when the cursor moves. A wheel stream
+   * usually holds still, and capture measures every page element.
+   */
+  private continuousWheelZoom(deltaPx: number, cursor: Point): void {
+    if (deltaPx === 0) return;
+    if (!this.wheelZooming) {
+      // A level animation still converging would fight the stream's own
+      // frame writes; land it before taking over.
+      if (this.animator.isAnimating) this.finishNow();
+      this.wheelZooming = true;
+      this.wheelAnchor = null;
+    }
+    if (!this.wheelAnchor || this.wheelAnchor.x !== cursor.x || this.wheelAnchor.y !== cursor.y) {
+      if (!this.captureAnchor(cursor.x, cursor.y)) return;
+      this.wheelAnchor = cursor;
+    }
+    this.startZoom = this.animator.current;
+    this.applyPinchZoom(this.animator.current * wheelZoomRatio(deltaPx), cursor);
+    this.scheduleWheelSettle();
+  }
+
+  private scheduleWheelSettle(): void {
+    if (this.wheelSettleTimer !== null) clearTimeout(this.wheelSettleTimer);
+    this.wheelSettleTimer = setTimeout(() => {
+      this.wheelSettleTimer = null;
+      this.endWheelStream();
+      this.settle('gesture');
+    }, WHEEL_ZOOM_SETTLE_MS);
+  }
+
+  /** Drop the stream's bookkeeping without settling. */
+  private endWheelStream(): void {
+    if (this.wheelSettleTimer !== null) {
+      clearTimeout(this.wheelSettleTimer);
+      this.wheelSettleTimer = null;
+    }
+    this.wheelZooming = false;
+    this.wheelAnchor = null;
+    // Leave the zoom where the gesture left it; the target follows so the
+    // next notch steps from here, the same way pinchEnd hands off.
+    this.target = this.animator.current;
   }
 
   /**
@@ -265,7 +336,7 @@ export class ContinuousZoomController {
    * re-baselines distance/zoom/anchor so the gesture stays continuous.
    */
   pinchStart(points: readonly Point[]): void {
-    if (!this.pinching && this.animator.isAnimating) this.finishNow();
+    if (!this.pinching && this.isActive) this.finishNow();
     const mid = pinchMidpoint(points);
     if (!this.captureAnchor(mid.x, mid.y)) return;
     this.pinching = true;
@@ -300,7 +371,7 @@ export class ContinuousZoomController {
 
   // Safari desktop trackpad pinch (proprietary gesture events).
   gestureStart(x: number, y: number): void {
-    if (!this.pinching && this.animator.isAnimating) this.finishNow();
+    if (!this.pinching && this.isActive) this.finishNow();
     if (!this.captureAnchor(x, y)) return;
     this.pinching = true;
     this.pinchStartDist = 0; // pointer-pair distance unused for gesture events
@@ -348,6 +419,11 @@ export class ContinuousZoomController {
       this.settle(reason);
       return;
     }
+    if (this.wheelZooming) {
+      this.endWheelStream();
+      this.settle(reason);
+      return;
+    }
     if (this.animator.isAnimating) {
       this.animator.snapTo(this.target);
       this.settle(reason);
@@ -356,7 +432,7 @@ export class ContinuousZoomController {
 
   /** Instantly return to 1× (zoom-mode change, viewport resize). */
   reset(): void {
-    if (this.animator.current === 1 && !this.animator.isAnimating && !this.pinching) {
+    if (this.animator.current === 1 && !this.isActive) {
       this.target = 1;
       return;
     }
@@ -371,6 +447,7 @@ export class ContinuousZoomController {
    */
   snapToLevel(level: number): void {
     this.pinching = false;
+    this.endWheelStream();
     this.target = level;
     this.anchorEl = null; // skip anchor correction; layout placement only
     this.animator.snapTo(level);
@@ -378,6 +455,7 @@ export class ContinuousZoomController {
   }
 
   destroy(): void {
+    this.endWheelStream();
     this.animator.destroy();
   }
 

--- a/src/lib/reader/zoom-math.test.ts
+++ b/src/lib/reader/zoom-math.test.ts
@@ -13,7 +13,11 @@ import {
   normalizeWheelDelta,
   WheelAccumulator,
   pinchDistance,
-  pinchMidpoint
+  pinchMidpoint,
+  isFineWheelEvent,
+  WheelStreamClassifier,
+  wheelZoomRatio,
+  WHEEL_ZOOM_SENSITIVITY
 } from './zoom-math';
 
 describe('anchorFraction', () => {
@@ -151,6 +155,16 @@ describe('wheelIntentIsZoom', () => {
     expect(wheelIntentIsZoom(false, true)).toBe(true);
     expect(wheelIntentIsZoom(true, true)).toBe(false);
   });
+
+  it('treats a fine ctrl+wheel as a trackpad pinch, whatever the swap setting', () => {
+    expect(wheelIntentIsZoom(true, true, true)).toBe(true);
+    expect(wheelIntentIsZoom(true, false, true)).toBe(true);
+  });
+
+  it('leaves a fine bare wheel to the swap setting', () => {
+    expect(wheelIntentIsZoom(false, true, true)).toBe(true);
+    expect(wheelIntentIsZoom(false, false, true)).toBe(false);
+  });
 });
 
 describe('normalizeWheelDelta', () => {
@@ -279,5 +293,80 @@ describe('gapWheelSteps', () => {
     const acc = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
     const px = gapWheelSteps({ deltaX: 0, deltaY: -3, deltaMode: 1, timeStamp: 1000 }, acc);
     expect(px).toBe(6); // 3 lines * 40px = 120 wheel px -> six 20px steps
+  });
+});
+
+describe('isFineWheelEvent', () => {
+  const ev = (deltaY: number, deltaX = 0, deltaMode = 0) => ({ deltaX, deltaY, deltaMode });
+
+  it('rejects classic notches', () => {
+    expect(isFineWheelEvent(ev(-100))).toBe(false);
+    expect(isFineWheelEvent(ev(120))).toBe(false);
+  });
+
+  it('rejects line and page deltas — only a notched wheel reports them', () => {
+    expect(isFineWheelEvent(ev(-3, 0, 1))).toBe(false);
+    expect(isFineWheelEvent(ev(-1, 0, 2))).toBe(false);
+  });
+
+  it('accepts fractional deltas', () => {
+    expect(isFineWheelEvent(ev(-4.5))).toBe(true);
+    expect(isFineWheelEvent(ev(-133.75))).toBe(true);
+  });
+
+  it('accepts sub-notch magnitudes', () => {
+    expect(isFineWheelEvent(ev(-8))).toBe(true);
+    expect(isFineWheelEvent(ev(2))).toBe(true);
+  });
+
+  it('accepts simultaneous two-axis deltas — no mouse steers both at once', () => {
+    expect(isFineWheelEvent(ev(-110, 3))).toBe(true);
+  });
+
+  it('reads no evidence from an empty delta', () => {
+    expect(isFineWheelEvent(ev(0))).toBe(false);
+  });
+});
+
+describe('WheelStreamClassifier', () => {
+  it('stays coarse for a notched-wheel stream', () => {
+    const c = new WheelStreamClassifier();
+    expect(c.classify({ deltaX: 0, deltaY: -100, deltaMode: 0, timeStamp: 1000 })).toBe(false);
+    expect(c.classify({ deltaX: 0, deltaY: -100, deltaMode: 0, timeStamp: 1050 })).toBe(false);
+  });
+
+  it('holds the fine verdict through momentum spikes later in the stream', () => {
+    const c = new WheelStreamClassifier();
+    expect(c.classify({ deltaX: 0, deltaY: -3, deltaMode: 0, timeStamp: 1000 })).toBe(true);
+    // macOS momentum turns a flick into large round deltas mid-gesture.
+    expect(c.classify({ deltaX: 0, deltaY: -240, deltaMode: 0, timeStamp: 1016 })).toBe(true);
+  });
+
+  it('re-classifies after the stream goes idle', () => {
+    const c = new WheelStreamClassifier();
+    c.classify({ deltaX: 0, deltaY: -3, deltaMode: 0, timeStamp: 1000 });
+    expect(c.classify({ deltaX: 0, deltaY: -120, deltaMode: 0, timeStamp: 2000 })).toBe(false);
+  });
+});
+
+describe('wheelZoomRatio', () => {
+  it('zooms in on wheel-up and out on wheel-down', () => {
+    expect(wheelZoomRatio(-100)).toBeGreaterThan(1);
+    expect(wheelZoomRatio(100)).toBeLessThan(1);
+    expect(wheelZoomRatio(0)).toBe(1);
+  });
+
+  it('is exponential, so a split gesture equals the whole one', () => {
+    const whole = wheelZoomRatio(-90);
+    const split = wheelZoomRatio(-30) * wheelZoomRatio(-60);
+    expect(split).toBeCloseTo(whole, 10);
+  });
+
+  it('is symmetric — scrolling back undoes the zoom exactly', () => {
+    expect(wheelZoomRatio(-40) * wheelZoomRatio(40)).toBeCloseTo(1, 10);
+  });
+
+  it('moves immediately for a small nudge', () => {
+    expect(wheelZoomRatio(-10)).toBeCloseTo(Math.exp(10 * WHEEL_ZOOM_SENSITIVITY), 10);
   });
 });

--- a/src/lib/reader/zoom-math.ts
+++ b/src/lib/reader/zoom-math.ts
@@ -107,8 +107,21 @@ export function nextZoomLevel(levels: readonly number[], zoom: number, direction
  * Whether a wheel event means zoom, matching paged-mode semantics:
  * ctrl/meta+wheel zooms by default; swapWheelBehavior inverts so bare wheel
  * zooms and ctrl/meta+wheel scrolls.
+ *
+ * `fine` (a trackpad stream — see WheelStreamClassifier) overrides the swap
+ * for ctrl/meta: Chrome and Firefox deliver a trackpad PINCH as a synthetic
+ * ctrl+wheel, and a pinch means zoom on every surface regardless of what the
+ * user chose for their mouse wheel. Only Safari has real pinch events
+ * (gesturestart/change/end — see pointer-tracker.ts), so without this a
+ * Mac user with the swap on has no working pinch at all (#259). A coarse
+ * ctrl+wheel is a genuine keyboard chord and keeps the swap semantics.
  */
-export function wheelIntentIsZoom(ctrlOrMeta: boolean, swapWheelBehavior: boolean): boolean {
+export function wheelIntentIsZoom(
+  ctrlOrMeta: boolean,
+  swapWheelBehavior: boolean,
+  fine = false
+): boolean {
+  if (fine && ctrlOrMeta) return true;
   return swapWheelBehavior ? !ctrlOrMeta : ctrlOrMeta;
 }
 
@@ -180,6 +193,80 @@ export class WheelAccumulator {
     this.acc -= steps * this.stepSize;
     return steps === 0 ? 0 : -steps;
   }
+}
+
+/**
+ * Largest per-event delta (px) that still reads as fine-grained. A notched
+ * wheel reports a whole notch at once — 100 in Chromium, 120 on Windows,
+ * ~102 for Firefox's pixel mode — so anything well below that came from a
+ * device reporting continuous travel.
+ */
+export const FINE_WHEEL_MAX_DELTA = 50;
+
+/** Idle gap (ms) that ends a wheel stream for classification purposes. */
+export const WHEEL_STREAM_IDLE_MS = 250;
+
+/**
+ * Whether one wheel event carries positive evidence of a fine-grained
+ * (trackpad, precision wheel, synthetic pinch) source rather than a notched
+ * mouse wheel. Absence of evidence is not evidence of a mouse — see
+ * WheelStreamClassifier, which is what callers should use.
+ */
+export function isFineWheelEvent(e: Pick<WheelEvent, 'deltaX' | 'deltaY' | 'deltaMode'>): boolean {
+  // Line and page deltas are a notched wheel by construction: a precision
+  // device has sub-line travel to report and never picks those units.
+  if (e.deltaMode !== 0) return false;
+  const { deltaX, deltaY } = e;
+  if (!Number.isInteger(deltaX) || !Number.isInteger(deltaY)) return true;
+  // No mouse drives both axes at once; a trackpad barely avoids it.
+  if (deltaX !== 0 && deltaY !== 0) return true;
+  const magnitude = Math.max(Math.abs(deltaX), Math.abs(deltaY));
+  return magnitude > 0 && magnitude < FINE_WHEEL_MAX_DELTA;
+}
+
+/**
+ * Classifies a wheel STREAM as fine-grained or notched, sticky until the
+ * stream goes idle.
+ *
+ * Sticky because the evidence is one-sided. A trackpad flick starts with
+ * small deltas and then hands off to momentum, which reports large round
+ * numbers indistinguishable from notches; a mouse never reports the small
+ * ones. So evidence only ever upgrades a stream to fine, and the verdict
+ * holds for the rest of the gesture.
+ *
+ * Erring toward fine is the safe direction: a precision wheel misread as a
+ * trackpad gets smooth zoom, which is what its owner wanted anyway. The
+ * reverse is the #259 bug.
+ */
+export class WheelStreamClassifier {
+  private fine = false;
+  private lastTime = -Infinity;
+
+  constructor(private idleResetMs = WHEEL_STREAM_IDLE_MS) {}
+
+  classify(e: Pick<WheelEvent, 'deltaX' | 'deltaY' | 'deltaMode' | 'timeStamp'>): boolean {
+    if (e.timeStamp - this.lastTime > this.idleResetMs) this.fine = false;
+    this.lastTime = e.timeStamp;
+    if (!this.fine && isFineWheelEvent(e)) this.fine = true;
+    return this.fine;
+  }
+}
+
+/**
+ * Zoom ratio per pixel of fine wheel travel. 100px of travel is ~1.65x,
+ * a shade faster than the level ladder's ~1.4x per notch — a trackpad user
+ * asks for the same zoom range with less finger travel (#259).
+ */
+export const WHEEL_ZOOM_SENSITIVITY = 0.005;
+
+/**
+ * Continuous zoom multiplier for one fine wheel event: scale-invariant
+ * (exponential), so the same finger travel covers the same ratio at any
+ * zoom, splitting a gesture across events changes nothing, and scrolling
+ * back lands exactly where it started.
+ */
+export function wheelZoomRatio(deltaPx: number, sensitivity = WHEEL_ZOOM_SENSITIVITY): number {
+  return Math.exp(-deltaPx * sensitivity);
 }
 
 /** Distance between the first two points; 0 when fewer than two. */


### PR DESCRIPTION
Release v1.9.1 — two reader fixes on top of 1.9.0.

### Fixed

- Trackpad zoom is now smooth instead of lurching (#259)
- Trackpad pinch zooms even with wheel swap on (#259)
- Night mode tints extension popups and menus again

**Pre-release verification (on `develop` @ 28a85c79):**

- `vitest run` — 183 files, 2905 tests passed
- `svelte-check` — 0 errors, 0 warnings
- `npm run lint` — 0 errors (272 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)